### PR TITLE
fix(steam-track): clippy warnings introduced by Rust 1.88.0

### DIFF
--- a/steam-track/src/lib.rs
+++ b/steam-track/src/lib.rs
@@ -285,6 +285,7 @@ macro_rules! error {
 pub mod steam_track_capnp {
     // No need to emit warnings for auto-generated Cap'n Proto code
     #![allow(missing_docs)]
+    #![allow(clippy::all)]
     #![allow(clippy::pedantic)]
 
     include!(concat!(env!("OUT_DIR"), "/steam_track_capnp.rs"));


### PR DESCRIPTION
The `uninlined_format_args` lint was moved from the `pedantic` group to
the `style` group of lints, see
https://github.com/rust-lang/rust-clippy/pull/14160.

As the `clippy::all` group does not include the pedantic group, warnings
were emitted for the genereated Cap'n Proto code. To disable all
warnings currently raised both clippy allow attributes are now required.
