### PR TITLE
fix(gwr-models): remove unnecessary dead code attribute

### DIFF
--- a/gwr-models/src/registers/regfile.rs
+++ b/gwr-models/src/registers/regfile.rs
@@ -32,7 +32,6 @@ macro_rules! build_register_file {
                 }
             }
 
-            #[allow(dead_code)]
             pub fn write(&self, resolver: &impl gwr_engine::traits::Resolver, index: u64, value: u64) {
                 match index {
                     $( $index => self.[< $reg_name:lower >].write(resolver, value), )+

--- a/gwr-models/src/registers/register.rs
+++ b/gwr-models/src/registers/register.rs
@@ -91,13 +91,11 @@ macro_rules! build_register_view {
                 }
             }
 
-            #[allow(dead_code)]
             /// Install a callback function to be called whenever a `write` completes
             pub fn install_write_cb(&mut self, cb: $crate::registers::register::WrittenCallback) {
                 self.write_callbacks.push(cb);
             }
 
-            #[allow(dead_code)]
             /// Install a callback function to be called whenever a `read` completes
             pub fn install_read_cb(&mut self, cb: $crate::registers::register::ReadCallback) {
                 self.read_callbacks.push(cb);


### PR DESCRIPTION
No warnings are emitted when building the workspace having removed the
`#[allow(dead_code)]` attribute.

To test that users of gwr-models will not start to see warnings, all
calls to `install_write_cb` were commented out from the tests
temporarily.
