### PR TITLE
infra: reduce macOS GitHub-hosted runner usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,10 +23,7 @@ jobs:
       - uses: ./.github/actions/install-build-dependencies
 
   warm-dev-deps-cache:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: warm-build-deps-cache
 
     steps:
@@ -48,7 +45,7 @@ jobs:
         run: pre-commit run --all-files
 
   check-semantic-versioning:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [warm-build-deps-cache, warm-dev-deps-cache]
 
     steps:


### PR DESCRIPTION
The macOS runners are effectively charged at ~5x the Linux runners,
though very often appear to offer better runtime performance.

The check-semantic-versioning CI job is being switched to run on Linux
to reduce the risk of hitting usage limits again in future, which also
removes the need to run the `install-dev-dependencies` action on macOS
(and therefore also the `warm-dev-deps-cache` job).

The downside of this is that the install-dev-dependencies\install.sh
script will no longer be run on macOS by the CI system.
