### PR TITLE
infra: align CHANGELOG template to `cog` defaults

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,7 +11,7 @@ All notable changes for each release of this package will be documented in this 
 commit_parsers = [
     { message = "^feat", group = "Features" },
     { message = "^fix", group = "Bug Fixes" },
-    { message = "^doc", group = "Documentation" },
+    { message = "^docs", group = "Documentation" },
     { message = "^perf", group = "Performance" },
     { message = "^refactor", group = "Refactor" },
     { message = "^style", group = "Styling" },


### PR DESCRIPTION
There are slight differences between the default behaviours of
Release-plz and Cocogitto in the area of commit message types (`doc` vs
`docs`). The Release-plz template has been aligned to match the
Cocogitto default of `docs`, as this is the convention also used the
Conventional Commits specification.
