### PR TITLE
infra: persist lychee cache in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lycheecache-${{ hashFiles('lychee.toml') }}
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/install-dev-dependencies
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -25,8 +25,12 @@ exclude = [
 
 # Cache the status returned when checking external links
 cache = true
+max_cache_age = "14d"
 # But only if the status is OK (200)
 cache_exclude_status = "..200,201.."
+
+# Allow a generous timout to avoid spurious failures when run under CI
+timeout = 300
 
 # Search for possible replacements when broken links are found
 suggest = true


### PR DESCRIPTION
As well as ensuring the cache file created by lychee persists between CI
runs, the timeout has also been increased to reduce the risk of spurious
failures.
