### PR TITLE
feat(steam-perfetto-sys,steam-perfetto)!: remove Perfetto build support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,8 +94,7 @@ repos:
         description: check Rust source code documentation
         language: system
         types: [rust]
-        entry:
-          env RUSTDOCFLAGS="-D warnings" STEAM_DOCS_ONLY=1 cargo doc-steam-dev
+        entry: env RUSTDOCFLAGS="-D warnings" cargo doc-steam-dev
         pass_filenames: false
         stages: [pre-commit, pre-merge-commit, pre-push, manual]
       - id: cargo-semver-checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "steam-perfetto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "steam-perfetto-sys"
-version = "1.0.0"
+version = "2.0.0"
 
 [[package]]
 name = "steam-protocols"

--- a/licenses.html
+++ b/licenses.html
@@ -7472,8 +7472,8 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-engine 0.4.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-model-builder 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-models 0.4.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/steam ">steam-perfetto 0.2.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/steam ">steam-perfetto-sys 1.0.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/steam ">steam-perfetto 0.3.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/steam ">steam-perfetto-sys 2.0.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-resources 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/steam ">steam-spotter 0.3.0</a></li>

--- a/steam-developer-guide/md_src/docs/api.md
+++ b/steam-developer-guide/md_src/docs/api.md
@@ -3,7 +3,7 @@
 # API Documentation
 
 <!-- cmdrun bash -x -c "cargo clean --doc --target-dir ../../rustdoc_cache" > ../../rustdoc_build.log 2>&1 -->
-<!-- cmdrun bash -x -c "STEAM_DOCS_ONLY=1 cargo doc-steam --target-dir ../../rustdoc_cache" >> ../../rustdoc_build.log 2>&1 -->
+<!-- cmdrun bash -x -c "cargo doc-steam --target-dir ../../rustdoc_cache" >> ../../rustdoc_build.log 2>&1 -->
 <!-- cmdrun bash -x -c "rm -rfv ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->
 <!-- cmdrun bash -x -c "mkdir -pv ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->
 <!-- cmdrun bash -x -c "cp -rv ../../rustdoc_cache/doc/. ../../book/rustdoc" >> ../../rustdoc_build.log 2>&1 -->

--- a/steam-perfetto-sys/Cargo.toml
+++ b/steam-perfetto-sys/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "steam-perfetto-sys"
-version = "1.0.0"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -19,8 +19,3 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
-[features]
-default = []
-_perfetto_src = []
-_perfetto_ui = ["_perfetto_src"]

--- a/steam-perfetto-sys/src/lib.rs
+++ b/steam-perfetto-sys/src/lib.rs
@@ -1,13 +1,8 @@
 // Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
-//! This crate is provided to wrap up the build of Perfetto.
+//! This crate is provided to wrap up the download of Perfetto.
 //!
 //! # Features
 //!
-//! By default this crate will not download or build Perfetto. The following
-//! features can be enabled to cause it to do so:
-//!
-//! - `_perfetto_src` - Download the Perfetto source code and symlink it into
-//!   the source tree of this crate.
-//! - `_perfetto_ui` - Build the Perfetto UI from the downloaded source (implies
-//!   `_perfetto_src`).
+//! Download the Perfetto source code and symlink it into the source tree of
+//! this crate.

--- a/steam-perfetto/Cargo.toml
+++ b/steam-perfetto/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "steam-perfetto"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -21,7 +21,4 @@ prost.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
-steam-perfetto-sys = { path = "../steam-perfetto-sys", features = ["_perfetto_src"] }
-
-[features]
-_perfetto-protoc = ["steam-perfetto-sys/_perfetto_ui"]
+steam-perfetto-sys = { path = "../steam-perfetto-sys" }

--- a/steam-perfetto/build.rs
+++ b/steam-perfetto/build.rs
@@ -3,38 +3,16 @@
 use std::fs;
 use std::path::Path;
 
-const STEAM_DOCS_ONLY_ENV_VAR: &str = "STEAM_DOCS_ONLY";
-const DOCS_RS_ENV_VAR: &str = "DOCS_RS";
-
 const PERFETTO_SRC_DIR: &str = "../steam-perfetto-sys/perfetto/";
 
-fn add_env_build_triggers() {
-    println!("cargo::rerun-if-env-changed={STEAM_DOCS_ONLY_ENV_VAR}");
-    println!("cargo::rerun-if-env-changed={DOCS_RS_ENV_VAR}");
-}
-
-fn compile_perfetto_schema() {
+fn main() {
     let perfetto_src = fs::canonicalize(Path::new(PERFETTO_SRC_DIR)).unwrap();
 
     let mut prost_build = prost_build::Config::new();
-    if std::env::var(STEAM_DOCS_ONLY_ENV_VAR).is_err() && std::env::var(DOCS_RS_ENV_VAR).is_err() {
-        // Only allow the use of the Protobuf compiler when a regular build is
-        // occuring. Perfetto will not be built during documentation-only
-        // builds, regardless of the features enabled.
-
-        #[cfg(feature = "_perfetto-protoc")]
-        prost_build.protoc_executable(perfetto_src.join("out/ui/protoc"));
-    }
     prost_build
         .compile_protos(
             &[perfetto_src.join("protos/perfetto/trace/trace.proto")],
             &[perfetto_src],
         )
         .expect("Protobuf compiler failed to generate Rust source for Perfetto support");
-}
-
-fn main() {
-    add_env_build_triggers();
-
-    compile_perfetto_schema();
 }


### PR DESCRIPTION
The steam-perfetto-sys package has been simplified to now only supply
the Perfetto source, but no longer to build the Perfetto UI. All
Cargo features have been removed, making the source download the default
behaviour.

The steam-perfetto package no longer supports using the version of the
Protobuf compiler built from source as part of the Perfetto UI build
process. All Cargo features have been removed, mandating the use of an
externally installed Protobuf compiler (already provided by the
.github/actions/install-build-dependencies/install.sh script).

The use of `STEAM_DOCS_ONLY` and `DOCS_RS` environment variables has
been removed, as the steam-perfetto-sys build script no longer has any
expensive operations to perform (which can be omitted during a
documentation build).

BREAKING CHANGE: removed the `_perfetto_src`, `_perfetto_ui`, and
`_perfetto_protoc` Cargo features.
