### PR TITLE
infra: use main branch results as benchmark baseline on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,28 @@ jobs:
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/run-build-command
         with:
-          command: |
-            cargo bench --all-features --verbose --no-run
-            cargo bench --all-features --verbose --bench one_shot_benchmarks
+          command: cargo bench --all-features --verbose --no-run
+          cache-name: ${{ github.job }}
+      - uses: actions/download-artifact@v8
+
+      - name: Run benchmarks and save results
+        id: run-benchmarks-save-results
+        if: github.ref == 'refs/heads/main'
+        uses: ./.github/actions/run-build-command
+        with:
+          command: cargo bench --all-features --verbose --bench one_shot_benchmarks -- --save-baseline=main
+          cache-name: ${{ github.job }}
+      - if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: one-shot-benchmark-baselines
+          path: target/gungraun/
+          overwrite: true
+
+      - name: Run benchmarks
+        id: run-benchmarks
+        if: github.ref != 'refs/heads/main'
+        uses: ./.github/actions/run-build-command
+        with:
+          command: cargo bench --all-features --verbose --bench one_shot_benchmarks -- --baseline=main
           cache-name: ${{ github.job }}


### PR DESCRIPTION
The one-shot benchmark results will be saved as a workflow artifact
when CI runs for the main branch.

The saved results, when avaliable, will be used as the baseline for
comparison when the one-shot benchmarks are subsequently run on any
branch.
