### PR TITLE
feat(gwr-engine): use mimalloc as the global allocator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: ./.github/actions/install-dev-dependencies
 
       - name: Lint with pre-commit
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure
 
   check-semantic-versioning:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,10 @@ jobs:
       - uses: ./.github/actions/install-build-dependencies
 
   warm-dev-deps-cache:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     needs: warm-build-deps-cache
 
     steps:
@@ -31,7 +34,7 @@ jobs:
       - uses: ./.github/actions/install-dev-dependencies
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: [warm-build-deps-cache, warm-dev-deps-cache]
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,7 @@ dependencies = [
  "gwr-components",
  "gwr-track",
  "log",
+ "mimalloc",
 ]
 
 [[package]]
@@ -1781,6 +1782,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -25,11 +25,13 @@ clap.workspace = true
 futures.workspace = true
 gwr-track = { path = "../gwr-track", version = "0.7.0" }
 log.workspace = true
+mimalloc = { version = "0.1.48", features = ["v3"], optional = true }
 
 [dev-dependencies]
 arc-swap = "1.6.0"
 gwr-components = { path = "../gwr-components", version = "0.7.0" }
 
 [features]
-default = []
+default = ["global_allocator"]
+global_allocator = ["dep:mimalloc"]
 phase = []

--- a/gwr-engine/src/global_allocator.rs
+++ b/gwr-engine/src/global_allocator.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;

--- a/gwr-engine/src/lib.rs
+++ b/gwr-engine/src/lib.rs
@@ -12,6 +12,16 @@
 //! executes event driven asynchronous simulation
 //! [components].
 //!
+//! # Features
+//!
+//! - `global_allocator`: When enabled this feature causes applications
+//!   dependendant on `gwr-engine` to use a global allocator selected to
+//!   deliver optimal runtime performace of the GWR engine. Currently this is
+//!   the [mimalloc](https://github.com/microsoft/mimalloc) allocator.
+//!
+//!   This feature is enabled by default. Should an application wish to use a
+//!   alternative global allocator the feature must be explicitly disabled.
+//!
 //! # Developer Guide
 //!
 //! The Developer Guide provides a document that goes through the GWR engine
@@ -76,6 +86,8 @@
 pub mod engine;
 pub mod events;
 pub mod executor;
+#[cfg(feature = "global_allocator")]
+mod global_allocator;
 pub mod port;
 pub mod test_helpers;
 pub mod time;

--- a/licenses.html
+++ b/licenses.html
@@ -45,7 +45,7 @@
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             <li><a href="#Apache-2.0">Apache License 2.0</a> (253)</li>
-            <li><a href="#MIT">MIT License</a> (104)</li>
+            <li><a href="#MIT">MIT License</a> (106)</li>
             <li><a href="#Zlib">zlib License</a> (2)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
@@ -7863,6 +7863,38 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/purpleprotocol/mimalloc_rust ">mimalloc 0.1.48</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2019 Octavian Oncescu
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.16.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -7956,6 +7988,35 @@ SOFTWARE.
                 <pre class="license-text">MIT License
 
 Copyright (c) 2018-2020 Naim A.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/purpleprotocol/mimalloc_rust/tree/master/libmimalloc-sys ">libmimalloc-sys 0.1.44</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2018-2025 Microsoft Corporation, Daan Leijen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal


### PR DESCRIPTION
The use of mimalloc v3 is gated by the `global_allocator` feature,
though this is enabled by default.

The performance improvements provided by this change seen in the
benchmarks are as follows:
```
 cargo bench --bench wall_clock_benchmarks -- --load-baseline wallclock_bench_baseline-mimalloc_v3 --baseline wallclock_bench_baseline
    Finished `bench` profile [optimized] target(s) in 0.13s
     Running benches/wall_clock_benchmarks.rs (target/release/deps/wall_clock_benchmarks-d85dea226e5ce77f)
blocks/source_store_sink
                        time:   [15.719 µs 15.757 µs 15.790 µs]
                        change: [+0.3214% +0.5801% +0.8374%] (p = 0.00 < 0.03)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) low mild
blocks/source_delay_sink
                        time:   [19.544 µs 19.627 µs 19.774 µs]
                        change: [−4.7827% −4.0312% −2.8497%] (p = 0.00 < 0.03)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
blocks/arbiter_fixedpriority_policy
                        time:   [1.2772 ms 1.2800 ms 1.2843 ms]
                        change: [−6.5126% −6.2627% −6.0137%] (p = 0.00 < 0.03)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe

blocks/larger_simulation
                        time:   [19.569 ms 19.708 ms 19.996 ms]
                        change: [−12.709% −12.023% −10.369%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

     Running benches/wall_clock_benchmarks.rs (target/release/deps/wall_clock_benchmarks-6119018ce6ecb88c)
ethernet_frame/vec_of_frame
                        time:   [52.147 µs 52.192 µs 52.237 µs]
                        change: [−1.5958% −1.4606% −1.3301%] (p = 0.00 < 0.05)
                        Change within noise threshold.
ethernet_frame/vec_of_box
                        time:   [39.520 µs 39.583 µs 39.652 µs]
                        change: [−5.9681% −5.7364% −5.5093%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```

The performance of mimalloc v2 was also measured, as this is the current
main version, though close on balance it did not appear to privide the
bigger improvement overall:
```
cargo bench --bench wall_clock_benchmarks -- --load-baseline wallclock_bench_baseline-mimalloc_v2 --baseline wallclock_bench_baseline
    Finished `bench` profile [optimized] target(s) in 0.13s
     Running benches/wall_clock_benchmarks.rs (target/release/deps/wall_clock_benchmarks-d85dea226e5ce77f)
blocks/source_store_sink
                        time:   [15.843 µs 15.898 µs 15.949 µs]
                        change: [+0.8196% +1.1367% +1.4638%] (p = 0.00 < 0.03)
                        Change within noise threshold.
blocks/source_delay_sink
                        time:   [19.752 µs 19.806 µs 19.861 µs]
                        change: [−3.8961% −3.5772% −3.2758%] (p = 0.00 < 0.03)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
blocks/arbiter_fixedpriority_policy
                        time:   [1.3320 ms 1.3341 ms 1.3365 ms]
                        change: [−2.4627% −2.1488% −1.8110%] (p = 0.00 < 0.03)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

blocks/larger_simulation
                        time:   [20.610 ms 20.806 ms 21.011 ms]
                        change: [−8.0581% −7.1222% −6.3151%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running benches/wall_clock_benchmarks.rs (target/release/deps/wall_clock_benchmarks-6119018ce6ecb88c)
ethernet_frame/vec_of_frame
                        time:   [52.866 µs 52.917 µs 52.968 µs]
                        change: [−0.1895% −0.0452% +0.0979%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
ethernet_frame/vec_of_box
                        time:   [38.709 µs 38.764 µs 38.829 µs]
                        change: [−7.9272% −7.7036% −7.4736%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
```
