### PR TITLE
infra: update stable Rust toolchain to 1.90.0

### DIFF
--- a/.github/actions/install-build-dependencies/install.sh
+++ b/.github/actions/install-build-dependencies/install.sh
@@ -18,7 +18,7 @@ fi
 
 rustup show  # Cause toolchain specified in rust-toolchain.toml to be installed
 
-export BINSTALL_VERSION=1.15.4
+export BINSTALL_VERSION=1.15.5
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
 cargo binstall --disable-telemetry --no-confirm --locked   \

--- a/.github/actions/install-build-dependencies/install.sh
+++ b/.github/actions/install-build-dependencies/install.sh
@@ -22,7 +22,7 @@ export BINSTALL_VERSION=1.15.5
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
 cargo binstall --disable-telemetry --no-confirm --locked   \
-  cargo-expand@1.0.114                                     \
+  cargo-expand@1.0.116                                     \
   mdbook@0.4.52                                            \
   mdbook-cmdrun@0.7.1                                      \
   mdbook-keeper@0.5.0                                      \

--- a/.github/actions/install-build-dependencies/install.sh
+++ b/.github/actions/install-build-dependencies/install.sh
@@ -24,6 +24,6 @@ curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-
 cargo binstall --disable-telemetry --no-confirm --locked   \
   cargo-expand@1.0.116                                     \
   mdbook@0.4.52                                            \
-  mdbook-cmdrun@0.7.1                                      \
+  mdbook-cmdrun@0.7.3                                      \
   mdbook-keeper@0.5.0                                      \
   mdbook-linkcheck@0.7.7

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -21,7 +21,7 @@ npm install --no-save prettier@3.6.2
 rustup toolchain install --profile minimal --component rustfmt nightly
 
 cargo binstall --disable-telemetry --no-confirm --locked   \
-  cargo-about@0.7.1                                        \
+  cargo-about@0.8.2                                        \
   cargo-deny@0.18.3                                        \
   cargo-semver-checks@0.44.0                               \
   release-plz@0.3.139

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -22,7 +22,7 @@ rustup toolchain install --profile minimal --component rustfmt nightly
 
 cargo binstall --disable-telemetry --no-confirm --locked   \
   cargo-about@0.8.2                                        \
-  cargo-deny@0.18.3                                        \
+  cargo-deny@0.18.5                                        \
   cargo-semver-checks@0.44.0                               \
   release-plz@0.3.139
 cargo binstall --disable-telemetry --no-confirm --locked --bin=cog cocogitto@6.3.0

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -23,6 +23,6 @@ rustup toolchain install --profile minimal --component rustfmt nightly
 cargo binstall --disable-telemetry --no-confirm --locked   \
   cargo-about@0.7.1                                        \
   cargo-deny@0.18.3                                        \
-  cargo-semver-checks@0.42.0                               \
+  cargo-semver-checks@0.44.0                               \
   release-plz@0.3.139
 cargo binstall --disable-telemetry --no-confirm --locked --bin=cog cocogitto@6.3.0

--- a/.github/actions/install-dev-dependencies/install.sh
+++ b/.github/actions/install-dev-dependencies/install.sh
@@ -24,5 +24,5 @@ cargo binstall --disable-telemetry --no-confirm --locked   \
   cargo-about@0.8.2                                        \
   cargo-deny@0.18.5                                        \
   cargo-semver-checks@0.44.0                               \
-  release-plz@0.3.139
+  release-plz@0.3.147
 cargo binstall --disable-telemetry --no-confirm --locked --bin=cog cocogitto@6.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         language: system
         types_or: [rust, toml]
         entry:
-          cargo about generate --offline --workspace --all-features --fail
+          cargo about generate --locked --workspace --all-features --fail
           --config about.toml --output-file licenses.html about.hbs
         pass_filenames: false
         stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,12 +143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_float"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62af46d040ba9df09edc6528dae9d8e49f5f3e82f55b7d2ec31a733c38dbc49d"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,15 +168,6 @@ name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -335,15 +320,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "console"
@@ -541,17 +517,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1209,12 +1174,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1935,7 +1894,6 @@ name = "steam-components"
 version = "0.4.0"
 dependencies = [
  "async-trait",
- "atomic_float",
  "clap",
  "criterion",
  "futures",
@@ -2001,9 +1959,7 @@ dependencies = [
  "async-trait",
  "clap",
  "criterion",
- "event-listener",
  "futures",
- "itertools 0.11.0",
  "log",
  "steam-components",
  "steam-track",
@@ -2034,7 +1990,6 @@ dependencies = [
  "steam-engine",
  "steam-model-builder",
  "steam-track",
- "trait-variant",
 ]
 
 [[package]]
@@ -2088,12 +2043,10 @@ dependencies = [
 name = "steam-track"
 version = "0.4.0"
 dependencies = [
- "bincode",
  "capnp",
  "capnpc",
  "clap",
  "figment",
- "itertools 0.11.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -2446,17 +2399,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "trait-variant"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d702f06d03402af0cfc6490c40e4e8763305400bff6d8e480ea71bc6dea8e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,15 +323,24 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width 0.2.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -347,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
@@ -370,12 +379,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -420,6 +429,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio 1.0.4",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +468,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -474,6 +522,15 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -557,7 +614,7 @@ version = "2.0.0"
 dependencies = [
  "async-trait",
  "clap",
- "rand",
+ "rand 0.9.2",
  "steam-components",
  "steam-engine",
  "steam-model-builder",
@@ -570,7 +627,7 @@ version = "2.0.0"
 dependencies = [
  "async-trait",
  "clap",
- "rand",
+ "rand 0.9.2",
  "steam-components",
  "steam-engine",
  "steam-model-builder",
@@ -855,14 +912,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.1",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -905,15 +962,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -975,6 +1023,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
@@ -1059,6 +1113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -1141,12 +1196,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -1410,8 +1459,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1421,7 +1480,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1434,6 +1503,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,7 +1519,7 @@ checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm",
+ "crossterm 0.27.0",
  "indoc",
  "itertools 0.11.0",
  "paste",
@@ -1549,7 +1627,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -1796,6 +1874,7 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
+ "mio 1.0.4",
  "signal-hook",
 ]
 
@@ -1899,7 +1978,7 @@ dependencies = [
  "futures",
  "log",
  "paste",
- "rand",
+ "rand 0.9.2",
  "steam-engine",
  "steam-model-builder",
  "steam-resources",
@@ -1985,7 +2064,7 @@ dependencies = [
  "futures",
  "log",
  "paste",
- "rand",
+ "rand 0.9.2",
  "steam-components",
  "steam-engine",
  "steam-model-builder",
@@ -2029,8 +2108,8 @@ version = "0.3.0"
 dependencies = [
  "capnp",
  "clap",
- "crossterm",
- "itertools 0.11.0",
+ "crossterm 0.29.0",
+ "itertools 0.14.0",
  "log",
  "ratatui",
  "regex",
@@ -2052,7 +2131,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "prost",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde",
  "serial_test",
@@ -2472,6 +2551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2781,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2729,7 +2829,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ capnp = "0.21.1"
 capnpc = "0.21.0"
 clap = { version = "4.4.6", features = ["derive"] }
 criterion = "0.6.0"
-event-listener = "3.0.0"
 figment = { version = "0.10.19", features = ["env", "toml"] }
 futures = "0.3.28"
 itertools = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 [workspace.package]
 authors = ["The Silicon Architecture team"]
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.90"
 description = "The Simulation Technology for Evaluation and Architecture Modelling (STEAM) workspace"
 documentation = "https://graphcore-research.github.io/steam"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ async-trait = "0.1.88"
 capnp = "0.21.1"
 capnpc = "0.21.0"
 clap = { version = "4.4.6", features = ["derive"] }
-criterion = "0.6.0"
+criterion = "0.7.0"
 figment = { version = "0.10.19", features = ["env", "toml"] }
 futures = "0.3.28"
-itertools = "0.11.0"
+itertools = "0.14.0"
 log = { version = "0.4.20", features = ["std", "serde"] }
 num = "0.4.1"
 num-derive = "0.4.1"
@@ -58,7 +58,7 @@ proc-macro2 = "1.0.69"
 prost = "0.14.1"
 prost-build = "0.14.1"
 quote = "1.0.33"
-rand = "0.8.5"
+rand = "0.9.2"
 regex = "1.9.6"
 serde = { version = "1.0.188", features = ["derive"] }
 serial_test = "3.2.0"

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -21,7 +21,7 @@ publish.workspace = true
 [dependencies]
 clap.workspace = true
 log.workspace = true
-indicatif = "0.17.11"
+indicatif = "0.18.0"
 steam-components = { path = "../../steam-components" }
 steam-engine = { path = "../../steam-engine" }
 steam-models = { path = "../../steam-models" }

--- a/licenses.html
+++ b/licenses.html
@@ -7517,19 +7517,19 @@ SOFTWARE.
 
 Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
 following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
-EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>

--- a/licenses.html
+++ b/licenses.html
@@ -44,8 +44,8 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (238)</li>
-            <li><a href="#MIT">MIT License</a> (75)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (233)</li>
+            <li><a href="#MIT">MIT License</a> (74)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
         </ul>
@@ -3660,215 +3660,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/thomcc/atomic_float ">atomic_float 0.1.0</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2016 The Miri Developers
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/SergioBenitez/yansi ">yansi 1.0.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -5136,7 +4927,6 @@ limitations under the License.
                     <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.35</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.3</a></li>
-                    <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                     <li><a href=" https://github.com/bheisler/criterion.rs ">criterion-plot 0.5.0</a></li>
                     <li><a href=" https://github.com/bheisler/criterion.rs ">criterion 0.6.0</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
@@ -5145,7 +4935,6 @@ limitations under the License.
                     <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.13</a></li>
-                    <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 3.1.0</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.0</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
@@ -5175,7 +4964,6 @@ limitations under the License.
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
                     <li><a href=" https://github.com/gimli-rs/object ">object 0.36.7</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
-                    <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.4</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.11</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
@@ -6563,7 +6351,6 @@ limitations under the License.
                     <li><a href=" https://github.com/time-rs/time ">time-core 0.1.6</a></li>
                     <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.24</a></li>
                     <li><a href=" https://github.com/time-rs/time ">time 0.3.43</a></li>
-                    <li><a href=" https://github.com/rust-lang/impl-trait-utils ">trait-variant 0.0.1</a></li>
                     <li><a href=" https://github.com/dtolnay/trybuild ">trybuild 1.0.110</a></li>
                     <li><a href=" https://github.com/SergioBenitez/ubyte ">ubyte 0.10.4</a></li>
                     <li><a href=" https://github.com/SergioBenitez/uncased ">uncased 0.9.10</a></li>
@@ -7900,35 +7687,6 @@ SOFTWARE.</pre>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright 2017-2023 Eira Fransham.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/servo/bincode ">bincode 1.3.3</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2014 Ty Overby
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal

--- a/licenses.html
+++ b/licenses.html
@@ -44,8 +44,8 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (233)</li>
-            <li><a href="#MIT">MIT License</a> (74)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (239)</li>
+            <li><a href="#MIT">MIT License</a> (78)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
         </ul>
@@ -1306,10 +1306,12 @@
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.1.3</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.2.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.48.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.3</a></li>
@@ -4927,8 +4929,8 @@ limitations under the License.
                     <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.35</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.3</a></li>
-                    <li><a href=" https://github.com/bheisler/criterion.rs ">criterion-plot 0.5.0</a></li>
-                    <li><a href=" https://github.com/bheisler/criterion.rs ">criterion 0.6.0</a></li>
+                    <li><a href=" https://github.com/bheisler/criterion.rs ">criterion-plot 0.6.0</a></li>
+                    <li><a href=" https://github.com/bheisler/criterion.rs ">criterion 0.7.0</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.21</a></li>
@@ -4948,7 +4950,6 @@ limitations under the License.
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
                     <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.11.0</a></li>
                     <li><a href=" https://github.com/fitzgen/inlinable_string ">inlinable_string 0.1.15</a></li>
-                    <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.10.5</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.11.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
@@ -5216,6 +5217,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.3</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6320,11 +6322,13 @@ limitations under the License.
                     <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.99</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
+                    <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.11</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Figment ">figment 0.10.19</a></li>
                     <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.6.0</a></li>
                     <li><a href=" https://github.com/dtolnay/indoc ">indoc 2.0.6</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.15</a></li>
                     <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.175</a></li>
+                    <li><a href=" https://github.com/LukasKalbertodt/litrs/ ">litrs 0.4.2</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Pear ">pear 0.2.9</a></li>
@@ -6337,6 +6341,8 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.40</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast-impl 1.0.24</a></li>
                     <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast 1.0.24</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
@@ -7246,6 +7252,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/commons-rs/unit-prefix ">unit-prefix 0.5.1</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2024 Benjamin Sago, Fabio Valentini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/graphcore-research/steam ">check-copyright 1.0.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">flaky-component 2.0.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">flaky-with-delay 2.0.0</a></li>
@@ -7293,9 +7328,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rutrum/convert-case ">convert_case 0.7.1</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2025 rutrum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream-impl 0.3.6</a></li>
                     <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream 0.3.6</a></li>
-                    <li><a href=" https://github.com/ogham/rust-number-prefix ">number_prefix 0.4.0</a></li>
                     <li><a href=" https://github.com/plotters-rs/plotters ">plotters-backend 0.3.7</a></li>
                     <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                     <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
@@ -7356,6 +7418,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/crossterm-rs/crossterm ">crossterm 0.27.0</a></li>
+                    <li><a href=" https://github.com/crossterm-rs/crossterm ">crossterm 0.29.0</a></li>
                     <li><a href=" https://github.com/crossterm-rs/crossterm-winapi ">crossterm_winapi 0.9.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -7563,6 +7626,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 2.0.1</a></li>
+                    <li><a href=" https://github.com/JelteF/derive_more ">derive_more 2.0.1</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2016 Jelte Fennema
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/ratatui-org/ratatui ">ratatui 0.23.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -7623,8 +7716,8 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/console-rs/console ">console 0.15.11</a></li>
-                    <li><a href=" https://github.com/console-rs/indicatif ">indicatif 0.17.11</a></li>
+                    <li><a href=" https://github.com/console-rs/console ">console 0.16.1</a></li>
+                    <li><a href=" https://github.com/console-rs/indicatif ">indicatif 0.18.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 profile = "default"

--- a/steam-components/Cargo.toml
+++ b/steam-components/Cargo.toml
@@ -24,7 +24,6 @@ harness = false
 
 [dependencies]
 async-trait.workspace = true
-atomic_float = "0.1.0"
 log.workspace = true
 futures.workspace = true
 paste.workspace = true

--- a/steam-config/Cargo.toml
+++ b/steam-config/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 regex.workspace = true
-syn = { version = "2.0.90", features = ["derive", "extra-traits", "full"] }
+syn = { version = "2.0.106", features = ["derive", "extra-traits", "full"] }
 
 [dev-dependencies]
 clap.workspace = true

--- a/steam-doc-builder/src/asciidoctor_pp.rs
+++ b/steam-doc-builder/src/asciidoctor_pp.rs
@@ -81,12 +81,12 @@ impl AsciiDoctorPreProcessor {
         if heading_depth > 0 {
             // Ensure the next character is a space
             let next_char = line.chars().nth(heading_depth);
-            if let Some(ch) = next_char {
-                if ch == ' ' {
-                    let (_old_heading, rest) = line.split_at(heading_depth);
-                    let new_depth = heading_depth + depth - 2;
-                    return format!("{}{}", "=".repeat(new_depth), rest).to_owned();
-                }
+            if let Some(ch) = next_char
+                && ch == ' '
+            {
+                let (_old_heading, rest) = line.split_at(heading_depth);
+                let new_depth = heading_depth + depth - 2;
+                return format!("{}{}", "=".repeat(new_depth), rest).to_owned();
             }
         }
         line

--- a/steam-engine/Cargo.toml
+++ b/steam-engine/Cargo.toml
@@ -21,9 +21,7 @@ publish.workspace = true
 [dependencies]
 async-trait.workspace = true
 clap.workspace = true
-event-listener.workspace = true
 futures.workspace = true
-itertools.workspace = true
 log.workspace = true
 steam-track = { path = "../steam-track" }
 

--- a/steam-models/Cargo.toml
+++ b/steam-models/Cargo.toml
@@ -32,7 +32,6 @@ steam-components = { path = "../steam-components" }
 steam-model-builder = { path = "../steam-model-builder" }
 steam-engine = { path = "../steam-engine" }
 steam-track = { path = "../steam-track" }
-trait-variant = "0.0.1"
 
 [dev-dependencies]
 criterion.workspace = true

--- a/steam-spotter/Cargo.toml
+++ b/steam-spotter/Cargo.toml
@@ -21,7 +21,7 @@ publish.workspace = true
 [dependencies]
 capnp.workspace = true
 clap.workspace = true
-crossterm = "0.27.0"
+crossterm = "0.29.0"
 itertools.workspace = true
 log.workspace = true
 regex.workspace = true

--- a/steam-spotter/src/filter.rs
+++ b/steam-spotter/src/filter.rs
@@ -206,10 +206,10 @@ impl Filter {
         search = search.trim().to_owned();
 
         let mut search_re = None;
-        if self.use_regex {
-            if let Ok(re) = Regex::new(search.as_str()) {
-                search_re = Some(re);
-            }
+        if self.use_regex
+            && let Ok(re) = Regex::new(search.as_str())
+        {
+            search_re = Some(re);
         }
 
         SearchState {

--- a/steam-track/Cargo.toml
+++ b/steam-track/Cargo.toml
@@ -19,11 +19,9 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bincode = "1.3.3"
 capnp.workspace = true
 clap.workspace = true
 figment.workspace = true
-itertools.workspace = true
 lazy_static = "1.4.0"
 log.workspace = true
 num-derive.workspace = true

--- a/steam-track/build.rs
+++ b/steam-track/build.rs
@@ -46,10 +46,10 @@ fn get_capnp_schemas() -> Vec<PathBuf> {
         match entry {
             Ok(entry) => {
                 let filename = PathBuf::from(entry.file_name());
-                if let Some(extension) = filename.extension() {
-                    if extension == "capnp" {
-                        schemas.push(entry.path());
-                    }
+                if let Some(extension) = filename.extension()
+                    && extension == "capnp"
+                {
+                    schemas.push(entry.path());
                 }
             }
             Err(error) => panic!("{}", error),

--- a/steam-track/examples/trace_checker.rs
+++ b/steam-track/examples/trace_checker.rs
@@ -183,7 +183,7 @@ impl Checker {
         let still_active = self
             .active_ids
             .iter()
-            .filter(|&(k, _v)| (*k != steam_track::NO_ID && *k != steam_track::ROOT));
+            .filter(|&(k, _v)| *k != steam_track::NO_ID && *k != steam_track::ROOT);
 
         for (k, v) in still_active {
             warn!("ID {k} still active");


### PR DESCRIPTION
The minimum required version set in the workspace has also been updated.
