### PR TITLE
infra: update pull request branch naming convention

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ name: CI
 on:
   push:
     branches-ignore:
-      - "pr/**"
+      - "pr-**"
   pull_request:
 
 env:

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ may be opened, and doing so will cause the CI workflows to be run on every
 commit.
 
 For short lived branches pushed only at the point of opening a pull request the
-branch naming prefix `pr/` should be used, for example, `pr/new-example-app`.
+branch naming prefix `pr-` should be used, for example, `pr-new-example-app`.
 Branches named with this prefix will still cause the pull request specific CI
 workflow to run, but will avoid the push specific CI workflow from running until
 the point they are merged.


### PR DESCRIPTION
To better support the use of git worktrees the pull request branch
naming convention has be changed to ensure that branch names do not
contain forward slashes as these are interpreted as directory separators
when using git-worktree.

Whereas previously to create a worktree for a new pull request would
have required the branch name and the worktree directory to have been
specified seperately:
```
git worktree add -b pr/foo ../foo
```
This resulted in a difference between the branch and directory names.

The same can now be achieved with just:
```
git worktree add ../pr-foo
```
and the directory and branch names will now match.
