### PR TITLE
docs: detail the use of cargo-about

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ required build dependencies can be installed by running:
 ## Developing STEAM Packages
 
 For developers of the STEAM packages both `stable` and `nightly` Rust toolchains
-are required, as well external tools such as [cargo-deny],
+are required, as well external tools such as [cargo-deny], [cargo-about]
 [cargo-semver-checks], [Cocogitto], [pre-commit], [Prettier], and [Release-plz].
 All of the required development dependencies can be installed by running:
 
@@ -189,6 +189,8 @@ During the commit process a number of different hooks will be invoked by
   semantic versioning using [cargo-semver-checks].
 - All dependencies will be checked for vulnerabilities and compatible licensing
   using [cargo-deny].
+- The licenses of all dependencies will collated and included in the
+  [licenses.html] file using [cargo-about].
 - Source files will be formatted using `rustfmt`, [Prettier], and built in tools
   from the [pre-commit-hooks] library.
 - Rust source will be linted using [clippy].
@@ -222,6 +224,7 @@ updated package, and automatically publishes the updated packages using
 `cargo publish` and as Github releases.
 
 [Cap'n Proto]: https://capnproto.org
+[cargo-about]: https://github.com/EmbarkStudios/cargo-about
 [cargo-deny]: https://github.com/EmbarkStudios/cargo-deny
 [cargo-semver-checks]: https://github.com/obi1kenobi/cargo-semver-checks
 [clippy]: https://doc.rust-lang.org/clippy
@@ -233,6 +236,8 @@ updated package, and automatically publishes the updated packages using
 [Release-plz]: https://release-plz.dev
 
 <!-- ANCHOR_END: package_developers -->
+
+[licenses.html]: https://graphcore-research.github.io/steam/licenses.html
 
 <!-- ANCHOR: dev_docs -->
 

--- a/steam-developer-guide/.gitignore
+++ b/steam-developer-guide/.gitignore
@@ -3,3 +3,4 @@
 book
 doctest_cache
 rustdoc_cache
+md_src/licenses.html

--- a/steam-developer-guide/md_src/getting_started/setup.md
+++ b/steam-developer-guide/md_src/getting_started/setup.md
@@ -7,3 +7,7 @@
 {{#include ../../../README.md:package_users}}
 
 {{#include ../../../README.md:package_developers}}
+
+<!-- cmdrun cp ../../../licenses.html ../../md_src/licenses.html -->
+
+[licenses.html]: ../licenses.html


### PR DESCRIPTION
The generation of the licenses.html file when the pre-commit hooks run
cargo-about is now described in the "Committing a Change" section which
appears in both the README.md and the "Setup" chapter of the developer
guide.

The generated licenses.html file is now included in the built developer
guide output, and the link in README.md will direct readers to the
copy included in the Github Pages hosted version of the guide.
