### PR TITLE
test(steam-config): serialise tests which share an executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "quote",
  "regex",
  "serde",
+ "serial_test",
  "syn 2.0.101",
  "trybuild",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ quote = "1.0.33"
 rand = "0.8.5"
 regex = "1.9.6"
 serde = { version = "1.0.188", features = ["derive"] }
+serial_test = "3.2.0"
 syn = { version = "1.0.41", features = ["parsing", "full", "extra-traits"] }
 tempfile = "3.19.0"
 trybuild = "1.0.103"

--- a/steam-config/Cargo.toml
+++ b/steam-config/Cargo.toml
@@ -29,4 +29,5 @@ syn = { version = "2.0.90", features = ["derive", "extra-traits", "full"] }
 clap.workspace = true
 figment.workspace = true
 serde.workspace = true
+serial_test.workspace = true
 trybuild.workspace = true

--- a/steam-config/src/lib.rs
+++ b/steam-config/src/lib.rs
@@ -618,12 +618,15 @@ mod tests {
     use std::path::PathBuf;
     use std::process::Command;
 
+    use serial_test::serial;
+
     fn get_workspace_dir() -> PathBuf {
         let package_dir = std::env::current_dir().unwrap();
         package_dir.parent().unwrap().to_path_buf()
     }
 
     #[test]
+    #[serial(no_conf_file)]
     fn defaults_with_no_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -661,6 +664,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(no_conf_file)]
     fn defaults_and_cli_with_no_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -700,6 +704,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(no_conf_file)]
     fn defaults_and_env_vars_with_no_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -738,6 +743,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(no_conf_file)]
     fn defaults_and_cli_and_env_vars_with_no_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -778,6 +784,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(partial_conf_file)]
     fn defaults_and_partial_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -815,6 +822,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(partial_conf_file)]
     fn defaults_and_cli_and_partial_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -854,6 +862,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(partial_conf_file)]
     fn defaults_and_env_vars_and_partial_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -892,6 +901,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(partial_conf_file)]
     fn defaults_and_cli_and_env_vars_and_partial_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -932,6 +942,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(full_conf_file)]
     fn defaults_and_full_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -969,6 +980,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(full_conf_file)]
     fn defaults_and_cli_and_full_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -1008,6 +1020,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(full_conf_file)]
     fn defaults_and_env_vars_and_full_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -1046,6 +1059,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(full_conf_file)]
     fn defaults_and_cli_and_env_vars_and_full_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -1086,6 +1100,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(partial_conf_file)]
     fn defaults_and_cli_and_env_vars_and_conf_file_priority() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -1126,6 +1141,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(alt_conf_file)]
     fn defaults_and_alternative_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -1163,6 +1179,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(alt_conf_file_missing)]
     fn defaults_and_missing_alternative_conf_file() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -1200,6 +1217,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(alt_and_runtime_conf_files)]
     fn defaults_and_alternative_and_extra_conf_files() {
         let run = String::from_utf8(
             Command::new("cargo")
@@ -1245,6 +1263,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(alt_and_runtime_conf_files)]
     fn defaults_and_cli_and_env_vars_and_alt_and_extra_conf_files_priority() {
         let run = String::from_utf8(
             Command::new("cargo")

--- a/steam-developer-guide/book.toml
+++ b/steam-developer-guide/book.toml
@@ -7,9 +7,6 @@ description = "The Simulation Technology for Evaluation and Architecture Modelli
 src = "md_src"
 language = "en"
 
-[rust]
-edition = "2024"
-
 [preprocessor.cmdrun]
 
 [preprocessor.keeper]

--- a/steam-track/Cargo.toml
+++ b/steam-track/Cargo.toml
@@ -36,4 +36,4 @@ capnpc.workspace = true
 walkdir = "2.4.0"
 
 [dev-dependencies]
-serial_test = "3.2.0"
+serial_test.workspace = true


### PR DESCRIPTION
Several instances of these tests failing with the error `"No such file
or directory"` have been observed during CI, with the tests passing when
the workflow is re-run. The removal of escargot did not resolved this.

I suspect the race condition may be caused by multiple tests attempting
to build the same executable:
- Cargo will lock the target directory preventing multiple compilations
  from occuring in parallel.
- The build directory is unlocked once the binary has been built.
- Another test manages to lock the target directory and rebuild the
  binary whilst the first `cargo run` command attempts to launch process
  running the binary it built.

However it is not clear why subsequent `cargo run` invocations should
build the binary as the source cannot have changed.
