### PR TITLE
fix: api doc build and publication

### DIFF
--- a/.github/workflows/online-documentation.yaml
+++ b/.github/workflows/online-documentation.yaml
@@ -38,7 +38,6 @@ jobs:
       - name: Build with mdBook
         run: |
           mdbook build
-          mdbook build # Second run required for cmdrun to work
           cat steam-developer-guide/rustdoc_build.log
         working-directory: ./steam-developer-guide
 

--- a/.github/workflows/online-documentation.yaml
+++ b/.github/workflows/online-documentation.yaml
@@ -39,6 +39,7 @@ jobs:
         run: |
           mdbook build
           mdbook build # Second run required for cmdrun to work
+          cat steam-developer-guide/rustdoc_build.log
         working-directory: ./steam-developer-guide
 
       - name: Generate top-level index.html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,8 @@ repos:
         description: check Rust source code documentation
         language: system
         types: [rust]
-        entry: env RUSTDOCFLAGS="-D warnings" DOCS_RS=1 cargo doc-steam-dev
+        entry:
+          env RUSTDOCFLAGS="-D warnings" STEAM_DOCS_ONLY=1 cargo doc-steam-dev
         pass_filenames: false
         stages: [pre-commit, pre-merge-commit, pre-push, manual]
       - id: cargo-semver-checks

--- a/steam-developer-guide/.gitignore
+++ b/steam-developer-guide/.gitignore
@@ -2,5 +2,6 @@
 
 book
 doctest_cache
+rustdoc_build.log
 rustdoc_cache
 md_src/licenses.html

--- a/steam-developer-guide/md_src/docs/api.md
+++ b/steam-developer-guide/md_src/docs/api.md
@@ -2,10 +2,10 @@
 
 # API Documentation
 
-<!-- cmdrun cargo clean --doc --target-dir ../../rustdoc_cache -->
-<!-- cmdrun STEAM_DOCS_ONLY=1 cargo doc-steam --target-dir ../../rustdoc_cache -->
-<!-- cmdrun rm -rf ../../book/rustdoc -->
-<!-- cmdrun cp -r ../../rustdoc_cache/doc ../../book/rustdoc -->
+<!-- cmdrun bash -x -c "cargo clean --doc --target-dir ../../rustdoc_cache" > ../../rustdoc_build.log 2>&1 -->
+<!-- cmdrun bash -x -c "STEAM_DOCS_ONLY=1 cargo doc-steam --target-dir ../../rustdoc_cache" >> ../../rustdoc_build.log 2>&1 -->
+<!-- cmdrun bash -x -c "rm -rfv ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->
+<!-- cmdrun bash -x -c "cp -rv ../../rustdoc_cache/doc ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->
 
 <iframe src="../../rustdoc/steam_engine/index.html" width="100%" height="600" style="border:1px solid black;">
 </iframe>

--- a/steam-developer-guide/md_src/docs/api.md
+++ b/steam-developer-guide/md_src/docs/api.md
@@ -3,7 +3,7 @@
 # API Documentation
 
 <!-- cmdrun cargo clean --doc --target-dir ../../rustdoc_cache -->
-<!-- cmdrun DOCS_RS=1 cargo doc-steam --target-dir ../../rustdoc_cache -->
+<!-- cmdrun STEAM_DOCS_ONLY=1 cargo doc-steam --target-dir ../../rustdoc_cache -->
 <!-- cmdrun rm -rf ../../book/rustdoc -->
 <!-- cmdrun cp -r ../../rustdoc_cache/doc ../../book/rustdoc -->
 

--- a/steam-developer-guide/md_src/docs/api.md
+++ b/steam-developer-guide/md_src/docs/api.md
@@ -5,6 +5,7 @@
 <!-- cmdrun bash -x -c "cargo clean --doc --target-dir ../../rustdoc_cache" > ../../rustdoc_build.log 2>&1 -->
 <!-- cmdrun bash -x -c "STEAM_DOCS_ONLY=1 cargo doc-steam --target-dir ../../rustdoc_cache" >> ../../rustdoc_build.log 2>&1 -->
 <!-- cmdrun bash -x -c "rm -rfv ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->
+<!-- cmdrun bash -x -c "mkdir -pv ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->
 <!-- cmdrun bash -x -c "cp -rv ../../rustdoc_cache/doc ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->
 
 <iframe src="../../rustdoc/steam_engine/index.html" width="100%" height="600" style="border:1px solid black;">

--- a/steam-perfetto-sys/build.rs
+++ b/steam-perfetto-sys/build.rs
@@ -25,14 +25,17 @@ fn main() {
     println!("cargo::rerun-if-changed=build.rs");
     println!("cargo::rerun-if-changed=src/lib.rs");
 
-    if std::env::var("DOCS_RS").is_ok() {
+    if std::env::var("STEAM_DOCS_ONLY").is_ok() || std::env::var("DOCS_RS").is_ok() {
         // Do not attempt to download or build Perfetto if a documentation only
         // build is occuring, regardless of the features enabled. This is useful
         // as it allows the `--all-features` flag to be passed to rustdoc
         // without incurring the time penalty of the Perfetto build.
-        // `DOCS_RS` was chosen as it is the defacto-standard mechanism used,
-        // due to a lack of support for detecting documentation builds in Cargo,
-        // see https://docs.rs/about/builds#detecting-docsrs.
+        //
+        // `DOCS_RS` is also supported as it is the defacto-standard mechanism
+        // used, due to a lack of support for detecting documentation builds in
+        // Cargo, see https://docs.rs/about/builds#detecting-docsrs.
+        // However as the build of the Rocket crate fails when `DOCS_RS` is set,
+        // within the STEAM infrastructure only `STEAM_DOCS_ONLY` is used.
         exit(0);
     }
 


### PR DESCRIPTION
- **fix: Rocket docs build failure with `DOCS_RS` set**
- **infra: capture log of rustdoc build process**
- **infra: remove the need to run mdbook twice**
