### PR TITLE
fix: Ensure the execution order of Timetables is deterministic

### DIFF
--- a/gwr-terminus/src/recipe/mod.rs
+++ b/gwr-terminus/src/recipe/mod.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -132,7 +132,7 @@ impl Recipe {
         let (arg_re_bracket, arg_re_no_bracket) = build_regexs();
 
         // Track unique names of all arguments found in the commands
-        let mut arg_names = HashSet::new();
+        let mut arg_names = BTreeSet::new();
 
         for command in commands {
             if command.selected() {
@@ -394,7 +394,7 @@ pub fn run_command_as_interactive(
 /// Parse a command and add the variables found in the command as an argument
 fn find_arguments(
     command: &Command,
-    arg_names: &mut HashSet<String>,
+    arg_names: &mut BTreeSet<String>,
     arg_re_bracket: &Regex,
     arg_re_no_bracket: &Regex,
 ) {

--- a/gwr-timetable/src/lib.rs
+++ b/gwr-timetable/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Graphcore Ltd. All rights reserved.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
 use async_trait::async_trait;
@@ -29,8 +29,10 @@ pub struct Timetable {
     node_idx_by_id: HashMap<String, usize>,
     completed_node_indices: RefCell<HashSet<usize>>,
     active_node_indices: RefCell<HashSet<usize>>,
-    nodes_per_pe: RefCell<HashMap<usize, HashSet<usize>>>,
-    edges_to_node: RefCell<HashMap<usize, HashSet<usize>>>,
+    // Use BTreeSet for the cases where we iterate over the set as they have
+    // deterministic iteration order.
+    nodes_per_pe: RefCell<HashMap<usize, BTreeSet<usize>>>,
+    edges_to_node: RefCell<HashMap<usize, BTreeSet<usize>>>,
     ready_nodes_changed: Repeated<()>,
 }
 
@@ -54,7 +56,7 @@ impl Timetable {
                 let pe_idx = platform.pe_idx_from_name(pe_id)?;
                 nodes_per_pe
                     .entry(pe_idx)
-                    .or_insert_with(HashSet::new)
+                    .or_insert_with(BTreeSet::new)
                     .insert(i);
             }
         }
@@ -64,7 +66,7 @@ impl Timetable {
             let to_node_idx = node_idx_by_id.get(&edge.to).unwrap();
             edges_to_node
                 .entry(*to_node_idx)
-                .or_insert_with(HashSet::new)
+                .or_insert_with(BTreeSet::new)
                 .insert(i);
         }
 


### PR DESCRIPTION
The `HashSet` is defined to have non-deterministic iteration order. Replacing with `BTreeSet` where we iterate in order to ensure repeatable execution to aid debug.