### PR TITLE
feat: Add [must_use] attribute to functions that return a future

### DIFF
--- a/steam-engine/src/port.rs
+++ b/steam-engine/src/port.rs
@@ -78,6 +78,7 @@ where
         self.state.clone()
     }
 
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn get(&self) -> PortGet<T> {
         if !*self.connected.borrow() {
             panic!("{} not connected", self);
@@ -90,6 +91,7 @@ where
     }
 
     /// Must be matched with a `finish_get` to allow the OutPort to continue.
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn start_get(&self) -> PortStartGet<T> {
         if !*self.connected.borrow() {
             panic!("{} not connected", self);
@@ -147,6 +149,7 @@ where
         }
     }
 
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn put(&self, value: T) -> PortPut<T> {
         let state = self
             .state
@@ -160,6 +163,7 @@ where
         }
     }
 
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn try_put(&self) -> PortTryPut<T> {
         let state = self
             .state

--- a/steam-engine/src/time/clock.rs
+++ b/steam-engine/src/time/clock.rs
@@ -213,6 +213,7 @@ impl Clock {
 
     /// Returns a [ClockDelay] future which must be `await`ed to delay the
     /// specified number of ticks.
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn wait_ticks(&self, ticks: u64) -> ClockDelay {
         let mut until = self.tick_now();
         until.tick += ticks;
@@ -229,6 +230,7 @@ impl Clock {
     /// completes then this future is allowed to not complete. This allows the
     /// user to create tasks that can run continuously as long as the rest of
     /// the simulation continues to run.
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn wait_ticks_or_exit(&self, ticks: u64) -> ClockDelay {
         let mut until = self.tick_now();
         until.tick += ticks;
@@ -240,6 +242,7 @@ impl Clock {
         }
     }
 
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn next_tick_and_phase(&self, phase: u32) -> ClockDelay {
         let mut until = self.tick_now();
         until.tick += 1;
@@ -252,6 +255,7 @@ impl Clock {
         }
     }
 
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn wait_phase(&self, phase: u32) -> ClockDelay {
         let mut until = self.tick_now();
         assert!(phase > until.phase, "Time going backwards");

--- a/steam-engine/src/traits.rs
+++ b/steam-engine/src/traits.rs
@@ -112,6 +112,7 @@ impl SimObject for usize {}
 /// }
 /// ```
 pub trait Event<T> {
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     fn listen(&self) -> BoxFuture<'static, T>;
 
     /// Allow cloning of Boxed elements of vector for AllOf/AnyOf

--- a/steam-resources/src/base.rs
+++ b/steam-resources/src/base.rs
@@ -58,12 +58,14 @@ impl Resource {
         }
     }
 
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn request(&self) -> ResourceRequest {
         ResourceRequest {
             shared_state: self.shared_state.clone(),
         }
     }
 
+    #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
     pub fn release(&self) -> ResourceRelease {
         ResourceRelease {
             shared_state: self.shared_state.clone(),


### PR DESCRIPTION
- This should help avoid missing the `.await`.
- The warning message needs to be a literal, so for now it's replicated in each attribute. Maybe something to address in the future.