### PR TITLE
Fix CI benchmark baselines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
       BASELINE_BRANCH_NAME: main
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v4
@@ -123,7 +124,27 @@ jobs:
         with:
           command: cargo bench --all-features --verbose --no-run
           cache-name: ${{ github.job }}
+
+      - name: Get ID of latest successful benchmark run on baseline branch
+        id: get-latest-successful-benchmark-run
+        run: |
+          id="$(
+            gh run list \
+              --workflow ${{ github.workflow }} \
+              --branch ${{ env.BASELINE_BRANCH_NAME }} \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId'
+          )"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v8
+        with:
+          name: one-shot-benchmark-baselines
+          path: target/gungraun/
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.get-latest-successful-benchmark-run.outputs.id }}
 
       - name: Run benchmarks and save results
         id: run-benchmarks-save-results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,7 @@ jobs:
     needs: warm-build-deps-cache
     env:
       RUSTFLAGS: -D warnings
+      BASELINE_BRANCH_NAME: main
 
     steps:
       - uses: actions/checkout@v4
@@ -126,12 +127,12 @@ jobs:
 
       - name: Run benchmarks and save results
         id: run-benchmarks-save-results
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == format('refs/heads/{0}', env.BASELINE_BRANCH_NAME)
         uses: ./.github/actions/run-build-command
         with:
-          command: cargo bench --all-features --verbose --bench one_shot_benchmarks -- --save-baseline=main
+          command: cargo bench --all-features --verbose --bench one_shot_benchmarks -- --save-baseline=$BASELINE_BRANCH_NAME
           cache-name: ${{ github.job }}
-      - if: github.ref == 'refs/heads/main'
+      - if: github.ref == format('refs/heads/{0}', env.BASELINE_BRANCH_NAME)
         uses: actions/upload-artifact@v7
         with:
           name: one-shot-benchmark-baselines
@@ -140,8 +141,8 @@ jobs:
 
       - name: Run benchmarks
         id: run-benchmarks
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != format('refs/heads/{0}', env.BASELINE_BRANCH_NAME)
         uses: ./.github/actions/run-build-command
         with:
-          command: cargo bench --all-features --verbose --bench one_shot_benchmarks -- --baseline=main
+          command: cargo bench --all-features --verbose --bench one_shot_benchmarks -- --baseline=$BASELINE_BRANCH_NAME
           cache-name: ${{ github.job }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-build-dependencies
-      - uses: ./.github/actions/run-build-command
+
+      - name: Build all benchmarks
+        id: build-all-benchmarks
+        uses: ./.github/actions/run-build-command
         with:
           command: cargo bench --all-features --verbose --no-run
           cache-name: ${{ github.job }}
@@ -139,28 +142,33 @@ jobs:
           )"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v8
+      - name: Download baseline benchmark results
+        id: download-baseline-benchmark-results
+        uses: actions/download-artifact@v8
         with:
           name: one-shot-benchmark-baselines
           path: target/gungraun/
           github-token: ${{ github.token }}
           run-id: ${{ steps.get-latest-successful-benchmark-run.outputs.id }}
 
-      - name: Run benchmarks and save results
+      - name: Run one-shot benchmarks and update baseline results
         id: run-benchmarks-save-results
         if: github.ref == format('refs/heads/{0}', env.BASELINE_BRANCH_NAME)
         uses: ./.github/actions/run-build-command
         with:
           command: cargo bench --all-features --verbose --bench one_shot_benchmarks -- --save-baseline=$BASELINE_BRANCH_NAME
           cache-name: ${{ github.job }}
-      - if: github.ref == format('refs/heads/{0}', env.BASELINE_BRANCH_NAME)
+
+      - name: Upload baseline benchmark results
+        id: upload-baseline-benchmark-results
+        if: github.ref == format('refs/heads/{0}', env.BASELINE_BRANCH_NAME)
         uses: actions/upload-artifact@v7
         with:
           name: one-shot-benchmark-baselines
           path: target/gungraun/
           overwrite: true
 
-      - name: Run benchmarks
+      - name: Run one-shot benchmarks
         id: run-benchmarks
         if: github.ref != format('refs/heads/{0}', env.BASELINE_BRANCH_NAME)
         uses: ./.github/actions/run-build-command


### PR DESCRIPTION
- **chore: use constant to keep benchmark baseline branch name DRY**
- **chore: explicitly download benchmark baseline from latest successful run**
- **chore: add names to steps of benchmark job**
