### PR TITLE
Fix Task leak in executor

### DIFF
--- a/gwr-engine/src/executor.rs
+++ b/gwr-engine/src/executor.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::future::Future;
+use std::mem;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
@@ -14,8 +15,14 @@ use crate::types::SimResult;
 
 fn no_op(_: *const ()) {}
 
+unsafe fn drop_task(data: *const ()) {
+    unsafe {
+        drop(Rc::from_raw(data as *const Task));
+    }
+}
+
 fn task_raw_waker(task: Rc<Task>) -> RawWaker {
-    let vtable = &RawWakerVTable::new(clone_raw_waker, wake_task, no_op, no_op);
+    let vtable = &RawWakerVTable::new(clone_raw_waker, wake_task, no_op, drop_task);
     let ptr = Rc::into_raw(task) as *const ();
     RawWaker::new(ptr, vtable)
 }
@@ -27,10 +34,12 @@ fn waker_for_task(task: Rc<Task>) -> Waker {
 unsafe fn clone_raw_waker(data: *const ()) -> RawWaker {
     unsafe {
         // Tasks are always wrapped in a reference counter to allow them to be shared
-        // read-only.
+        // read-only. The input `data` pointer is borrowed — we must not decrement its
+        // refcount, so we mem::forget the reconstructed Rc rather than letting it drop.
         let rc_task = Rc::from_raw(data as *const Task);
         let clone = rc_task.clone();
-        let vtable = &RawWakerVTable::new(clone_raw_waker, wake_task, no_op, no_op);
+        mem::forget(rc_task);
+        let vtable = &RawWakerVTable::new(clone_raw_waker, wake_task, no_op, drop_task);
         let ptr = Rc::into_raw(clone) as *const ();
         RawWaker::new(ptr, vtable)
     }

--- a/gwr-engine/src/executor.rs
+++ b/gwr-engine/src/executor.rs
@@ -21,10 +21,11 @@ unsafe fn drop_task(data: *const ()) {
     }
 }
 
+static VTABLE: RawWakerVTable = RawWakerVTable::new(clone_raw_waker, wake_task, no_op, drop_task);
+
 fn task_raw_waker(task: Rc<Task>) -> RawWaker {
-    let vtable = &RawWakerVTable::new(clone_raw_waker, wake_task, no_op, drop_task);
     let ptr = Rc::into_raw(task) as *const ();
-    RawWaker::new(ptr, vtable)
+    RawWaker::new(ptr, &VTABLE)
 }
 
 fn waker_for_task(task: Rc<Task>) -> Waker {
@@ -39,9 +40,8 @@ unsafe fn clone_raw_waker(data: *const ()) -> RawWaker {
         let rc_task = Rc::from_raw(data as *const Task);
         let clone = rc_task.clone();
         mem::forget(rc_task);
-        let vtable = &RawWakerVTable::new(clone_raw_waker, wake_task, no_op, drop_task);
         let ptr = Rc::into_raw(clone) as *const ();
-        RawWaker::new(ptr, vtable)
+        RawWaker::new(ptr, &VTABLE)
     }
 }
 


### PR DESCRIPTION
- **fix(gwr-engine): Task leak in executor**
> A drop_task function is now provided to ensure that the Task memory is not leaked when the Waker is dropped.
>
> Fixing the leak exposed a use-after-free scenario. This is addressed by using mem::forget to prevent the rc_task from being dropped as clone_raw_waker's contract says the data pointer is borrowed, the original waker must remain valid after the call.
>
> Previously the code did Rc::from_raw(data) (taking ownership) then let rc_task drop at end of scope, decrementing the original's refcount. Every pending future that calls cx.waker().clone() (i.e. every ClockDelay, OnceFuture, RepeatedFuture) would silently corrupt the reference count, leading to use-after-free once the refcount hit zero prematurely.
- **refactor(gwr-engine): optimise vtable allocation**

Note, this PR is stacked on:
-  #116.