### PR TITLE
fix(steam-developer-guide): don't specify rust edition

### DIFF
--- a/steam-developer-guide/book.toml
+++ b/steam-developer-guide/book.toml
@@ -7,9 +7,6 @@ description = "The Simulation Technology for Evaluation and Architecture Modelli
 src = "md_src"
 language = "en"
 
-[rust]
-edition = "2024"
-
 [preprocessor.cmdrun]
 
 [preprocessor.keeper]


### PR DESCRIPTION
- The packages that are installed when doing `cargo install --locked` seem to be broken for rust edition 2024.