### PR TITLE
chore: upgrade to the latest GitHub Actions versions

### DIFF
--- a/.github/actions/install-build-dependencies/action.yaml
+++ b/.github/actions/install-build-dependencies/action.yaml
@@ -6,7 +6,7 @@ description: Install all dependencies required to build the repo source
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/.crates.toml

--- a/.github/actions/install-dev-dependencies/action.yaml
+++ b/.github/actions/install-dev-dependencies/action.yaml
@@ -6,8 +6,8 @@ description: Install all dependencies required when developing the repo source
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
-    - uses: actions/cache@v4
+    - uses: actions/setup-node@v6
+    - uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/.crates.toml

--- a/.github/actions/run-build-command/action.yaml
+++ b/.github/actions/run-build-command/action.yaml
@@ -31,7 +31,7 @@ runs:
 
     - name: Restore cached build files
       id: restore-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.paths }}
         key: ${{ steps.get-cache-key.outputs.key }}
@@ -44,7 +44,7 @@ runs:
     - name: Save build files to cache
       id: save-cache
       if: github.ref == 'refs/heads/main'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ inputs.paths }}
         key: ${{ steps.get-cache-key.outputs.key }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-build-dependencies
 
   warm-dev-deps-cache:
@@ -27,7 +27,7 @@ jobs:
     needs: warm-build-deps-cache
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-dev-dependencies
 
   lint:
@@ -37,8 +37,8 @@ jobs:
       RUSTFLAGS: -D warnings
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: .lycheecache
           key: lycheecache-${{ hashFiles('lychee.toml') }}
@@ -53,7 +53,7 @@ jobs:
     needs: [warm-build-deps-cache, warm-dev-deps-cache]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required to cause the main branch to also be fetched
       - uses: ./.github/actions/install-build-dependencies
@@ -76,7 +76,7 @@ jobs:
       RUSTFLAGS: -D warnings
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/run-build-command
         with:
@@ -94,7 +94,7 @@ jobs:
       RUSTFLAGS: -D warnings
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/run-build-command
         with:
@@ -116,7 +116,7 @@ jobs:
       RUSTFLAGS: -D warnings
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/run-build-command
         with:

--- a/.github/workflows/online-documentation.yaml
+++ b/.github/workflows/online-documentation.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-build-dependencies
 
       - name: Setup Pages


### PR DESCRIPTION
Due to the deprecation of Node 20 on GitHub Actions runners many actions
have been updated to use Node 24.

This change should resolve the following warnings emitted during each
CI run:

Node.js 20 actions are deprecated. The following actions are running on
Node.js 20 and may not work as expected: actions/cache@v4,
actions/checkout@v4, actions/setup-node@v4. Actions will be forced to
run with Node.js 24 by default starting June 2nd, 2026. Please check if
updated versions of these actions are available that support Node.js 24.
To opt into Node.js 24 now, set the
FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the
runner or in your workflow file. Once Node.js 24 becomes the default,
you can temporarily opt out by setting
ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
