### PR TITLE
Revert "chore: temporarily disable semver checks ahead of package renaming"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,15 +103,7 @@ repos:
         description: lint crate API changes for semver violations
         language: system
         types_or: [rust, toml]
-        entry:
-          cargo semver-checks --baseline-rev origin/main --exclude
-          tramway-components --exclude tramway-config --exclude
-          tramway-developer-guide --exclude tramway-doc-builder --exclude
-          tramway-docpp --exclude tramway-engine --exclude tramway-model-builder
-          --exclude tramway-models --exclude tramway-perfetto --exclude
-          tramway-perfetto-sys --exclude tramway-protocols --exclude
-          tramway-resources --exclude tramway-spotter --exclude tramway-terminus
-          --exclude tramway-track
+        entry: cargo semver-checks --baseline-rev origin/main
         pass_filenames: false
         stages: [manual]
       - id: cog-verify


### PR DESCRIPTION
This reverts commit 18e404d972e533b8d12875039ac4385cf6c23e12.
