### PR TITLE
fix(gwr-track)!: name PerfettoTraceBuilder API consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-track"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/gwr-spotter/src/perfetto.rs
+++ b/gwr-spotter/src/perfetto.rs
@@ -50,7 +50,7 @@ impl TraceVisitor for PerfettoGenerator {
                 )
         } else {
             self.trace_builder
-                .build_counter_track_descriptor_trace_packet(
+                .build_enter_exit_track_descriptor_trace_packet(
                     self.current_time_ns,
                     id,
                     created_by,
@@ -72,11 +72,10 @@ impl TraceVisitor for PerfettoGenerator {
     }
 
     fn enter(&mut self, id: Id, entered: Id) {
-        let trace_packet = self.trace_builder.build_counter_track_event_trace_packet(
+        let trace_packet = self.trace_builder.build_enter_track_event_trace_packet(
             self.current_time_ns,
             id,
             entered,
-            1,
         );
         let buf = self.trace_builder.build_trace_to_bytes(vec![trace_packet]);
         self.output
@@ -85,11 +84,10 @@ impl TraceVisitor for PerfettoGenerator {
     }
 
     fn exit(&mut self, id: Id, exited: Id) {
-        let trace_packet = self.trace_builder.build_counter_track_event_trace_packet(
+        let trace_packet = self.trace_builder.build_exit_track_event_trace_packet(
             self.current_time_ns,
             id,
             exited,
-            -1,
         );
         let buf = self.trace_builder.build_trace_to_bytes(vec![trace_packet]);
         self.output

--- a/gwr-track/Cargo.toml
+++ b/gwr-track/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-track"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-track/src/tracker/perfetto.rs
+++ b/gwr-track/src/tracker/perfetto.rs
@@ -49,24 +49,16 @@ impl Track for PerfettoTracker {
 
     fn enter(&self, id: Id, entered: Id) {
         let guard = self.trace_builder.borrow_mut();
-        let trace_packet = guard.build_counter_track_event_trace_packet(
-            *self.current_time_ns.borrow(),
-            id,
-            entered,
-            1,
-        );
+        let trace_packet =
+            guard.build_enter_track_event_trace_packet(*self.current_time_ns.borrow(), id, entered);
         let buf = guard.build_trace_to_bytes(vec![trace_packet]);
         self.writer.borrow_mut().write_all(&buf).unwrap();
     }
 
     fn exit(&self, id: Id, exited: Id) {
         let guard = self.trace_builder.borrow_mut();
-        let trace_packet = guard.build_counter_track_event_trace_packet(
-            *self.current_time_ns.borrow(),
-            id,
-            exited,
-            -1,
-        );
+        let trace_packet =
+            guard.build_exit_track_event_trace_packet(*self.current_time_ns.borrow(), id, exited);
         let buf = guard.build_trace_to_bytes(vec![trace_packet]);
         self.writer.borrow_mut().write_all(&buf).unwrap();
     }
@@ -89,7 +81,7 @@ impl Track for PerfettoTracker {
                 name,
             )
         } else {
-            guard.build_counter_track_descriptor_trace_packet(
+            guard.build_enter_exit_track_descriptor_trace_packet(
                 *self.current_time_ns.borrow(),
                 id,
                 created_by,

--- a/licenses.html
+++ b/licenses.html
@@ -7610,7 +7610,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.6.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-terminus 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.6.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.7.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 


### PR DESCRIPTION
The public functions of the PerfettoTraceBuilder are now all named to
correspond with events from the Track trait.

The private functions of the PerfettoTraceBuilder are now all named to
correspond with Perfetto Protocol Buffers schemas.
