### PR TITLE
feat(steam-track): simplify to remove concept of trace enable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,6 +1563,7 @@ dependencies = [
  "async-std",
  "criterion",
  "futures",
+ "log",
  "paste",
  "steam-components",
  "steam-engine",
@@ -1609,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "steam-track"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "capnp",

--- a/licenses.html
+++ b/licenses.html
@@ -5361,7 +5361,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-resources 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-spotter 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/steam ">steam-track 0.1.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/steam ">steam-track 0.2.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 

--- a/steam-components/src/connect.rs
+++ b/steam-components/src/connect.rs
@@ -9,21 +9,21 @@ pub use paste::paste;
 /// [InPort](steam_engine::port::InPort)
 macro_rules! connect_port {
     ($from:expr, $from_type:ident => $to:expr, $to_type:ident) => {
-        steam_track::info!($from.entity ; "Connect {}.{} => {}.{}", $from, stringify!($from_type), $to, stringify!($to_type));
+        steam_track::debug!($from.entity ; "Connect {}.{} => {}.{}", $from, stringify!($from_type), $to, stringify!($to_type));
         $crate::connect::paste! {
             $from.[< connect_port_ $from_type >]($to.[< port_ $to_type >]());
         }
     };
     ($from:expr, $from_type:ident, $from_index:expr => $to:expr, $to_type:ident) => {
         let from_index: usize = $from_index;
-        steam_track::info!($from.entity ; "Connect {}.{}[{}] => {}.{}", $from, stringify!($from_type), from_index, $to, stringify!($to_type));
+        steam_track::debug!($from.entity ; "Connect {}.{}[{}] => {}.{}", $from, stringify!($from_type), from_index, $to, stringify!($to_type));
         $crate::connect::paste! {
             $from.[< connect_port_ $from_type _i >](from_index, $to.[< port_ $to_type >]());
         }
     };
     ($from:expr, $from_type:ident => $to:expr, $to_type:ident, $to_index:expr) => {
         let to_index: usize = $to_index;
-        steam_track::info!($from.entity ; "Connect {}.{} => {}.{}[{}]", $from, stringify!($from_type), $to, stringify!($to_type), to_index);
+        steam_track::debug!($from.entity ; "Connect {}.{} => {}.{}[{}]", $from, stringify!($from_type), $to, stringify!($to_type), to_index);
         $crate::connect::paste! {
             $from.[< connect_port_ $from_type >]($to.[< port_ $to_type _i >](to_index));
         }
@@ -31,7 +31,7 @@ macro_rules! connect_port {
     ($from:expr, $from_type:ident, $from_index:expr => $to:expr, $to_type:ident, $to_index:expr) => {
         let from_index: usize = $from_index;
         let to_index: usize = $to_index;
-        steam_track::info!($from.entity ; "Connect {}.{}[{}] => {}.{}[{}]", $from, stringify!($from_type), from_index, $to, stringify!($to_type), to_index);
+        steam_track::debug!($from.entity ; "Connect {}.{}[{}] => {}.{}[{}]", $from, stringify!($from_type), from_index, $to, stringify!($to_type), to_index);
         $crate::connect::paste! {
             $from.[< connect_port_ $from_type _i >](from_index, $to.[< port_ $to_type _i >](to_index));
         }

--- a/steam-engine/src/engine.rs
+++ b/steam-engine/src/engine.rs
@@ -98,7 +98,15 @@ impl Engine {
 /// concepts to have to consider at once.
 impl Default for Engine {
     fn default() -> Self {
-        let tracker = stdout_tracker();
+        let tracker = stdout_tracker(log::Level::Info);
         Self::new(&tracker)
+    }
+}
+
+impl Drop for Engine {
+    fn drop(&mut self) {
+        // The tracker can be using a buffered writer and so it needs to be shut down
+        // cleanly to ensure that it is flushed properly.
+        self.tracker.shutdown();
     }
 }

--- a/steam-engine/src/test_helpers.rs
+++ b/steam-engine/src/test_helpers.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use steam_track::tracker::{CapnProtoTracker, EntityManager};
-use steam_track::{TraceState, Tracker, Writer};
+use steam_track::{Tracker, Writer};
 
 use crate::engine::Engine;
 
@@ -26,10 +26,9 @@ pub fn create_tracker(full_filepath: &str) -> Tracker {
         fs::File::create(format!("{FOLDER}/{filename_only}.bin")).unwrap(),
     ));
 
-    let default_trace_enabled = TraceState::Enabled;
     let default_log_level = log::Level::Trace;
-    let entity_manger = Arc::new(EntityManager::new(default_trace_enabled, default_log_level));
-    let tracker: Tracker = Arc::new(CapnProtoTracker::new(entity_manger.clone(), bin_writer));
+    let entity_manger = EntityManager::new(default_log_level);
+    let tracker: Tracker = Arc::new(CapnProtoTracker::new(entity_manger, bin_writer));
     tracker
 }
 

--- a/steam-models/Cargo.toml
+++ b/steam-models/Cargo.toml
@@ -24,6 +24,7 @@ harness = false
 async-std.workspace = true
 futures.workspace = true
 paste.workspace = true
+log.workspace = true
 steam-components = { path = "../steam-components" }
 steam-model-builder = { path = "../steam-model-builder" }
 steam-engine = { path = "../steam-engine" }

--- a/steam-models/src/ethernet_frame.rs
+++ b/steam-models/src/ethernet_frame.rs
@@ -8,7 +8,7 @@ use steam_engine::{
     traits::{Routable, SimObject, TotalBytes},
     types::ReqType,
 };
-use steam_track::{Tag, create_tag, entity::Entity, tag::Tagged};
+use steam_track::{Tag, create, create_tag, entity::Entity, tag::Tagged};
 
 pub const PREAMBLE_BYTES: usize = 7;
 pub const SFD_BYTES: usize = 1;
@@ -40,14 +40,16 @@ pub struct EthernetFrame {
 }
 
 impl EthernetFrame {
-    pub fn new(create_by: &Arc<Entity>, payload_size_bytes: usize) -> Self {
-        Self {
-            created_by: create_by.clone(),
-            tag: create_tag!(create_by),
+    pub fn new(created_by: &Arc<Entity>, payload_size_bytes: usize) -> Self {
+        let frame = Self {
+            created_by: created_by.clone(),
+            tag: create_tag!(created_by),
             dst_mac: [0; DEST_MAC_BYTES],
             src_mac: [0; DEST_MAC_BYTES],
             payload_size_bytes,
-        }
+        };
+        create!(created_by ; frame, frame.total_bytes(), frame.req_type() as i8);
+        frame
     }
 
     pub fn set_dest(mut self, dst_mac: [u8; DEST_MAC_BYTES]) -> Self {

--- a/steam-track/Cargo.toml
+++ b/steam-track/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "steam-track"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/steam-track/src/test_helpers.rs
+++ b/steam-track/src/test_helpers.rs
@@ -47,8 +47,12 @@ impl Track for TestTracker {
         Tag(tag)
     }
 
-    fn get_entity_enables(&self, _entity_name: &str) -> (bool, log::Level) {
-        (true, log::Level::Trace)
+    fn is_entity_enabled(&self, _tag: Tag, _level: log::Level) -> bool {
+        true
+    }
+
+    fn add_entity(&self, _tag: Tag, _entity_name: &str) {
+        // Do nothing
     }
 
     fn enter(&self, tag: Tag, item: Tag) {
@@ -76,6 +80,10 @@ impl Track for TestTracker {
 
     fn time(&self, set_by: Tag, time_ns: f64) {
         self.add_event(format!("{}: set time {:.1}ns", set_by, time_ns));
+    }
+
+    fn shutdown(&self) {
+        // Do nothing
     }
 }
 

--- a/steam-track/src/tracker/dev_null.rs
+++ b/steam-track/src/tracker/dev_null.rs
@@ -15,15 +15,17 @@ impl Track for DevNullTracker {
         Tag(0)
     }
 
-    fn get_entity_enables(&self, _entity_name: &str) -> (bool, log::Level) {
-        (false, log::Level::Error)
+    fn is_entity_enabled(&self, _tag: Tag, _level: log::Level) -> bool {
+        false
     }
+    fn add_entity(&self, _tag: Tag, _entity_name: &str) {}
     fn enter(&self, _tag: Tag, _obj: Tag) {}
     fn exit(&self, _tag: Tag, _obj: Tag) {}
     fn create(&self, _tag: Tag, _obj: Tag, _num_bytes: usize, _req_type: i8, _name: &str) {}
     fn destroy(&self, _tag: Tag, _obj: Tag) {}
     fn log(&self, _tag: Tag, _level: log::Level, _msg: std::fmt::Arguments) {}
     fn time(&self, _set_by: Tag, _time_ns: f64) {}
+    fn shutdown(&self) {}
 }
 
 /// Take the command-line string and convert it to a Level

--- a/steam-track/src/tracker/in_memory.rs
+++ b/steam-track/src/tracker/in_memory.rs
@@ -295,11 +295,12 @@ impl Track for InMemoryTracker {
         self.entity_manager.unique_tag()
     }
 
-    fn get_entity_enables(&self, entity_name: &str) -> (bool, log::Level) {
-        (
-            self.entity_manager.trace_enabled_for(entity_name),
-            self.entity_manager.log_level_for(entity_name),
-        )
+    fn is_entity_enabled(&self, tag: Tag, level: log::Level) -> bool {
+        self.entity_manager.is_enabled(tag, level)
+    }
+
+    fn add_entity(&self, tag: Tag, entity_name: &str) {
+        self.entity_manager.add_entity(tag, entity_name);
     }
 
     fn enter(&self, tag: Tag, object: Tag) {
@@ -348,5 +349,9 @@ impl Track for InMemoryTracker {
 
     fn time(&self, _set_by: Tag, time_ns: f64) {
         self.entity_manager.set_time(time_ns);
+    }
+
+    fn shutdown(&self) {
+        // Do nothing
     }
 }

--- a/steam-track/src/tracker/multi_tracker.rs
+++ b/steam-track/src/tracker/multi_tracker.rs
@@ -1,33 +1,29 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
-use std::sync::Arc;
-
+use crate::Tag;
 use crate::tracker::{EntityManager, Track, Tracker};
-use crate::{Tag, TraceState};
 
 /// Container for multiple [`Tracker`]s
 pub struct MultiTracker {
-    entity_manager: Arc<EntityManager>,
+    entity_manager: EntityManager,
     trackers: Vec<Tracker>,
 }
 
 impl MultiTracker {
     /// Basic constructor
-    pub fn new(default_trace_enabled: TraceState, default_log_level: log::Level) -> Self {
-        Self {
-            entity_manager: Arc::new(EntityManager::new(default_trace_enabled, default_log_level)),
-            trackers: Vec::new(),
-        }
-    }
-
     /// Add a new tracker
     pub fn add_tracker(&mut self, tracker: Tracker) {
         self.trackers.push(tracker);
     }
+}
 
-    /// Getter for the internal [`EntityManager`]
-    pub fn get_entity_manager(&self) -> Arc<EntityManager> {
-        self.entity_manager.clone()
+impl Default for MultiTracker {
+    fn default() -> Self {
+        Self {
+            // Create a local entity_manager that will just be used for handling tags
+            entity_manager: EntityManager::new(log::Level::Error),
+            trackers: Vec::new(),
+        }
     }
 }
 
@@ -36,46 +32,72 @@ impl Track for MultiTracker {
         self.entity_manager.unique_tag()
     }
 
-    fn get_entity_enables(&self, entity_name: &str) -> (bool, log::Level) {
-        (
-            self.entity_manager.trace_enabled_for(entity_name),
-            self.entity_manager.log_level_for(entity_name),
-        )
+    fn is_entity_enabled(&self, tag: Tag, level: log::Level) -> bool {
+        for tracker in &self.trackers {
+            if tracker.is_entity_enabled(tag, level) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn add_entity(&self, tag: Tag, entity_name: &str) {
+        for tracker in &self.trackers {
+            tracker.add_entity(tag, entity_name);
+        }
     }
 
     fn enter(&self, tag: Tag, object: Tag) {
         for tracker in &self.trackers {
-            tracker.enter(tag, object);
+            if tracker.is_entity_enabled(tag, log::Level::Trace) {
+                tracker.enter(tag, object);
+            }
         }
     }
 
     fn exit(&self, tag: Tag, object: Tag) {
         for tracker in &self.trackers {
-            tracker.exit(tag, object);
+            if tracker.is_entity_enabled(tag, log::Level::Trace) {
+                tracker.exit(tag, object);
+            }
         }
     }
 
     fn create(&self, created_by: Tag, tag: Tag, num_bytes: usize, req_type: i8, name: &str) {
         for tracker in &self.trackers {
-            tracker.create(created_by, tag, num_bytes, req_type, name);
+            if tracker.is_entity_enabled(tag, log::Level::Trace) {
+                tracker.create(created_by, tag, num_bytes, req_type, name);
+            }
         }
     }
 
     fn destroy(&self, destroyed_by: Tag, tag: Tag) {
         for tracker in &self.trackers {
-            tracker.destroy(destroyed_by, tag);
+            if tracker.is_entity_enabled(tag, log::Level::Trace) {
+                tracker.destroy(destroyed_by, tag);
+            }
         }
     }
 
     fn log(&self, tag: Tag, level: log::Level, msg: std::fmt::Arguments) {
         for tracker in &self.trackers {
-            tracker.log(tag, level, msg);
+            if tracker.is_entity_enabled(tag, level) {
+                tracker.log(tag, level, msg);
+            }
         }
     }
 
     fn time(&self, set_by: Tag, time_ns: f64) {
         for tracker in &self.trackers {
-            tracker.time(set_by, time_ns);
+            if tracker.is_entity_enabled(set_by, log::Level::Trace) {
+                tracker.time(set_by, time_ns);
+            }
+        }
+    }
+
+    fn shutdown(&self) {
+        for tracker in &self.trackers {
+            tracker.shutdown();
         }
     }
 }

--- a/steam-track/tests/smoke_macros.rs
+++ b/steam-track/tests/smoke_macros.rs
@@ -2,6 +2,7 @@
 
 //! Ensure that all version of each macro can be used
 
+use std::fmt::Display;
 use std::sync::Arc;
 
 use steam_track::entity::{Entity, toplevel};
@@ -84,45 +85,6 @@ fn enter_exit_basics() {
     test_helpers::check_and_clear(&test_tracker, &["40: destroyed"]);
 }
 
-#[test]
-fn disable_enable() {
-    let (test_tracker, tracker) = test_init!(1001);
-
-    let top = toplevel(&tracker, "top");
-    test_helpers::check_and_clear(&test_tracker, &["0: created 1001, top, 0, 0 bytes"]);
-
-    trace!(top ; "I should be seen");
-    test_helpers::check_and_clear(&test_tracker, &["1001:TRACE: I should be seen"]);
-
-    info!(top ; "I should be seen");
-    test_helpers::check_and_clear(&test_tracker, &["1001:INFO: I should be seen"]);
-
-    warn!(top ; "I should be seen");
-    test_helpers::check_and_clear(&test_tracker, &["1001:WARN: I should be seen"]);
-
-    error!(top ; "I should be seen");
-    test_helpers::check_and_clear(&test_tracker, &["1001:ERROR: I should be seen"]);
-
-    top.set_log_level(log::Level::Error);
-
-    trace!(top ; "I should not be seen");
-    test_helpers::check_and_clear(&test_tracker, &[]);
-
-    info!(top ; "I should not be seen");
-    test_helpers::check_and_clear(&test_tracker, &[]);
-
-    warn!(top ; "I should not be seen");
-    test_helpers::check_and_clear(&test_tracker, &[]);
-
-    error!(top ; "I should be seen");
-    test_helpers::check_and_clear(&test_tracker, &["1001:ERROR: I should be seen"]);
-
-    top.set_log_level(log::Level::Trace);
-
-    drop(top);
-    test_helpers::check_and_clear(&test_tracker, &["1001: destroyed"]);
-}
-
 #[derive(Debug)]
 struct Packet {
     pub tag: Tag,
@@ -132,6 +94,12 @@ impl Packet {
     fn new(entity: &Arc<Entity>) -> Self {
         let tag = create_and_track_tag!(entity);
         Self { tag }
+    }
+}
+
+impl Display for Packet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Packet {{ tag: {} }}", self.tag)
     }
 }
 


### PR DESCRIPTION
We had two concepts for steam-track; the log level and whether trace was enabled. However,
this distinction was unhelpful so now we just have the level and tracing is enabled whenever
logging at level log::Level::Trace is set.

Also, in order to support different behaviour with a MultiTracker we needed to move the
level/enable caching to the EntityManager rather than each entity.
