### PR TITLE
chore: update bytes dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capnp"

--- a/licenses.html
+++ b/licenses.html
@@ -7107,7 +7107,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 


### PR DESCRIPTION
Updating to the latest release of bytes resolves the undefined behaviour
risk identified in RUSTSEC-2026-0007.
See https://rustsec.org/advisories/RUSTSEC-2026-0007.
