### PR TITLE
fix(gwr-perfetto-sys): use of git submodule during cargo-semver-checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,9 @@ repos:
         description: lint crate API changes for semver violations
         language: system
         types_or: [rust, toml]
-        entry: cargo semver-checks --baseline-rev origin/main
+        entry:
+          env CARGO_SEMVER_CHECKS=1 cargo semver-checks --baseline-rev
+          origin/main
         pass_filenames: false
         stages: [manual]
       - id: cog-verify

--- a/gwr-perfetto-sys/README.md
+++ b/gwr-perfetto-sys/README.md
@@ -3,7 +3,7 @@
 # gwr-perfetto-sys
 
 The `gwr-perfetto-sys` package provides Cargo access to the [Perfetto] source
-code, which will be download using [`git`].
+code, via the use of a [`git`] submodule.
 
 [Perfetto]: https://perfetto.dev
 [`git`]: https://git-scm.com

--- a/gwr-perfetto-sys/build.rs
+++ b/gwr-perfetto-sys/build.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::fs;
+use std::process::Command;
+
+#[path = "src/submodule_path.rs"]
+mod submodule_path;
+
+const SEMVER_ENV_VAR_KEY: &str = "CARGO_SEMVER_CHECKS";
+
+fn main() {
+    println!(
+        "cargo::rerun-if-changed={}",
+        submodule_path::PERFETTO_SOURCE
+    );
+
+    if cargo_semver_checks_enabled() && !submodule_is_updated() {
+        update_submodule();
+    }
+
+    assert!(
+        submodule_is_updated(),
+        "{}",
+        &format!(
+            "Perfetto source submodule does not appear to have been checked out.
+    Please run `git {}`.",
+            get_git_args().join(" ")
+        )
+    );
+}
+
+fn cargo_semver_checks_enabled() -> bool {
+    let cargo_semver_checks = std::env::var(SEMVER_ENV_VAR_KEY)
+        .unwrap_or_default()
+        .parse()
+        .unwrap_or(0);
+
+    cargo_semver_checks == 1
+}
+
+fn submodule_is_updated() -> bool {
+    let mut directory_entries = fs::read_dir(submodule_path::PERFETTO_SOURCE).expect(
+        "The Perfetto source
+    directory is expected to exist whether or not the submodule has been
+    initialised and updated.",
+    );
+
+    directory_entries.next().is_some()
+}
+
+fn update_submodule() {
+    let git_command = Command::new("git")
+        .args(get_git_args())
+        .status()
+        .unwrap_or_else(|_| {
+            panic!("git should be available on the PATH when {SEMVER_ENV_VAR_KEY} is set.")
+        });
+    assert!(git_command.success(), "{}", git_command.to_string());
+}
+
+fn get_git_args() -> [&'static str; 4] {
+    [
+        "submodule",
+        "update",
+        "--init",
+        submodule_path::PERFETTO_SOURCE,
+    ]
+}

--- a/gwr-perfetto-sys/src/lib.rs
+++ b/gwr-perfetto-sys/src/lib.rs
@@ -2,4 +2,6 @@
 
 //! This crate is provided to wrap up the download of Perfetto.
 
-pub const PERFETTO_SOURCE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/perfetto_src");
+mod submodule_path;
+
+pub use submodule_path::PERFETTO_SOURCE;

--- a/gwr-perfetto-sys/src/submodule_path.rs
+++ b/gwr-perfetto-sys/src/submodule_path.rs
@@ -1,0 +1,3 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+pub const PERFETTO_SOURCE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/perfetto_src");


### PR DESCRIPTION
During execution cargo-semver-checks clones and checks out the repo, but
does not initialise or update git submodules. This has caused the semver
checks to start failing since the change made in
c5e359080886142c068de4f653d61dc27b13ffb2 was merged
into main.

The cargo-semver-checks issue is tracked in
https://github.com/obi1kenobi/cargo-semver-checks/issues/927.
