### PR TITLE
docs: link to hosted logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <div align="center">
 
-![The Great Western Runtime](gwr-developer-guide/md_src/gwr.png)
+![The Great Western Runtime](https://raw.githubusercontent.com/graphcore-research/gwr/main/gwr-developer-guide/md_src/gwr.png)
 
 [Developer guide] | [API documentation]
 


### PR DESCRIPTION
To allow the README.md file to be rendered on crates.io image links must
be to hosted sources rather than paths within the repo.
