### PR TITLE
docs: ensure `cargo doc --document-private-items` can be used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,16 @@ repos:
         entry: env RUSTFLAGS="-D warnings" cargo clippy-strict
         pass_filenames: false
         stages: [pre-commit, pre-merge-commit, pre-push, manual]
+      - id: cargo-doc
+        name: cargo doc
+        description: check Rust source code documentation
+        language: system
+        types: [rust]
+        entry:
+          env RUSTDOCFLAGS="-D warnings" DOCS_RS=1 cargo doc --workspace
+          --all-features --document-private-items --no-deps
+        pass_filenames: false
+        stages: [pre-commit, pre-merge-commit, pre-push, manual]
       - id: cargo-semver-checks
         name: cargo semver-checks
         description: lint crate API changes for semver violations

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Welcome to the STEAM (Simulation Technology for Evaluation and Architecture
 Modelling) project. The core STEAM packages are provided as a monorepo, which
 together provide the following functionality:
 
-- An event-driven [simulation engine]
-- [Logging] and [log viewing] system
-- Hierarchical configuration support
-- Documentation tooling
-- A library of [components] and basic [models]
+- An event-driven [simulation engine].
+- [Logging] and [log viewing] system.
+- Hierarchical configuration support.
+- Documentation tooling.
+- A library of [components] and basic [models].
 
 <!-- ANCHOR_END: intro -->
 

--- a/steam-config/src/multi_source_config.rs
+++ b/steam-config/src/multi_source_config.rs
@@ -3,8 +3,8 @@
 //! The implementation of the [macro@crate::multi_source_config] macro.
 //!
 //! Within this file [proc_macro2] types are used, with [syn] providing the
-//! required parsing functionality and [quote] allowing new AST to be created as
-//! if writing Rust as normal.
+//! required parsing functionality and [mod@quote] allowing new AST to be
+//! created as if writing Rust as normal.
 
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};

--- a/steam-doc-builder/src/asciidoctor_pp.rs
+++ b/steam-doc-builder/src/asciidoctor_pp.rs
@@ -92,6 +92,7 @@ impl AsciiDoctorPreProcessor {
         line
     }
 
+    #[allow(rustdoc::broken_intra_doc_links)]
     /// Process the markdown links and replace them with AsciiDoctor ones.
     ///
     /// Markdown links should be of the form: [`Visible Text`](link)

--- a/steam-track/src/tracker/capnp.rs
+++ b/steam-track/src/tracker/capnp.rs
@@ -10,7 +10,7 @@ use crate::steam_track_capnp::log::LogLevel;
 use crate::tracker::{EntityManager, Track};
 use crate::{SharedWriter, Tag, Writer};
 
-/// A tracer that writes Cap'n Proto binary data
+/// A tracker that writes Cap'n Proto binary data
 pub struct CapnProtoTracker {
     entity_manager: EntityManager,
     writer: SharedWriter,

--- a/steam-track/src/tracker/in_memory.rs
+++ b/steam-track/src/tracker/in_memory.rs
@@ -12,7 +12,7 @@ use crate::tracker::{EntityManager, Track};
 /// A [`Track`] event.
 #[derive(Debug, Clone)]
 pub struct EventCommon {
-    /// The [`Tag`](crate::Tag) of the event originator.
+    /// The [`Tag`] of the event originator.
     tag: Tag,
 
     /// The time at which the event occurred.

--- a/steam-track/src/tracker/mod.rs
+++ b/steam-track/src/tracker/mod.rs
@@ -102,13 +102,13 @@ pub struct EntityManager {
     /// Keep track of the current time.
     current_time: Mutex<f64>,
 
-    /// Keep track of entites that have trace enable/log levels different to the
-    /// default
+    /// Keep track of entities that have trace enable/log levels different to
+    /// the default
     entity_lookup: Mutex<HashMap<Tag, log::Level>>,
 }
 
 impl EntityManager {
-    /// Constructor with [`TraceState`] and [`log::Level`]
+    /// Constructor with default [`log::Level`]
     #[must_use]
     pub fn new(default_entity_level: log::Level) -> Self {
         Self {


### PR DESCRIPTION
As it can be useful when developing functionality withing the STEAM
packages to build the API documentation with `--document-private-items`
enabled all warnings and errors reported with this set have been
resolved.

A new pre-commit hook has been added to ensure that documentation builds
of this kind remain warning and error free.

Other minor documentation improvements are also included, such as
spelling corrections.
