### PR TITLE
infra: lock build and development tool versions

### DIFF
--- a/.github/actions/install-build-dependencies/install.sh
+++ b/.github/actions/install-build-dependencies/install.sh
@@ -16,7 +16,11 @@ else
   exit 1
 fi
 
-rustup update
-rustup toolchain install --profile default stable
+rustup show  # Cause toolchain specified in rust-toolchain.toml to be installed
 
-cargo install --locked cargo-expand mdbook mdbook-cmdrun mdbook-keeper mdbook-linkcheck
+cargo install --locked    \
+  cargo-expand@1.0.110    \
+  mdbook@0.4.51           \
+  mdbook-cmdrun@0.7.1     \
+  mdbook-keeper@0.5.0     \
+  mdbook-linkcheck@0.7.7

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -16,7 +16,7 @@ else
   exit 1
 fi
 
-npm install --no-save prettier@3.6.1
+npm install --no-save prettier@3.6.2
 
 rustup toolchain install --profile minimal --component rustfmt nightly
 

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -16,10 +16,13 @@ else
   exit 1
 fi
 
-npm install --no-save prettier
+npm install --no-save prettier@3.6.1
 
-rustup update
-rustup toolchain install --profile default nightly
+rustup toolchain install --profile minimal --component rustfmt nightly
 
-cargo install --locked cargo-about cargo-deny cargo-semver-checks release-plz
-cargo install --locked --bin cog cocogitto
+cargo install --locked        \
+  cargo-about@0.7.1           \
+  cargo-deny@0.18.3           \
+  cargo-semver-checks@0.41.0  \
+  release-plz@0.3.136
+cargo install --locked --bin cog cocogitto@6.3.0

--- a/README.md
+++ b/README.md
@@ -180,9 +180,11 @@ When writing a commmit message in this form:
   changelog.
 - The `optional scope` should be used to detail the name of the updated package.
   For example:
+
   ```text
   fix(steam-developer-guide): check for panic when running mdBook tests
   ```
+
   - If the change applied to multiple, but not all packages, the names should be
     comma seperated. For example:
     ```text

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Graphcore Ltd. All rights reserved.
+
+[toolchain]
+channel = "1.87.0"
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 profile = "default"

--- a/steam-track/src/lib.rs
+++ b/steam-track/src/lib.rs
@@ -285,6 +285,7 @@ macro_rules! error {
 pub mod steam_track_capnp {
     // No need to emit warnings for auto-generated Cap'n Proto code
     #![allow(missing_docs)]
+    #![allow(clippy::all)]
     #![allow(clippy::pedantic)]
 
     include!(concat!(env!("OUT_DIR"), "/steam_track_capnp.rs"));


### PR DESCRIPTION
Most tools are now fixed to specific versions to avoid unexpected CI
failures, either when opening a pull request or when a pull request is
merged, due to a new version of a tool having been released in the mean
time.

The versions of tools installed with `apt` and `brew` have not been
fixed.

The stable Rust toolchain used to build STEAM is now specified via the
rust-toolchain.toml file. This will cause `rustup` to automatically
activate the required toolchain when commands are run from within the
STEAM directory tree. `rustup` will automatically install the toolchain
as required when any command is invoked, hence executing `rustup show`
within the install-build-dependencies install script.

The rust-toolchain.toml file format does not support the controlling of
multiple toolchain installed. As STEAM also relies on a nightly Rust
toolchain to provide a version of `rustfmt` that allows the use of
"unstable" features the install-dev-dependencies install script still
installs this. To reduce the time taken the "minimal" profile of the
toolchain is now installed (plus `rustfmt` which is not included in
minimal).

The versions of tools installed with both `cargo` and `npm` are
specified directly in the `install.sh` scripts using the "@version"
notation they both support.
