### PR TITLE
infra: use origin/main as the baseline for semver checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required to cause the main branch to also be fetched
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/install-dev-dependencies
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,7 +100,7 @@ repos:
         description: lint crate API changes for semver violations
         language: system
         types_or: [rust, toml]
-        entry: cargo semver-checks --baseline-rev HEAD
+        entry: cargo semver-checks --baseline-rev origin/main
         pass_filenames: false
         stages: [manual]
       - id: cog-verify


### PR DESCRIPTION
Using HEAD as the baseline revision to perform semantic version checks
against works fine during the git pre-commit hook, as HEAD has not yet
been updated to include the change being tested. However, this is not
the case when running pre-commits hooks during the CI "lint" job.

To ensure changes introduced via pull requests can be correctly checked
for semantic version compliance origin/main is now used as the baseline
revision. This should ensure that all pull requests merged into the main
branch are correctly versioned.
