### PR TITLE
style: set rustfmt `imports_granularity` to `Module`

### DIFF
--- a/examples/sim-ring/src/tracker_builder.rs
+++ b/examples/sim-ring/src/tracker_builder.rs
@@ -6,9 +6,8 @@ use std::io::BufWriter;
 use std::sync::Arc;
 use std::{fs, io};
 
-use steam_track::tracker::{
-    CapnProtoTracker, EntityManager, TextTracker, multi_tracker::MultiTracker,
-};
+use steam_track::tracker::multi_tracker::MultiTracker;
+use steam_track::tracker::{CapnProtoTracker, EntityManager, TextTracker};
 use steam_track::{Tracker, Writer};
 
 /// Create a tracker that prints to stdout

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,4 +2,5 @@
 
 format_code_in_doc_comments = true
 group_imports = "StdExternalCrate"
+imports_granularity = "Module"
 wrap_comments = true

--- a/steam-components/src/flow_controls/credit_issuer.rs
+++ b/steam-components/src/flow_controls/credit_issuer.rs
@@ -14,8 +14,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use steam_engine::port::OutPort;
-use steam_engine::port::{InPort, PortState};
+use steam_engine::port::{InPort, OutPort, PortState};
 use steam_engine::traits::SimObject;
 use steam_engine::types::SimResult;
 use steam_model_builder::EntityDisplay;

--- a/steam-components/src/types.rs
+++ b/steam-components/src/types.rs
@@ -6,10 +6,8 @@
 
 use std::mem::size_of;
 
-use steam_engine::{
-    traits::{Routable, SimObject, TotalBytes},
-    types::{ReqType, SimError},
-};
+use steam_engine::traits::{Routable, SimObject, TotalBytes};
+use steam_engine::types::{ReqType, SimError};
 use steam_track::tag::Tagged;
 
 /// The `DataGenerator` is what a [source](crate::source) uses

--- a/steam-config/tests/parse_extra_conf_file.rs
+++ b/steam-config/tests/parse_extra_conf_file.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 use steam_config::multi_source_config;
 

--- a/steam-doc-builder/src/bin/adoc-builder.rs
+++ b/steam-doc-builder/src/bin/adoc-builder.rs
@@ -17,7 +17,8 @@
 //! ```bash
 //! > adoc-builder --help
 //! ```
-use std::{error::Error, fs::File};
+use std::error::Error;
+use std::fs::File;
 
 use clap::Parser;
 use steam_doc_builder::doc_parser::DocParser;

--- a/steam-docpp/src/lib.rs
+++ b/steam-docpp/src/lib.rs
@@ -5,8 +5,7 @@
 //! Supports a number of helper macros that allow the user to embded content
 //! into documentation.
 
-use steam_doc_builder::helpers;
-use steam_doc_builder::toc;
+use steam_doc_builder::{helpers, toc};
 
 #[cfg(feature = "asciidoctor")]
 mod adoc;

--- a/steam-engine/tests/clocks.rs
+++ b/steam-engine/tests/clocks.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
-use std::{cell::RefCell, rc::Rc};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use steam_engine::test_helpers::start_test;
 

--- a/steam-engine/tests/run_until.rs
+++ b/steam-engine/tests/run_until.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+use steam_engine::events::all_of::AllOf;
 use steam_engine::events::any_of::AnyOf;
-use steam_engine::{events::all_of::AllOf, test_helpers::start_test};
+use steam_engine::test_helpers::start_test;
 
 mod common;
 use common::{create_once_event_at_delay, spawn_activity};

--- a/steam-models/benches/ethernet_frame.rs
+++ b/steam-models/benches/ethernet_frame.rs
@@ -4,9 +4,10 @@ use criterion::{BatchSize, Criterion, criterion_group};
 use steam_components::connect_port;
 use steam_components::sink::Sink;
 use steam_components::store::Store;
+use steam_engine::engine::Engine;
 use steam_engine::port::OutPort;
 use steam_engine::spawn_simulation;
-use steam_engine::{engine::Engine, traits::SimObject};
+use steam_engine::traits::SimObject;
 use steam_models::ethernet_frame::{EthernetFrame, SRC_MAC_BYTES};
 use steam_track::tracker::dev_null_tracker;
 

--- a/steam-models/src/ethernet_frame.rs
+++ b/steam-models/src/ethernet_frame.rs
@@ -2,13 +2,14 @@
 
 //! The EthernetFrame provides an implementation of a standard Ethernet frame
 
-use std::{fmt::Display, sync::Arc};
+use std::fmt::Display;
+use std::sync::Arc;
 
-use steam_engine::{
-    traits::{Routable, SimObject, TotalBytes},
-    types::ReqType,
-};
-use steam_track::{Tag, create, create_tag, entity::Entity, tag::Tagged};
+use steam_engine::traits::{Routable, SimObject, TotalBytes};
+use steam_engine::types::ReqType;
+use steam_track::entity::Entity;
+use steam_track::tag::Tagged;
+use steam_track::{Tag, create, create_tag};
 
 pub const PREAMBLE_BYTES: usize = 7;
 pub const SFD_BYTES: usize = 1;

--- a/steam-models/tests/fc_pipeline.rs
+++ b/steam-models/tests/fc_pipeline.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+use steam_components::flow_controls::limiter::Limiter;
 use steam_components::sink::Sink;
 use steam_components::source::Source;
-use steam_components::{connect_port, rc_limiter};
-use steam_components::{flow_controls::limiter::Limiter, option_box_repeat};
+use steam_components::{connect_port, option_box_repeat, rc_limiter};
 use steam_engine::run_simulation;
 use steam_engine::test_helpers::start_test;
 use steam_models::fc_pipeline::FcPipeline;

--- a/steam-spotter/src/app.rs
+++ b/steam-spotter/src/app.rs
@@ -4,10 +4,9 @@ use std::error;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 
-use crate::bin_loader;
 use crate::filter::{Filter, start_background_filter};
-use crate::log_parser;
 use crate::renderer::Renderer;
+use crate::{bin_loader, log_parser};
 
 /// Size of blocks of data to read from the file and filter at a time
 pub const CHUNK_SIZE: usize = 50000;

--- a/steam-spotter/src/main.rs
+++ b/steam-spotter/src/main.rs
@@ -7,7 +7,8 @@ use steam_spotter::app::{App, AppResult};
 use steam_spotter::event::{Event, EventHandler};
 use steam_spotter::handler::handle_key_events;
 use steam_spotter::tui::Tui;
-use tui::{Terminal, backend::CrosstermBackend};
+use tui::Terminal;
+use tui::backend::CrosstermBackend;
 
 /// Command-line arguments.
 #[derive(Parser)]

--- a/steam-spotter/src/tui.rs
+++ b/steam-spotter/src/tui.rs
@@ -4,7 +4,8 @@ use std::{io, panic};
 
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
-use tui::{Terminal, backend::Backend};
+use tui::Terminal;
+use tui::backend::Backend;
 
 use crate::app::{App, AppResult};
 use crate::event::EventHandler;

--- a/steam-spotter/src/ui.rs
+++ b/steam-spotter/src/ui.rs
@@ -5,17 +5,12 @@ use std::vec;
 
 use tui::Frame;
 use tui::backend::Backend;
-use tui::layout::Direction;
-use tui::layout::Layout;
-use tui::layout::{Alignment, Constraint, Rect};
-use tui::style::Modifier;
-use tui::style::{Color, Style};
+use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use tui::style::{Color, Modifier, Style};
 use tui::text::{Line, Span};
-use tui::widgets::BarChart;
-use tui::widgets::{Block, BorderType, Borders, Paragraph};
+use tui::widgets::{BarChart, Block, BorderType, Borders, Paragraph};
 
-use crate::app::App;
-use crate::app::InputState;
+use crate::app::{App, InputState};
 use crate::handler::TOGGLE_RE;
 
 /// Renders the user interface widgets.

--- a/steam-track/examples/log_test.rs
+++ b/steam-track/examples/log_test.rs
@@ -26,12 +26,10 @@
 //!   capnp convert packed:text steam-track/schemas/steam_track.capnp Event < foo.bin
 //! ```
 
-use std::fs;
-use std::io;
 use std::io::BufWriter;
 use std::net::TcpStream;
 use std::sync::{Arc, mpsc};
-use std::thread;
+use std::{fs, io, thread};
 
 use steam_config::multi_source_config;
 use steam_track::entity::{Entity, toplevel};

--- a/steam-track/src/test_helpers.rs
+++ b/steam-track/src/test_helpers.rs
@@ -10,7 +10,8 @@
 //! unpredictable results.
 
 use core::sync::atomic::Ordering;
-use std::sync::{Mutex, atomic::AtomicU64};
+use std::sync::Mutex;
+use std::sync::atomic::AtomicU64;
 
 use regex::Regex;
 

--- a/steam-track/src/trace_visitor.rs
+++ b/steam-track/src/trace_visitor.rs
@@ -7,9 +7,8 @@ use std::io::BufRead;
 
 use capnp::serialize_packed;
 
-use crate::Tag;
-use crate::steam_track_capnp;
 use crate::steam_track_capnp::log::LogLevel;
+use crate::{Tag, steam_track_capnp};
 
 /// The `TraceVisitor` trait is the interface that allows a user to see all the
 /// events as a binary file is processed.
@@ -117,7 +116,8 @@ pub trait TraceVisitor {
 /// A simple visitor that will count how many tags are used.
 /// ```no_run
 /// # use std::error::Error;
-/// use std::{fs::File, io::BufReader};
+/// use std::fs::File;
+/// use std::io::BufReader;
 ///
 /// use steam_track::Tag;
 /// use steam_track::trace_visitor::{TraceVisitor, process_capnp};

--- a/steam-track/src/tracker/capnp.rs
+++ b/steam-track/src/tracker/capnp.rs
@@ -4,11 +4,10 @@ use std::sync::{Arc, Mutex};
 
 use capnp::serialize_packed;
 
-use crate::steam_track_capnp;
 use crate::steam_track_capnp::event;
 use crate::steam_track_capnp::log::LogLevel;
 use crate::tracker::{EntityManager, Track};
-use crate::{SharedWriter, Tag, Writer};
+use crate::{SharedWriter, Tag, Writer, steam_track_capnp};
 
 /// A tracker that writes Cap'n Proto binary data
 pub struct CapnProtoTracker {


### PR DESCRIPTION
The `Module` style has largely been adopted across the STEAM packages,
and so is now enforced by rustfmt.
