### PR TITLE
test(steam-config): remove use of escargot library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,18 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "escargot"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f351750780493fc33fa0ce8ba3c7d61f9736cfa3b3bb9ee2342643ffe40211"
-dependencies = [
- "log",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,7 +1468,6 @@ name = "steam-config"
 version = "0.1.0"
 dependencies = [
  "clap",
- "escargot",
  "figment",
  "proc-macro2",
  "quote",

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (189)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (188)</li>
             <li><a href="#MIT">MIT License</a> (45)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
         </ul>
@@ -2170,7 +2170,6 @@
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.10</a></li>
                     <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.39</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.3</a></li>
-                    <li><a href=" https://github.com/crate-ci/escargot.git ">escargot 0.5.14</a></li>
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.1</a></li>
                     <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.1</a></li>
                     <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 0.6.8</a></li>

--- a/steam-config/Cargo.toml
+++ b/steam-config/Cargo.toml
@@ -27,7 +27,6 @@ syn = { version = "2.0.90", features = ["derive", "extra-traits", "full"] }
 
 [dev-dependencies]
 clap.workspace = true
-escargot = "0.5.13"
 figment.workspace = true
 serde.workspace = true
 trybuild.workspace = true

--- a/steam-config/src/lib.rs
+++ b/steam-config/src/lib.rs
@@ -616,6 +616,7 @@ pub fn multi_source_config(attr: TokenStream, item: TokenStream) -> TokenStream 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::process::Command;
 
     fn get_workspace_dir() -> PathBuf {
         let package_dir = std::env::current_dir().unwrap();
@@ -625,11 +626,14 @@ mod tests {
     #[test]
     fn defaults_with_no_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("no_conf_file")
-                .run()
-                .unwrap()
-                .command()
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "no_conf_file",
+                ])
                 .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
@@ -659,13 +663,17 @@ mod tests {
     #[test]
     fn defaults_and_cli_with_no_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("no_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "no_conf_file",
+                ])
+                .arg("--")
                 .args(["--a", "bar"])
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -694,13 +702,16 @@ mod tests {
     #[test]
     fn defaults_and_env_vars_with_no_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("no_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "no_conf_file",
+                ])
                 .env("STEAM_B", "true")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -729,14 +740,18 @@ mod tests {
     #[test]
     fn defaults_and_cli_and_env_vars_with_no_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("no_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "no_conf_file",
+                ])
+                .arg("--")
                 .args(["--a", "bar"])
                 .env("STEAM_B", "true")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -765,11 +780,14 @@ mod tests {
     #[test]
     fn defaults_and_partial_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("partial_conf_file")
-                .run()
-                .unwrap()
-                .command()
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "partial_conf_file",
+                ])
                 .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
@@ -799,13 +817,17 @@ mod tests {
     #[test]
     fn defaults_and_cli_and_partial_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("partial_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "partial_conf_file",
+                ])
+                .arg("--")
                 .args(["--a", "bar"])
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -834,13 +856,16 @@ mod tests {
     #[test]
     fn defaults_and_env_vars_and_partial_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("partial_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "partial_conf_file",
+                ])
                 .env("STEAM_B", "true")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -869,14 +894,18 @@ mod tests {
     #[test]
     fn defaults_and_cli_and_env_vars_and_partial_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("partial_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "partial_conf_file",
+                ])
+                .arg("--")
                 .args(["--a", "bar"])
                 .env("STEAM_B", "true")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -905,11 +934,14 @@ mod tests {
     #[test]
     fn defaults_and_full_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("full_conf_file")
-                .run()
-                .unwrap()
-                .command()
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "full_conf_file",
+                ])
                 .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
@@ -939,13 +971,17 @@ mod tests {
     #[test]
     fn defaults_and_cli_and_full_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("full_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "full_conf_file",
+                ])
+                .arg("--")
                 .args(["--a", "bar"])
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -974,13 +1010,16 @@ mod tests {
     #[test]
     fn defaults_and_env_vars_and_full_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("full_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "full_conf_file",
+                ])
                 .env("STEAM_C", "64")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -1009,14 +1048,18 @@ mod tests {
     #[test]
     fn defaults_and_cli_and_env_vars_and_full_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("full_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "full_conf_file",
+                ])
+                .arg("--")
                 .args(["--a", "fee"])
                 .env("STEAM_C", "64")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -1045,14 +1088,18 @@ mod tests {
     #[test]
     fn defaults_and_cli_and_env_vars_and_conf_file_priority() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("partial_conf_file")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "partial_conf_file",
+                ])
+                .arg("--")
                 .args(["--c", "96"])
                 .env("STEAM_C", "64")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -1081,11 +1128,14 @@ mod tests {
     #[test]
     fn defaults_and_alternative_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("alt_conf_file")
-                .run()
-                .unwrap()
-                .command()
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "alt_conf_file",
+                ])
                 .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
@@ -1115,11 +1165,14 @@ mod tests {
     #[test]
     fn defaults_and_missing_alternative_conf_file() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("alt_conf_file_missing")
-                .run()
-                .unwrap()
-                .command()
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "alt_conf_file_missing",
+                ])
                 .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
@@ -1149,16 +1202,20 @@ mod tests {
     #[test]
     fn defaults_and_alternative_and_extra_conf_files() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("alt_and_runtime_conf_files")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "alt_and_runtime_conf_files",
+                ])
+                .arg("--")
                 .args([
                     "--conf-file",
                     "steam-config/examples/runtime_conf_file.toml",
                 ])
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,
@@ -1190,12 +1247,15 @@ mod tests {
     #[test]
     fn defaults_and_cli_and_env_vars_and_alt_and_extra_conf_files_priority() {
         let run = String::from_utf8(
-            escargot::CargoBuild::new()
-                .example("alt_and_runtime_conf_files")
-                .run()
-                .unwrap()
-                .command()
-                .current_dir(get_workspace_dir())
+            Command::new("cargo")
+                .args([
+                    "run",
+                    "--package",
+                    "steam-config",
+                    "--example",
+                    "alt_and_runtime_conf_files",
+                ])
+                .arg("--")
                 .args([
                     "--c",
                     "96",
@@ -1203,6 +1263,7 @@ mod tests {
                     "steam-config/examples/runtime_conf_file.toml",
                 ])
                 .env("STEAM_C", "64")
+                .current_dir(get_workspace_dir())
                 .output()
                 .unwrap()
                 .stdout,


### PR DESCRIPTION
Several instances of these tests failing with the error `"No such file
or directory"` have been observed during CI, with the tests passing when
the workflow is re-run.

Instead of using escargot the tests now run the required cargo commands
directly, as hopefully this issue is to do with the way escargot calls
for required binaries to be built (as it claims to offer reduced compile
times) and not an issue with the way Cargo locks the build directory.
