### PR TITLE
feat(steam-engine): add support for background tasks

### DIFF
--- a/steam-developer-guide/md_src/steam_engine/time/clocks.md
+++ b/steam-developer-guide/md_src/steam_engine/time/clocks.md
@@ -43,4 +43,31 @@ println!("Time now {:.2}", clock.time_now_ns());
 # }
 ```
 
+## Background Tasks
+
+By default a simulation will run until all events have completed. However,
+sometimes it is useful to create a monitor task like a progress bar that just
+needs to run as long as the rest of the simulation.
+
+In order to do this the `wait_ticks_or_exit` function can be called. This lets
+the engine know that it does not have to keep running if this is the only thread
+of activity left. For example, the code below will start a thread of activity
+that prints the current time in `ns` periodically as long as the simulation is
+running:
+
+```rust,no_run
+# use steam_engine::engine::Engine;
+# fn main() {
+# let mut engine = Engine::default();
+# let spawner = engine.spawner();
+let clock = engine.clock_ghz(1.0);
+spawner.spawn(async move {
+  loop {
+    clock.wait_ticks_or_exit(1000).await;
+    println!("Time now {:.2}", clock.time_now_ns());
+  }
+});
+# }
+```
+
 [engine]: ../../steam_engine/chapter.md

--- a/steam-engine/src/engine.rs
+++ b/steam-engine/src/engine.rs
@@ -48,7 +48,7 @@ impl Engine {
         let finished = Rc::new(AtomicBool::new(false));
         {
             let finished = finished.clone();
-            self.executor.spawn(async move {
+            self.spawner.spawn(async move {
                 event.listen().await;
                 finished.store(true, Release);
                 Ok(())
@@ -63,7 +63,7 @@ impl Engine {
     }
 
     pub fn spawn(&self, future: impl Future<Output = SimResult> + 'static) {
-        self.executor.spawn(future);
+        self.spawner.spawn(future);
     }
 
     pub fn default_clock(&mut self) -> Clock {


### PR DESCRIPTION
It can be useful to create background tasks like monitors that can run as long
as the rest of the simulation is running. Without these changes that was not
possible because the background task would simply keep the simulation running.
