### PR TITLE
refactor: place doc comment above attribute

### DIFF
--- a/gwr-components/src/connect.rs
+++ b/gwr-components/src/connect.rs
@@ -4,9 +4,9 @@
 
 pub use paste::paste;
 
-#[macro_export]
 /// Connect an [OutPort](gwr_engine::port::OutPort) port to an
 /// [InPort](gwr_engine::port::InPort)
+#[macro_export]
 macro_rules! connect_port {
     ($from:expr, $from_port_name:ident => $to:expr, $to_port_name:ident) => {
         {
@@ -46,8 +46,8 @@ macro_rules! connect_port {
     };
 }
 
-#[macro_export]
 /// Create and connect a dummy RX port
+#[macro_export]
 macro_rules! connect_dummy_rx {
     ($from:expr, $from_port_name:ident => $engine:expr, $clock:expr, $entity:expr) => {
         {
@@ -74,8 +74,8 @@ macro_rules! connect_dummy_rx {
     };
 }
 
-#[macro_export]
 /// Create and connect a dummy TX port
+#[macro_export]
 macro_rules! connect_dummy_tx {
     ($entity:expr => $to:expr, $to_port_name:ident) => {
         {
@@ -100,10 +100,10 @@ macro_rules! connect_dummy_tx {
     };
 }
 
-#[macro_export]
 /// Connect a tx port for a subcomponent.
 ///
 /// The subcomponent is expected to be stored in a `RefCell<Option<>>`
+#[macro_export]
 macro_rules! connect_tx {
     ($component:expr, $fn:ident ; $port_state:ident) => {
         $crate::connect::paste! {
@@ -116,10 +116,10 @@ macro_rules! connect_tx {
     };
 }
 
-#[macro_export]
 /// Connect a tx port for a subcomponent where the port is one of an array.
 ///
 /// The subcomponent is expected to be stored in a `RefCell<Option<>>`
+#[macro_export]
 macro_rules! connect_tx_i {
     ($component:expr, $fn:ident, $index:expr ; $port_state:ident) => {
         $component
@@ -130,44 +130,44 @@ macro_rules! connect_tx_i {
     };
 }
 
-#[macro_export]
 /// Access rx port for a subcomponent.
 ///
 /// The subcomponent is expected to be stored in a `RefCell<Option<>>`
+#[macro_export]
 macro_rules! port_rx {
     ($component:expr, $fn:ident) => {
         $component.borrow().as_ref().unwrap().$fn()
     };
 }
 
-#[macro_export]
 /// Access an individual index of an rx port array for a subcomponent.
 ///
 /// The subcomponent is expected to be stored in a `RefCell<Option<>>`
+#[macro_export]
 macro_rules! port_rx_i {
     ($component:expr, $fn:ident, $index:expr) => {
         $component.borrow().as_ref().unwrap().$fn($index)
     };
 }
 
-#[macro_export]
 /// Get a reference to a variable stored in a `RefCell<Option<>>`.
+#[macro_export]
 macro_rules! borrow_option {
     ($var:expr) => {
         $var.borrow().as_ref().unwrap()
     };
 }
 
-#[macro_export]
 /// Get a mutable reference to a variable stored in a `RefCell<Option<>>`.
+#[macro_export]
 macro_rules! borrow_option_mut {
     ($var:expr) => {
         $var.borrow_mut().as_mut().unwrap()
     };
 }
 
-#[macro_export]
 /// Take a variable out of a `RefCell<Option<>>`.
+#[macro_export]
 macro_rules! take_option {
     ($var:expr) => {
         $var.borrow_mut().take().unwrap()

--- a/gwr-doc-builder/src/asciidoctor_pp.rs
+++ b/gwr-doc-builder/src/asciidoctor_pp.rs
@@ -92,11 +92,11 @@ impl AsciiDoctorPreProcessor {
         line
     }
 
-    #[allow(rustdoc::broken_intra_doc_links)]
     /// Process the markdown links and replace them with AsciiDoctor ones.
     ///
     /// Markdown links should be of the form: [`Visible Text`](link)
     /// Which are replace with adoc versions: <<link, Visible Text>>
+    #[allow(rustdoc::broken_intra_doc_links)]
     fn process_links(&self, line: &str) -> String {
         let mut line = line.to_owned();
         while let Some(e) = self.link_re.captures(&line) {

--- a/gwr-engine/src/lib.rs
+++ b/gwr-engine/src/lib.rs
@@ -94,8 +94,8 @@ pub mod time;
 pub mod traits;
 pub mod types;
 
-#[macro_export]
 /// Spawn all component run() functions and then run the simulation.
+#[macro_export]
 macro_rules! run_simulation {
     ($engine:ident) => {
         $engine.run().unwrap();
@@ -108,11 +108,11 @@ macro_rules! run_simulation {
     };
 }
 
-#[macro_export]
 /// Spawn a sub-component that is stored in an `RefCell<Option<>>`
 ///
 /// This removes the sub-component from the Option and then spawns the `run()`
 /// function.
+#[macro_export]
 macro_rules! spawn_subcomponent {
     ($($spawner:ident).+ ; $($block:ident).+) => {
         let sub_block = $($block).+.borrow_mut().take().unwrap();

--- a/gwr-engine/src/time/clock.rs
+++ b/gwr-engine/src/time/clock.rs
@@ -19,8 +19,8 @@ pub struct ClockTick {
     /// Clock ticks.
     tick: u64,
 
-    #[cfg(feature = "phase")]
     /// Clock phase.
+    #[cfg(feature = "phase")]
     phase: u32,
 }
 
@@ -102,8 +102,8 @@ impl std::fmt::Display for ClockTick {
     }
 }
 
-#[derive(Clone)]
 /// State representing a clock.
+#[derive(Clone)]
 pub struct Clock {
     /// Frequency of the clock in MHz.
     /// *Note*: Should never be changed as it is registered at this frequency.

--- a/gwr-engine/src/types.rs
+++ b/gwr-engine/src/types.rs
@@ -19,8 +19,8 @@ pub type Component = Rc<dyn Runnable + 'static>;
 
 // Simulation errors
 
-#[macro_export]
 /// Build a [SimError] from a message that supports `to_string`
+#[macro_export]
 macro_rules! sim_error {
     ($($arg:tt)+) => {
         Err($crate::types::SimError(format!($($arg)+).to_string()))

--- a/gwr-models/src/fabric/mod.rs
+++ b/gwr-models/src/fabric/mod.rs
@@ -89,9 +89,9 @@ fn num_x_y_ports(num_columns: usize, num_rows: usize, col: usize, row: usize) ->
     num_ports
 }
 
-#[must_use]
 /// Given a col/row position of a node in a fabric, compute how many
 /// ingress/egress ports there are
+#[must_use]
 fn node_num_ingress_egress_ports(
     num_columns: usize,
     num_rows: usize,

--- a/gwr-models/src/fabric/node.rs
+++ b/gwr-models/src/fabric/node.rs
@@ -109,8 +109,8 @@ use crate::fabric::FabricConfig;
 #[derive(ValueEnum, Clone, Copy, Default, Debug, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum FabricRoutingAlgorithm {
-    #[default]
     /// Route packets to the right column first
+    #[default]
     ColumnFirst,
 
     /// Route packets to the right row first

--- a/gwr-models/src/processing_element/operators/dtype.rs
+++ b/gwr-models/src/processing_element/operators/dtype.rs
@@ -19,8 +19,8 @@ pub enum DataType {
 }
 
 impl DataType {
-    #[must_use]
     /// Return the number of bits required
+    #[must_use]
     pub fn num_bits(&self) -> usize {
         match self {
             DataType::Fp32 => 32,

--- a/gwr-models/src/registers/register.rs
+++ b/gwr-models/src/registers/register.rs
@@ -91,14 +91,14 @@ macro_rules! build_register_view {
                 }
             }
 
-            #[allow(dead_code)]
             /// Install a callback function to be called whenever a `write` completes
+            #[allow(dead_code)]
             pub fn install_write_cb(&mut self, cb: $crate::registers::register::WrittenCallback) {
                 self.write_callbacks.push(cb);
             }
 
-            #[allow(dead_code)]
             /// Install a callback function to be called whenever a `read` completes
+            #[allow(dead_code)]
             pub fn install_read_cb(&mut self, cb: $crate::registers::register::ReadCallback) {
                 self.read_callbacks.push(cb);
             }

--- a/gwr-models/src/registers/state.rs
+++ b/gwr-models/src/registers/state.rs
@@ -170,11 +170,11 @@ macro_rules! build_register_state {
     }}
 }
 
-#[macro_export]
 /// Allow the creation of compile-time arrays of state up to 8 elements long
 /// without needing the `Copy` trait to be implemented.
 ///
 /// Derived from: <https://danielkeep.github.io/tlborm/book/pat-push-down-accumulation.html>
+#[macro_export]
 macro_rules! array {
     (@accum (0, $($_es:expr),*) -> ($($body:tt)*))
         => {$crate::array!(@as_expr [$($body)*])};

--- a/gwr-models/tests/cache.rs
+++ b/gwr-models/tests/cache.rs
@@ -113,8 +113,8 @@ fn cache_dev_read_goes_to_mem() {
     assert_eq!(cache.payload_bytes_written(), 0);
 }
 
-#[expect(clippy::type_complexity)]
 /// Helper to build a cache and four ports to drive it.
+#[expect(clippy::type_complexity)]
 fn build_cache_and_all_ports() -> (
     Engine,
     Rc<Cache<MemoryAccess>>,

--- a/gwr-models/tests/traffic_gen_random.rs
+++ b/gwr-models/tests/traffic_gen_random.rs
@@ -26,8 +26,8 @@ const DELAY_TICKS: usize = 20;
 
 const OVERHEAD_SIZE_BYTES: usize = 16;
 
-#[expect(clippy::type_complexity)]
 /// Helper to build a cache and the device-side ports to drive it.
+#[expect(clippy::type_complexity)]
 fn build_system(
     seed: u64,
     base_addr: u64,

--- a/gwr-models/tests/traffic_gen_strided.rs
+++ b/gwr-models/tests/traffic_gen_strided.rs
@@ -27,8 +27,8 @@ const DELAY_TICKS: usize = 20;
 
 const OVERHEAD_SIZE_BYTES: usize = 16;
 
-#[expect(clippy::type_complexity)]
 /// Helper to build a cache and the device-side ports to drive it.
+#[expect(clippy::type_complexity)]
 fn build_system(
     base_addr: u64,
     stride_bytes: u64,

--- a/gwr-protocols/src/packet.rs
+++ b/gwr-protocols/src/packet.rs
@@ -6,11 +6,11 @@
 
 pub use paste::paste;
 
-#[macro_export]
 /// Macro helper for building packet types.
 ///
 /// This macro builds the common components in a packet as well as adding all
 /// the packet-specific fields.
+#[macro_export]
 macro_rules! build_packet_type {
     ($protocol:ident, $packet_type:ident, $types:ident, $pkt_type:ident; $($field:ident : $type:ty, $bits:expr, $scale:expr),+ $(,)*) => {
         $crate::packet::paste! {

--- a/gwr-spotter/src/lib.rs
+++ b/gwr-spotter/src/lib.rs
@@ -22,6 +22,6 @@ pub mod handler;
 
 pub mod rocket;
 
-#[cfg(feature = "perfetto")]
 /// Perfetto output generator.
+#[cfg(feature = "perfetto")]
 pub mod perfetto;

--- a/gwr-spotter/src/main.rs
+++ b/gwr-spotter/src/main.rs
@@ -37,10 +37,10 @@ struct Cli {
     #[command(flatten)]
     input: InputOptions,
 
-    #[cfg(feature = "perfetto")]
     /// Generate Perfetto output from GWR binary trace with this name
     ///
     /// gwr-spotter will exit having produced the Perfetto trace.
+    #[cfg(feature = "perfetto")]
     #[arg(long, requires = "perfetto_compat")]
     perfetto: Option<PathBuf>,
 }

--- a/gwr-terminus/src/bin/terminus.rs
+++ b/gwr-terminus/src/bin/terminus.rs
@@ -61,10 +61,10 @@ enum CommandArg {
         #[arg(short, long)]
         recipe: Option<String>,
 
-        #[expect(rustdoc::invalid_html_tags)]
         /// Lines from history file to use. Use [<MODE>[RANGE|INDEX]+;]+
         /// Where:
         ///   MODE: is one of 's'elect, 'd'eselect, 't'oggle.
+        #[expect(rustdoc::invalid_html_tags)]
         #[arg(short, long, verbatim_doc_comment)]
         select: Option<String>,
 

--- a/gwr-track/src/test_helpers.rs
+++ b/gwr-track/src/test_helpers.rs
@@ -196,8 +196,8 @@ pub fn check_and_clear(tracker: &TestTracker, expected: &[&str]) {
     log_contents_ref.clear();
 }
 
-#[must_use]
 /// Create a tracker for tests
+#[must_use]
 pub fn create_tracker(full_filepath: &str) -> Tracker {
     // Place all trace files in one folder
     const FOLDER: &str = "traces";

--- a/gwr-track/src/tracker/aka.rs
+++ b/gwr-track/src/tracker/aka.rs
@@ -8,8 +8,8 @@ use std::rc::Rc;
 
 use crate::entity::Entity;
 
-#[macro_export]
 /// Helper function for creating local Aka derived from incoming Aka
+#[macro_export]
 macro_rules! build_aka {
     ($aka:ident, $parent:expr, $renames:expr) => {{
         let mut tmp_aka = gwr_track::tracker::aka::Aka::default();
@@ -41,8 +41,8 @@ impl Display for Aka {
     }
 }
 
-#[must_use]
 /// Lookup the renames for a given port name
+#[must_use]
 pub fn get_alternative_names<'a>(aka: Option<&'a Aka>, name: &str) -> AlternativeNames<'a> {
     if let Some(aka) = aka {
         return aka.get_alternative_names(name);

--- a/gwr-track/src/tracker/mod.rs
+++ b/gwr-track/src/tracker/mod.rs
@@ -10,8 +10,8 @@ pub mod capnp;
 pub mod dev_null;
 /// Include the in-memory tracker.
 pub mod in_memory;
-#[cfg(feature = "perfetto")]
 /// Include the Perfetto tracker.
+#[cfg(feature = "perfetto")]
 pub mod perfetto;
 /// Include the text-based tracker.
 pub mod text;


### PR DESCRIPTION
This is the idiomatic Rust style, and used throughout the rustdoc book,
for example, https://doc.rust-lang.org/rustdoc/advanced-features.html.
