### PR TITLE
infra: use cargo-binstall when installing build and dev dependencies

### DIFF
--- a/.github/actions/install-build-dependencies/action.yaml
+++ b/.github/actions/install-build-dependencies/action.yaml
@@ -20,5 +20,6 @@ runs:
           ${{ runner.os }}-cargo-build-deps-
 
     - name: Run install.sh
+      id: run-install
       run: ./.github/actions/install-build-dependencies/install.sh
       shell: bash

--- a/.github/actions/install-build-dependencies/install.sh
+++ b/.github/actions/install-build-dependencies/install.sh
@@ -18,9 +18,12 @@ fi
 
 rustup show  # Cause toolchain specified in rust-toolchain.toml to be installed
 
-cargo install --locked    \
-  cargo-expand@1.0.114    \
-  mdbook@0.4.52           \
-  mdbook-cmdrun@0.7.1     \
-  mdbook-keeper@0.5.0     \
+export BINSTALL_VERSION=1.15.4
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+cargo binstall --disable-telemetry --no-confirm --locked   \
+  cargo-expand@1.0.114                                     \
+  mdbook@0.4.52                                            \
+  mdbook-cmdrun@0.7.1                                      \
+  mdbook-keeper@0.5.0                                      \
   mdbook-linkcheck@0.7.7

--- a/.github/actions/install-dev-dependencies/action.yaml
+++ b/.github/actions/install-dev-dependencies/action.yaml
@@ -22,5 +22,6 @@ runs:
           ${{ runner.os }}-cargo-build-deps-
 
     - name: Run install.sh
+      id: run-install
       run: ./.github/actions/install-dev-dependencies/install.sh
       shell: bash

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -20,9 +20,9 @@ npm install --no-save prettier@3.6.2
 
 rustup toolchain install --profile minimal --component rustfmt nightly
 
-cargo install --locked        \
-  cargo-about@0.7.1           \
-  cargo-deny@0.18.3           \
-  cargo-semver-checks@0.42.0  \
+cargo binstall --disable-telemetry --no-confirm --locked   \
+  cargo-about@0.7.1                                        \
+  cargo-deny@0.18.3                                        \
+  cargo-semver-checks@0.42.0                               \
   release-plz@0.3.139
-cargo install --locked --bin cog cocogitto@6.3.0
+cargo binstall --disable-telemetry --no-confirm --locked --bin=cog cocogitto@6.3.0


### PR DESCRIPTION
The use of cargo-binstall should significatly reduce the time taken to
install these dependencies on Github Runners when the Actions cache does
not contain a usable previous build.
