### PR TITLE
fix(gwr-perfetto-sys,gwr-perfetto): always dirty during incremental builds

### DIFF
--- a/gwr-perfetto-sys/.gitignore
+++ b/gwr-perfetto-sys/.gitignore
@@ -1,3 +1,0 @@
-# Copyright (c) 2024 Graphcore Ltd. All rights reserved.
-
-perfetto

--- a/gwr-perfetto-sys/build.rs
+++ b/gwr-perfetto-sys/build.rs
@@ -1,34 +1,12 @@
 // Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
-//! Perfetto's source will be downloaded and a symlink
-//! (see the PERFETTO_SYMLINK const) created in the source tree of this package
-//! to give users of this package constant paths to tools and schema.
-//!
-//! Ideally we would have Cargo watch the PERFETTO_SYMLINK itself such that it
-//! would be recreate if deleted so that downstream builds that depend on this
-//! package do not fail unexpectedly. Unfortunately this is not possible as
-//! there appears to be no way to prevent the (mtime) check performed by Cargo
-//! following the symlink. Instead, as a compromise, we explicitly watch the
-//! PERFETTO_SYMLINK/protos directory as this is not expected to change once the
-//! Perfetto source has been downloaded (i.e. mtime check will be stable after
-//! the first rebuild attempt), and it allows us to detect if the symlink is
-//! removed.
-
 use std::env;
 use std::process::Command;
 
 pub const PERFETTO_REPO_URL: &str = "https://github.com/google/perfetto";
 pub const PERFETTO_REPO_REFSPEC: &str = "v52.0";
 
-pub const PERFETTO_SYMLINK: &str = "perfetto";
-
-fn add_file_build_triggers() {
-    println!("cargo::rerun-if-changed=src/lib.rs");
-}
-
 fn main() {
-    add_file_build_triggers();
-
     let out_dir = env::var("OUT_DIR").unwrap();
 
     let output = Command::new("git")
@@ -67,20 +45,4 @@ fn main() {
         "Failed to checkout Perfetto source repo:\n{}",
         str::from_utf8(&output.stderr).unwrap_or_default()
     );
-
-    let output = Command::new("ln")
-        .arg("-s")
-        .arg("-f")
-        .arg("-n")
-        .arg(&out_dir)
-        .arg(PERFETTO_SYMLINK)
-        .output()
-        .expect("ln command failed to start");
-    assert!(
-        output.status.success(),
-        "Failed to create symlink to Perfetto source repo:\n{}",
-        str::from_utf8(&output.stderr).unwrap_or_default()
-    );
-
-    println!("cargo::rerun-if-changed={PERFETTO_SYMLINK}/protos");
 }

--- a/gwr-perfetto-sys/src/lib.rs
+++ b/gwr-perfetto-sys/src/lib.rs
@@ -1,8 +1,5 @@
 // Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
 //! This crate is provided to wrap up the download of Perfetto.
-//!
-//! # Features
-//!
-//! Download the Perfetto source code and symlink it into the source tree of
-//! this crate.
+
+pub const PERFETTO_SOURCE: &str = env!("OUT_DIR");

--- a/gwr-perfetto/build.rs
+++ b/gwr-perfetto/build.rs
@@ -3,10 +3,10 @@
 use std::fs;
 use std::path::Path;
 
-const PERFETTO_SRC_DIR: &str = "../gwr-perfetto-sys/perfetto/";
+use gwr_perfetto_sys::PERFETTO_SOURCE;
 
 fn main() {
-    let perfetto_src = fs::canonicalize(Path::new(PERFETTO_SRC_DIR)).unwrap();
+    let perfetto_src = fs::canonicalize(Path::new(PERFETTO_SOURCE)).unwrap();
 
     let mut prost_build = prost_build::Config::new();
     prost_build


### PR DESCRIPTION
Incremental builds were not working optimally for dependants of
gwr-perfetto-sys, resulting in slower incremental builds.

To resolve this issue, and to ensure that these packages will work as
intended when used from crates.io,the `gwr-perfetto-sys/perfetto` symlink
has been replaced with the `PERFETTO_SOURCE` const now published by the
gwr-perfetto-sys library.

Incremental builds now work as expected, however it is worth noting that
if files within the gwr-perfetto-sys or gwr-perfetto packages are
touched in between incremental builds they may continue to appear dirty
until the next clean when running `cargo check`.
