### PR TITLE
infra: install additional build and dev deps when not run as a GitHub Action

### DIFF
--- a/.github/actions/install-build-dependencies/install.sh
+++ b/.github/actions/install-build-dependencies/install.sh
@@ -5,12 +5,58 @@
 set -e
 echo "Installing build dependencies"
 
+show_exit_message=false
+if [[ $GITHUB_ACTIONS != "true" ]]; then
+  if [[ $OSTYPE == "linux"* ]]; then
+    sudo apt-get update
+    sudo apt install    \
+      build-essential   \
+      curl              \
+      git               \
+      python3.12-venv
+  elif [[ $OSTYPE == "darwin"* ]]; then
+    if [ ! -f /opt/homebrew/bin/brew ]; then
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      echo >> $HOME/.zprofile
+      echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> $HOME/.zprofile
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+      show_exit_message=true
+    fi
+  else
+    echo "Installing build dependencies on $OSTYPE is unsupported"
+    exit 1
+  fi
+
+  if ! command -v rustup >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    show_exit_message=true
+  fi
+
+  cargo_bin_dir="$HOME/.cargo/bin"
+  case ":$PATH:" in
+    *":$cargo_bin_dir:"*)
+      echo "Cargo bin directory already found on PATH"
+      ;;
+    *)
+      echo "Adding Cargo bin directory to PATH"
+      export PATH="$cargo_bin_dir:$PATH"
+      show_exit_message=true
+      ;;
+  esac
+fi
+
 if [[ $OSTYPE == "linux"* ]]; then
   sudo apt-get update
-  sudo apt install asciidoctor capnproto protobuf-compiler
+  sudo apt install   \
+    asciidoctor      \
+    capnproto        \
+    protobuf-compiler
 elif [[ $OSTYPE == "darwin"* ]]; then
   brew update
-  brew install asciidoctor capnp protobuf
+  brew install    \
+    asciidoctor   \
+    capnp         \
+    protobuf
 else
   echo "Installing build dependencies on $OSTYPE is unsupported"
   exit 1
@@ -24,6 +70,11 @@ curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-
 cargo binstall --disable-telemetry --no-confirm --locked   \
   cargo-expand@1.0.116                                     \
   mdbook@0.4.52                                            \
+  mdbook-alerts@0.8.0                                      \
   mdbook-cmdrun@0.7.3                                      \
   mdbook-keeper@0.5.0                                      \
   mdbook-linkcheck@0.7.7
+
+if $show_exit_message; then
+  echo "Please start a new shell to pickup changes to PATH"
+fi

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -5,6 +5,19 @@
 set -e
 echo "Installing dev dependencies"
 
+if [[ $GITHUB_ACTIONS != "true" ]]; then
+  if [[ $OSTYPE == "linux"* ]]; then
+    sudo apt-get update
+    sudo apt install npm
+  elif [[ $OSTYPE == "darwin"* ]]; then
+    brew update
+    brew install npm
+  else
+    echo "Installing dev dependencies on $OSTYPE is unsupported"
+    exit 1
+  fi
+fi
+
 if [[ $OSTYPE == "linux"* ]]; then
   sudo apt-get update
   sudo apt install pre-commit

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ executable model. Where appropriate sections of specification and the reference
 model for that part of the specification can reside within the same source file
 if desired.
 
-Continuous integration is run on both Linux and macOS to ensure ongoing
-compatibly with whichever platform developers wish to use. A robust release
-process is also defined to guarantee semantic versioning of packages and
+Continuous integration is run on both Linux (Ubuntu LTS) and macOS to ensure
+ongoing compatibly with whichever platform developers wish to use. A robust
+release process is also defined to guarantee semantic versioning of packages and
 automated generation of release notes ensuring user upgrade processes are as
 smooth as possible.
 
@@ -78,36 +78,32 @@ included in the [Rust chapter] of the developer guide.
 
 <!-- ANCHOR: tooling_bootstrap -->
 
-## Rust Tools
+## Tooling
 
-A Rust toolchain is required to build both models and documentation.
+All of the required tooling to build and use, and to develop STEAM can be
+installed using the scripts included within the repo. These scripts are designed
+to be used by both users and the CI system.
 
-Rust toolchains can be [installed] and managed using the [`rustup`] tool.
+Dependencies will be installed using package managers where possible, with [APT]
+being used on Linux and [Homebrew] on macOS ([Homebrew] itself will be installed
+as required if not already avaliable). Various cross-platform package managers
+are also used, including [rustup], [Cargo], and [npm].
 
-To install rustup on Linux:
+See the [Using STEAM Packages](#using-steam-packages) and
+[Developing STEAM Packages](#developing-steam-packages) sections for further
+details on these install scripts.
 
-```bash
-sudo apt install rustup
-```
+### Rust Tools
 
-To install rustup on macOS:
+The correct Rust toolchain will automatically be selected and used by [rustup]
+when commands are executed from within the STEAM directory (or below). This
+behaviour is controlled by the the `rust-toolchain.toml` file.
 
-```bash
-brew install rustup
-```
-
-It may also be necessary to add rustup to the PATH, as indicated by `brew`.
-
-Or alternatively, rustup can be installed directly with:
-
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-Once installed, it can be used to install the required Rust toolchain(s).
-
-[installed]: https://www.rust-lang.org/tools/install
-[`rustup`]: https://rust-lang.github.io/rustup/
+[APT]: https://wiki.debian.org/AptCLI
+[Cargo]: https://doc.rust-lang.org/stable/cargo
+[Homebrew]: https://brew.sh
+[npm]: https://www.npmjs.com
+[rustup]: https://rust-lang.github.io/rustup
 
 <!-- ANCHOR_END: tooling_bootstrap -->
 
@@ -123,9 +119,26 @@ required build dependencies can be installed by running:
 ./.github/actions/install-build-dependencies/install.sh
 ```
 
+<!-- prettier-ignore-start -->
+
+> [!IMPORTANT]
+> To ensure that the correct Rust toolchain is used the script must be executed
+> from within the STEAM directory.
+
+> [!Tip]
+> Although the script is interactive, selecting the default option
+> (<kbd>Enter</kbd>) at every step is a reasonable choice and will result in a
+> working environment.
+
+> [!NOTE]
+> Some of the actions taken by the script may request elevated permissions via
+> `sudo`.
+
+<!-- prettier-ignore-end -->
+
 [Asciidoctor]: https://asciidoctor.org
-[Cap'n Proto]: https://capnproto.org/
-[mdBook]: https://rust-lang.github.io/mdBook/
+[Cap'n Proto]: https://capnproto.org
+[mdBook]: https://rust-lang.github.io/mdBook
 
 <!-- ANCHOR_END: package_users -->
 
@@ -142,11 +155,27 @@ All of the required development dependencies can be installed by running:
 ./.github/actions/install-dev-dependencies/install.sh
 ```
 
+<!-- prettier-ignore-start -->
+
+> [!IMPORTANT]
+> To ensure that the correct Rust toolchain is used the script must be executed
+> from within the STEAM directory.
+
+> [!Tip]
+> Although the script is interactive, selecting the default option
+> (<kbd>Enter</kbd>) at every step is a reasonable choice and will result in a
+> working environment.
+
+> [!NOTE]
+> Some of the actions taken by the script may request elevated permissions via
+> `sudo`.
+
+<!-- prettier-ignore-end -->
+
 Finally the pre-commit hooks need to be installed within the cloned copy of the
 STEAM repo:
 
 ```bash
-cd steam
 pre-commit install
 ```
 
@@ -257,7 +286,7 @@ updated package, and automatically publishes the updated packages using
   https://github.com/graphcore-research/steam/actions/workflows/ci.yaml
 [clippy]: https://doc.rust-lang.org/clippy
 [Cocogitto]: https://docs.cocogitto.io
-[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0
 [pre-commit]: https://pre-commit.com
 [pre-commit-hooks]: https://github.com/pre-commit/pre-commit-hooks
 [Prettier]: https://prettier.io

--- a/steam-developer-guide/book.toml
+++ b/steam-developer-guide/book.toml
@@ -7,6 +7,10 @@ description = "The Simulation Technology for Evaluation and Architecture Modelli
 src = "md_src"
 language = "en"
 
+[preprocessor.alerts]
+after = [ "links" ]
+renderers = ["html", "linkcheck"]
+
 [preprocessor.cmdrun]
 
 [preprocessor.keeper]


### PR DESCRIPTION
The tooling section of README.md has been reworked to cover the new
functionality of the install scripts, and to allow consistent rendering
of the Markdown admonishments via both Github and mdBook the
mdbook-alerts plugin has been added as a build dependency.

Also, the format of all URLs within README.md has been made consistent.
