### PR TITLE
infra: remove caching of cargo-semver-checks results under CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,12 +64,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/install-dev-dependencies
-      - uses: ./.github/actions/run-build-command
-        with:
-          command: pre-commit run --hook-stage manual --all-files cargo-semver-checks
-          cache-name: semver
-          paths: |
-            target/semver-checks/
+      - run: pre-commit run --hook-stage manual --all-files cargo-semver-checks
 
   build:
     strategy:


### PR DESCRIPTION
Currently the GitHub Action runner runs out of disk space whist
unpacking the cached results.
