### PR TITLE
Revert "chore: temporarily disable semver checks for steam-perfetto"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,9 +103,7 @@ repos:
         description: lint crate API changes for semver violations
         language: system
         types_or: [rust, toml]
-        entry:
-          cargo semver-checks --baseline-rev origin/main --exclude
-          steam-perfetto
+        entry: cargo semver-checks --baseline-rev origin/main
         pass_filenames: false
         stages: [manual]
       - id: cog-verify


### PR DESCRIPTION
This reverts commit 0c471684fd3882dda6dae5c89dccfa9f9a2de084.
