### PR TITLE
infra: improve efficiency of CI and reduce lint runtime

### DIFF
--- a/.github/actions/cached-build-access/action.yaml
+++ b/.github/actions/cached-build-access/action.yaml
@@ -6,24 +6,24 @@ description: The build directory paths and key to be used when caching
 outputs:
   paths:
     description: The cached build paths
-    value: ${{ steps.get_paths.outputs.cached_build_paths }}
+    value: ${{ steps.get-paths.outputs.cached-build-paths }}
 
   key:
     description: The generated cached build key
-    value: ${{ steps.generate_key.outputs.cached_build_key }}
+    value: ${{ steps.generate-key.outputs.cached-build-key }}
 
 runs:
   using: composite
   steps:
-    - id: get_paths
+    - id: get-paths
       run: |
-          echo 'cached_build_paths<<EOF' >> $GITHUB_OUTPUT
+          echo 'cached-build-paths<<EOF' >> $GITHUB_OUTPUT
           echo 'target/'>> $GITHUB_OUTPUT
           echo 'steam-developer-guide/doctest_cache/'>> $GITHUB_OUTPUT
           echo 'steam-developer-guide/rustdoc_cache/'>> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       shell: bash
 
-    - id: generate_key
-      run: echo "cached_build_key=${{ runner.os }}-cargo-steam-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_OUTPUT
+    - id: generate-key
+      run: echo "cached-build-key=${{ runner.os }}-cargo-steam-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/cached-build-access/action.yaml
+++ b/.github/actions/cached-build-access/action.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Graphcore Ltd. All rights reserved.
+
+name: Cached build access
+description: The build directory paths and key to be used when caching
+
+outputs:
+  paths:
+    description: The cached build paths
+    value: ${{ steps.get_paths.outputs.cached_build_paths }}
+
+  key:
+    description: The generated cached build key
+    value: ${{ steps.generate_key.outputs.cached_build_key }}
+
+runs:
+  using: composite
+  steps:
+    - id: get_paths
+      run: |
+          echo 'cached_build_paths<<EOF' >> $GITHUB_OUTPUT
+          echo 'target/'>> $GITHUB_OUTPUT
+          echo 'steam-developer-guide/doctest_cache/'>> $GITHUB_OUTPUT
+          echo 'steam-developer-guide/rustdoc_cache/'>> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+      shell: bash
+
+    - id: generate_key
+      run: echo "cached_build_key=${{ runner.os }}-cargo-steam-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/cached-semver-access/action.yaml
+++ b/.github/actions/cached-semver-access/action.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 Graphcore Ltd. All rights reserved.
+
+name: Cached semver check access
+description: The semantic version check build directory paths and key to be used when caching
+
+outputs:
+  paths:
+    description: The cached build paths
+    value: ${{ steps.get_paths.outputs.cached_build_paths }}
+
+  key:
+    description: The generated cached build key
+    value: ${{ steps.generate_key.outputs.cached_build_key }}
+
+runs:
+  using: composite
+  steps:
+    - id: get_paths
+      run: |
+          echo 'cached_build_paths<<EOF' >> $GITHUB_OUTPUT
+          echo 'target/semver-checks'>> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+      shell: bash
+
+    - id: generate_key
+      run: echo "cached_build_key=${{ runner.os }}-cargo-steam-semver-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/cached-semver-access/action.yaml
+++ b/.github/actions/cached-semver-access/action.yaml
@@ -6,22 +6,22 @@ description: The semantic version check build directory paths and key to be used
 outputs:
   paths:
     description: The cached build paths
-    value: ${{ steps.get_paths.outputs.cached_build_paths }}
+    value: ${{ steps.get-paths.outputs.cached-build-paths }}
 
   key:
     description: The generated cached build key
-    value: ${{ steps.generate_key.outputs.cached_build_key }}
+    value: ${{ steps.generate-key.outputs.cached-build-key }}
 
 runs:
   using: composite
   steps:
-    - id: get_paths
+    - id: get-paths
       run: |
-          echo 'cached_build_paths<<EOF' >> $GITHUB_OUTPUT
+          echo 'cached-build-paths<<EOF' >> $GITHUB_OUTPUT
           echo 'target/semver-checks'>> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       shell: bash
 
-    - id: generate_key
-      run: echo "cached_build_key=${{ runner.os }}-cargo-steam-semver-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_OUTPUT
+    - id: generate-key
+      run: echo "cached-build-key=${{ runner.os }}-cargo-steam-semver-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/install-build-dependencies/action.yaml
+++ b/.github/actions/install-build-dependencies/action.yaml
@@ -1,9 +1,10 @@
 # Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
-name: "Install build dependencies"
-description: "Install all dependencies required to build the repo source"
+name: Install build dependencies
+description: Install all dependencies required to build the repo source
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - uses: actions/cache@v4
       with:
@@ -17,6 +18,7 @@ runs:
         key: ${{ runner.os }}-cargo-build-deps-${{ hashFiles('./.github/actions/install-build-dependencies/**') }}
         restore-keys: |
           ${{ runner.os }}-cargo-build-deps-
+
     - name: Run install.sh
       run: ./.github/actions/install-build-dependencies/install.sh
       shell: bash

--- a/.github/actions/install-build-dependencies/install.sh
+++ b/.github/actions/install-build-dependencies/install.sh
@@ -19,4 +19,4 @@ fi
 rustup update
 rustup toolchain install --profile default stable
 
-cargo install cargo-expand mdbook mdbook-cmdrun mdbook-keeper mdbook-linkcheck
+cargo install --locked cargo-expand mdbook mdbook-cmdrun mdbook-keeper mdbook-linkcheck

--- a/.github/actions/install-dev-dependencies/action.yaml
+++ b/.github/actions/install-dev-dependencies/action.yaml
@@ -1,9 +1,10 @@
 # Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
-name: "Install dev dependencies"
-description: "Install all dependencies required when developing the repo source"
+name: Install dev dependencies
+description: Install all dependencies required when developing the repo source
+
 runs:
-  using: "composite"
+  using: composite
   steps:
     - uses: actions/setup-node@v4
     - uses: actions/cache@v4
@@ -19,6 +20,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-dev-deps-
           ${{ runner.os }}-cargo-build-deps-
+
     - name: Run install.sh
       run: ./.github/actions/install-dev-dependencies/install.sh
       shell: bash

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -21,4 +21,5 @@ npm install --no-save prettier
 rustup update
 rustup toolchain install --profile default nightly
 
-cargo install cargo-about cargo-deny cargo-semver-checks cocogitto release-plz
+cargo install --locked cargo-about cargo-deny cargo-semver-checks release-plz
+cargo install --locked --bin cog cocogitto

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,17 +28,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      CACHED_BUILD_PATHS: |
+        target/
+        steam-developer-guide/doctest_cache/
+        steam-developer-guide/rustdoc_cache/
 
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-build-dependencies
-      - uses: actions/cache@v4
+
+      - name: Generate cached build key
+        run: echo "CACHED_BUILD_KEY=${{ runner.os }}-cargo-steam-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_ENV
+
+      - name: Restore cached build files
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            target/
-            steam-developer-guide/doctest_cache/
-            steam-developer-guide/rustdoc_cache/
-          key: ${{ runner.os }}-cargo-steam-${{ hashFiles('**/Cargo.lock') }}
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.CACHED_BUILD_KEY }}
 
       - name: Build
         run: cargo build --all-features --verbose
@@ -48,3 +55,10 @@ jobs:
 
       - name: Run benchmarks
         run: cargo bench --all-features --verbose
+
+      - name: Save build files to cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.CACHED_BUILD_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,29 +23,53 @@ jobs:
       - name: Lint with pre-commit
         run: pre-commit run --all-files
 
+  check_semantic_versioning:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-build-dependencies
+      - uses: ./.github/actions/install-dev-dependencies
+
+      - name: Get cache access variables
+        id: cache_vars
+        uses: ./.github/actions/cached-semver-access
+
+      - name: Restore cached build files
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.cache_vars.outputs.paths }}
+          key: ${{ steps.cache_vars.outputs.key }}
+
+      - name: Run cargo semver-checks
+        run: pre-commit run --hook-stage manual --all-files cargo-semver-checks
+
+      - name: Save build files to cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.cache_vars.outputs.paths }}
+          key: ${{ steps.cache_vars.outputs.key }}
+
   build_and_test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      CACHED_BUILD_PATHS: |
-        target/
-        steam-developer-guide/doctest_cache/
-        steam-developer-guide/rustdoc_cache/
 
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-build-dependencies
 
-      - name: Generate cached build key
-        run: echo "CACHED_BUILD_KEY=${{ runner.os }}-cargo-steam-${{ hashFiles('**/Cargo.lock') }}" >> $GITHUB_ENV
+      - name: Get cache access variables
+        id: cache_vars
+        uses: ./.github/actions/cached-build-access
 
       - name: Restore cached build files
         uses: actions/cache/restore@v4
         with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.CACHED_BUILD_KEY }}
+          path: ${{ steps.cache_vars.outputs.paths }}
+          key: ${{ steps.cache_vars.outputs.key }}
 
       - name: Build
         run: cargo build --all-features --verbose
@@ -60,5 +84,5 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.CACHED_BUILD_KEY }}
+          path: ${{ steps.cache_vars.outputs.paths }}
+          key: ${{ steps.cache_vars.outputs.key }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Lint with pre-commit
         run: pre-commit run --all-files
 
-  check_semantic_versioning:
+  check-semantic-versioning:
     runs-on: macos-latest
 
     steps:
@@ -32,14 +32,14 @@ jobs:
       - uses: ./.github/actions/install-dev-dependencies
 
       - name: Get cache access variables
-        id: cache_vars
+        id: cache-vars
         uses: ./.github/actions/cached-semver-access
 
       - name: Restore cached build files
         uses: actions/cache/restore@v4
         with:
-          path: ${{ steps.cache_vars.outputs.paths }}
-          key: ${{ steps.cache_vars.outputs.key }}
+          path: ${{ steps.cache-vars.outputs.paths }}
+          key: ${{ steps.cache-vars.outputs.key }}
 
       - name: Run cargo semver-checks
         run: pre-commit run --hook-stage manual --all-files cargo-semver-checks
@@ -48,10 +48,10 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
-          path: ${{ steps.cache_vars.outputs.paths }}
-          key: ${{ steps.cache_vars.outputs.key }}
+          path: ${{ steps.cache-vars.outputs.paths }}
+          key: ${{ steps.cache-vars.outputs.key }}
 
-  build_and_test:
+  build-and-test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -62,14 +62,14 @@ jobs:
       - uses: ./.github/actions/install-build-dependencies
 
       - name: Get cache access variables
-        id: cache_vars
+        id: cache-vars
         uses: ./.github/actions/cached-build-access
 
       - name: Restore cached build files
         uses: actions/cache/restore@v4
         with:
-          path: ${{ steps.cache_vars.outputs.paths }}
-          key: ${{ steps.cache_vars.outputs.key }}
+          path: ${{ steps.cache-vars.outputs.paths }}
+          key: ${{ steps.cache-vars.outputs.key }}
 
       - name: Build
         run: cargo build --all-features --verbose
@@ -84,5 +84,5 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
-          path: ${{ steps.cache_vars.outputs.paths }}
-          key: ${{ steps.cache_vars.outputs.key }}
+          path: ${{ steps.cache-vars.outputs.paths }}
+          key: ${{ steps.cache-vars.outputs.key }}

--- a/.github/workflows/online-documentation.yaml
+++ b/.github/workflows/online-documentation.yaml
@@ -4,7 +4,8 @@ name: Online documentation
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -19,7 +20,7 @@ permissions:
 # in-progress and latest queued. However, do NOT cancel in-progress runs as we
 # want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
@@ -55,6 +56,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         types_or: [rust, toml]
         entry: cargo semver-checks --baseline-rev HEAD
         pass_filenames: false
-        stages: [pre-commit, pre-merge-commit, pre-push, manual]
+        stages: [manual]
       - id: cog-verify
         name: cog verify
         description: check commit message is in Conventional Commit form

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- Copyright (c) 2023 Graphcore Ltd. All rights reserved. -->
 
 [![CI](https://github.com/graphcore-research/steam/actions/workflows/ci.yaml/badge.svg)](https://github.com/graphcore-research/steam/actions/workflows/ci.yaml)
-[![Online documentation](https://github.com/graphcore-research/steam/actions/workflows/online_documentation.yaml/badge.svg)](https://github.com/graphcore-research/steam/actions/workflows/online_documentation.yaml)
+[![Online documentation](https://github.com/graphcore-research/steam/actions/workflows/online-documentation.yaml/badge.svg)](https://github.com/graphcore-research/steam/actions/workflows/online-documentation.yaml)
 
 [Developer guide](https://graphcore-research.github.io/steam) |
 [API documentation](https://graphcore-research.github.io/steam/rustdoc/steam_engine/index.html)

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ During the commit process a number of different hooks will be invoked by
   that it adheres to the [Conventional Commits] specification.
 - All packages within the workspace will be checked for adherence to proper
   semantic versioning using [cargo-semver-checks].
+  - As this can be a time consuming set of checks to run, by default, they are
+    only performed by the [CI system].
+  - The checks can be run locally with:
+    ```bash
+    pre-commit run --hook-stage manual --all-files cargo-semver-checks
+    ```
 - All dependencies will be checked for vulnerabilities and compatible licensing
   using [cargo-deny].
 - The licenses of all dependencies will collated and included in the
@@ -242,6 +248,8 @@ updated package, and automatically publishes the updated packages using
 [cargo-about]: https://github.com/EmbarkStudios/cargo-about
 [cargo-deny]: https://github.com/EmbarkStudios/cargo-deny
 [cargo-semver-checks]: https://github.com/obi1kenobi/cargo-semver-checks
+[CI system]:
+  https://github.com/graphcore-research/steam/actions/workflows/ci.yaml
 [clippy]: https://doc.rust-lang.org/clippy
 [Cocogitto]: https://docs.cocogitto.io
 [Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
The efficiency of the CI workflow has been improved by making better use of caching and ensuring deterministic builds of tools built and installed using cargo. Further reductions in CI runtime have been achieved by running the semantic versioning checking in parallel with other lint checks.

The semantic versioning checks are no longer run by git hooks, but can still be manually run via `pre-commit`.