### PR TITLE
infra: restrict linting to changes from origin/main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required to cause the main branch to also be fetched
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/install-dev-dependencies
 
       - name: Lint with pre-commit
-        run: pre-commit run --all-files
+        run: pre-commit run --from-ref origin/main --to-ref HEAD
 
   check-semantic-versioning:
     runs-on: macos-latest


### PR DESCRIPTION
Previously the pre-commit lints were run across all files, but this
could result in an unexpected result for a pull request should an
unmodified file already be failing a lint check.
