### PR TITLE
chore(steam-engine,steam-components,steam-models): remove async-std dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,124 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,12 +109,6 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -259,12 +135,6 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomic_float"
@@ -313,19 +183,6 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
-]
 
 [[package]]
 name = "bumpalo"
@@ -681,39 +538,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -818,19 +648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,18 +735,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -1161,15 +966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,7 +1000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "serde",
- "value-bag",
 ]
 
 [[package]]
@@ -1465,17 +1260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,20 +1285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2080,7 +1850,6 @@ dependencies = [
 name = "steam-components"
 version = "0.4.0"
 dependencies = [
- "async-std",
  "async-trait",
  "atomic_float",
  "clap",
@@ -2145,11 +1914,10 @@ name = "steam-engine"
 version = "0.4.0"
 dependencies = [
  "arc-swap",
- "async-std",
  "async-trait",
  "clap",
  "criterion",
- "event-listener 3.1.0",
+ "event-listener",
  "futures",
  "itertools 0.11.0",
  "log",
@@ -2172,7 +1940,6 @@ dependencies = [
 name = "steam-models"
 version = "0.4.0"
 dependencies = [
- "async-std",
  "async-trait",
  "criterion",
  "futures",
@@ -2680,12 +2447,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,19 +2519,6 @@ dependencies = [
  "quote",
  "syn 2.0.104",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ publish = ["kellnr"]
 
 [workspace.dependencies]
 approx = "0.5.1"
-async-std = { version = "1.12.0", features = ["attributes"] }
 async-trait = "0.1.88"
 capnp = "0.21.1"
 capnpc = "0.21.0"

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (249)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (228)</li>
             <li><a href="#MIT">MIT License</a> (76)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
@@ -3022,205 +3022,6 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/async-rs/async-attributes ">async-attributes 1.1.2</a></li>
-                    <li><a href=" https://github.com/yoshuawuyts/kv-log-macro ">kv-log-macro 1.0.7</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2019 Yoshua Wuyts
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/Xudong-Huang/generator-rs.git ">generator 0.7.5</a></li>
                 </ul>
                 <pre class="license-text">                               Apache License
@@ -5326,21 +5127,11 @@ limitations under the License.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.24.2</a></li>
                     <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.7.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 1.9.0</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.13.2</a></li>
-                    <li><a href=" https://github.com/Keruspe/async-global-executor ">async-global-executor 2.4.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-io ">async-io 2.5.0</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.1</a></li>
-                    <li><a href=" https://github.com/async-rs/async-std ">async-std 1.13.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-task ">async-task 4.7.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
                     <li><a href=" https://github.com/Amanieu/atomic-rs ">atomic 0.5.3</a></li>
                     <li><a href=" https://github.com/Amanieu/atomic-rs ">atomic 0.6.1</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
                     <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.75</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.9.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
                     <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.0</a></li>
                     <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.32</a></li>
@@ -5354,13 +5145,9 @@ limitations under the License.
                     <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.13</a></li>
-                    <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
-                    <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 2.5.3</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 3.1.0</a></li>
-                    <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
-                    <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite 2.6.1</a></li>
                     <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.31.1</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.2</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
@@ -5388,8 +5175,6 @@ limitations under the License.
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.4</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.11</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/piper ">piper 0.2.4</a></li>
-                    <li><a href=" https://github.com/smol-rs/polling ">polling 3.10.0</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.12.1</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.10.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-automata ">regex-automata 0.4.9</a></li>
@@ -5416,12 +5201,10 @@ limitations under the License.
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.1.14</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.1</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.6</a></li>
-                    <li><a href=" https://github.com/sval-rs/value-bag ">value-bag 1.11.1</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasi 0.14.2+wasi-0.2.4</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend ">wasm-bindgen-backend 0.2.100</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.50</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.100</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.100</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.100</a></li>
@@ -6740,7 +6523,6 @@ limitations under the License.
                     <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.88</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Figment ">figment 0.10.19</a></li>
-                    <li><a href=" https://github.com/rustwasm/gloo/tree/master/crates/timers ">gloo-timers 0.3.0</a></li>
                     <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.6.0</a></li>
                     <li><a href=" https://github.com/dtolnay/indoc ">indoc 2.0.6</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.15</a></li>

--- a/steam-components/Cargo.toml
+++ b/steam-components/Cargo.toml
@@ -23,7 +23,6 @@ name = "benchmarks_main"
 harness = false
 
 [dependencies]
-async-std.workspace = true
 async-trait.workspace = true
 atomic_float = "0.1.0"
 log.workspace = true

--- a/steam-engine/Cargo.toml
+++ b/steam-engine/Cargo.toml
@@ -19,7 +19,6 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 event-listener.workspace = true

--- a/steam-models/Cargo.toml
+++ b/steam-models/Cargo.toml
@@ -23,7 +23,6 @@ name = "bench_models"
 harness = false
 
 [dependencies]
-async-std.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 log.workspace = true


### PR DESCRIPTION
The async-std package was no longer used in STEAM but was still included
as a package dependency. This completes its removal.

As maintenance of async-std has been discontinued cargo-deny issued the
following advisory:

```
error[unmaintained]: async-std has been discontinued
   ┌─ /Volumes/scratch/repos/steam/Cargo.lock:18:1
   │
18 │ async-std 1.13.1 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2025-0052
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0052
   ├ The `async-std` has been discontinued.

     Alternatives:

     - [smol](https://crates.io/crates/smol)
   ├ Announcement: https://github.com/async-rs/async-std
   ├ Solution: No safe upgrade is available!
   ├ async-std v1.13.1
     ├── steam-components v0.4.0
     │   ├── flaky-component v2.0.0
     │   ├── flaky-with-delay v2.0.0
     │   ├── scrambler v2.0.0
     │   ├── sim-ring v2.0.0
     │   ├── (dev) steam-engine v0.4.0
     │   │   ├── flaky-component v2.0.0 (*)
     │   │   ├── flaky-with-delay v2.0.0 (*)
     │   │   ├── scrambler v2.0.0 (*)
     │   │   ├── sim-ring v2.0.0 (*)
     │   │   ├── steam-components v0.4.0 (*)
     │   │   ├── steam-models v0.4.0
     │   │   │   └── sim-ring v2.0.0 (*)
     │   │   ├── (dev) steam-protocols v0.1.0
     │   │   └── steam-resources v0.1.0
     │   │       └── steam-components v0.4.0 (*)
     │   ├── steam-models v0.4.0 (*)
     │   └── (dev) steam-protocols v0.1.0 (*)
     ├── steam-engine v0.4.0 (*)
     └── steam-models v0.4.0 (*)

advisories FAILED, bans ok, licenses ok, sources ok
```
