### PR TITLE
refactor: represent durations with std::time::Duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-spotter"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "capnp",
  "clap",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-track"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/examples/flaky-component/Cargo.toml
+++ b/examples/flaky-component/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", version = "0.12.0" }
 rand.workspace = true

--- a/examples/flaky-with-delay/Cargo.toml
+++ b/examples/flaky-with-delay/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", version = "0.12.0" }
 rand.workspace = true

--- a/examples/scrambler/Cargo.toml
+++ b/examples/scrambler/Cargo.toml
@@ -22,6 +22,6 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", version = "0.12.0" }

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -22,10 +22,10 @@ publish.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true
 rand_xoshiro = "0.7.0"

--- a/examples/sim-fabric/recipes/explore_ticks_per_hop.yaml
+++ b/examples/sim-fabric/recipes/explore_ticks_per_hop.yaml
@@ -87,9 +87,9 @@ ingredients:
           --monitor-window-ticks ${MONITOR_WINDOW_TICKS} --perfetto \
           --perfetto-file "${trace_file}" ${extra_args[@]} \
           > "${log_file}" 2>&1; then
-          runtime_ns=$(sed -n 's/.*Pass: Sent .* in \([0-9.]*ns\)\./\1/p' "${log_file}" | tail -n 1)
-          if [ -n "${runtime_ns}" ]; then
-            echo "PASS ticks_per_hop=${ticks_per_hop} runtime=${runtime_ns}" | tee "${status_file}"
+          runtime=$(sed -n 's/.*Pass: Sent .* in \([0-9.]*[mun]*s\)\./\1/p' "${log_file}" | tail -n 1)
+          if [ -n "${runtime}" ]; then
+            echo "PASS ticks_per_hop=${ticks_per_hop} runtime=${runtime}" | tee "${status_file}"
           else
             echo "PASS ticks_per_hop=${ticks_per_hop} runtime=unknown" | tee "${status_file}"
           fi

--- a/examples/sim-fabric/src/main.rs
+++ b/examples/sim-fabric/src/main.rs
@@ -258,7 +258,7 @@ fn main() -> Result<(), SimError> {
 
     if total_sunk_frames != total_expected_frames {
         error!(top ; "{}/{} frames received", total_sunk_frames, total_expected_frames);
-        error!(top ; "Deadlock detected at {:.2}ns", clock.time_now_ns());
+        error!(top ; "Deadlock detected at {:.2}", clock);
 
         tracker.shutdown();
         return sim_error!("Deadlock");
@@ -270,7 +270,7 @@ fn main() -> Result<(), SimError> {
 
     print_summary(
         &top,
-        clock.time_now_ns(),
+        &clock,
         total_sunk_frames,
         args.frame_overhead_bytes,
         args.frame_payload_bytes,
@@ -280,18 +280,19 @@ fn main() -> Result<(), SimError> {
 
 fn print_summary(
     top: &Rc<Entity>,
-    time_now_ns: f64,
+    clock: &Clock,
     total_sunk_frames: usize,
     frame_overhead_bytes: usize,
     frame_payload_bytes: usize,
 ) {
+    let elapsed = clock.time_now();
     let payload_bytes = total_sunk_frames * frame_payload_bytes;
     let (payload_value, payload_per_second) =
-        compute_adjusted_value_and_rate(time_now_ns, payload_bytes);
+        compute_adjusted_value_and_rate(elapsed, payload_bytes);
 
     let total_bytes = payload_bytes + (total_sunk_frames * frame_overhead_bytes);
-    let (total_value, total_per_second) = compute_adjusted_value_and_rate(time_now_ns, total_bytes);
+    let (total_value, total_per_second) = compute_adjusted_value_and_rate(elapsed, total_bytes);
 
-    info!(top ; "Pass: Sent {total_sunk_frames} in {time_now_ns:.2}ns.");
+    info!(top ; "Pass: Sent {total_sunk_frames} in {clock:.2}.");
     info!(top ; "Payload: {payload_value:.2} ({payload_per_second:.2}/s). Total: {total_value:.2} ({total_per_second:.2}/s).");
 }

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -22,10 +22,10 @@ publish.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true
 serde.workspace = true

--- a/examples/sim-pipe/src/main.rs
+++ b/examples/sim-pipe/src/main.rs
@@ -4,6 +4,7 @@
 //!
 //! See `lib.rs` for details.
 use std::rc::Rc;
+use std::time::Duration;
 
 use byte_unit::{AdjustedByte, Byte, UnitType};
 use clap::Parser;
@@ -192,7 +193,7 @@ fn main() -> Result<(), SimError> {
     let total_sunk_frames = sink.num_sunk();
     if total_sunk_frames != total_expected_frames {
         error!(top ; "{}/{} frames received", total_sunk_frames, total_expected_frames);
-        error!(top ; "Deadlock detected at {:.2}ns", clock.time_now_ns());
+        error!(top ; "Deadlock detected at {clock:.2}");
 
         tracker.shutdown();
         return sim_error!("Deadlock");
@@ -204,7 +205,7 @@ fn main() -> Result<(), SimError> {
 
     print_summary(
         &top,
-        clock.time_now_ns(),
+        &clock,
         total_sunk_frames,
         args.frame_overhead_bytes,
         args.frame_payload_bytes,
@@ -214,31 +215,35 @@ fn main() -> Result<(), SimError> {
 
 fn print_summary(
     top: &Rc<Entity>,
-    time_now_ns: f64,
+    clock: &Clock,
     total_sunk_frames: usize,
     frame_overhead_bytes: usize,
     frame_payload_bytes: usize,
 ) {
-    let time_now_s = time_now_ns / (1000.0 * 1000.0 * 1000.0);
-
+    let elapsed = clock.time_now();
     let payload_bytes = (total_sunk_frames * frame_payload_bytes) as u64;
     let (payload_value, payload_per_second) =
-        compute_adjusted_value_and_rate(time_now_s, payload_bytes);
+        compute_adjusted_value_and_rate(elapsed, payload_bytes);
 
     let total_bytes = payload_bytes + (total_sunk_frames * frame_overhead_bytes) as u64;
-    let (total_value, total_per_second) = compute_adjusted_value_and_rate(time_now_s, total_bytes);
+    let (total_value, total_per_second) = compute_adjusted_value_and_rate(elapsed, total_bytes);
 
-    info!(top ; "Pass: Sent {total_sunk_frames} in {time_now_ns:.2}ns.");
+    info!(top ; "Pass: Sent {total_sunk_frames} in {clock:.2}.");
     info!(top ; "Payload: {payload_value:.2} ({payload_per_second:.2}/s). Total: {total_value:.2} ({total_per_second:.2}/s).");
 }
 
 fn compute_adjusted_value_and_rate(
-    time_now_s: f64,
+    elapsed: Duration,
     num_bytes: u64,
 ) -> (AdjustedByte, AdjustedByte) {
     // Convert to a binary-only unit (KiB, MiB, etc)
     let count = Byte::from_u64(num_bytes).get_appropriate_unit(UnitType::Binary);
-    let per_second = Byte::from_f64(num_bytes as f64 / time_now_s).unwrap();
+    let time_now_s = elapsed.as_secs_f64();
+    let per_second = if time_now_s == 0.0 {
+        Byte::from_f64(0.0).unwrap()
+    } else {
+        Byte::from_f64(num_bytes as f64 / time_now_s).unwrap()
+    };
     let count_per_second = per_second.get_appropriate_unit(UnitType::Binary);
     (count, count_per_second)
 }

--- a/examples/sim-restaurant/Cargo.toml
+++ b/examples/sim-restaurant/Cargo.toml
@@ -21,8 +21,8 @@ clap.workspace = true
 crossterm.workspace = true
 futures.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 log.workspace = true
 rand.workspace = true
 ratatui.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -21,9 +21,9 @@ publish.workspace = true
 [dependencies]
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-ring/recipes/explore_ring_priorities.yaml
+++ b/examples/sim-ring/recipes/explore_ring_priorities.yaml
@@ -53,9 +53,9 @@ ingredients:
           --frame-payload-bytes ${FRAME_PAYLOAD_BYTES} --monitor-window-ticks \
           ${MONITOR_WINDOW_TICKS} --perfetto --perfetto-file "${trace_file}" \
           > "${log_file}" 2>&1; then
-          runtime_ns=$(sed -n 's/.*Pass (\([0-9.]*ns\)).*/\1/p' "${log_file}" | tail -n 1)
-          if [ -n "${runtime_ns}" ]; then
-            echo "PASS priority=${priority} runtime=${runtime_ns}" | tee "${status_file}"
+          runtime=$(sed -n 's/.*Pass (\([0-9.]*[mun]*s\)).*/\1/p' "${log_file}" | tail -n 1)
+          if [ -n "${runtime}" ]; then
+            echo "PASS priority=${priority} runtime=${runtime}" | tee "${status_file}"
           else
             echo "PASS priority=${priority} runtime=unknown" | tee "${status_file}"
           fi

--- a/examples/sim-ring/src/main.rs
+++ b/examples/sim-ring/src/main.rs
@@ -193,7 +193,7 @@ fn main() -> Result<(), SimError> {
     for sink in &sinks {
         if sink.num_sunk() != config.num_send_frames {
             error!(top ; "{}/{} frames received", sink.num_sunk(), config.num_send_frames);
-            error!(top ; "Deadlock detected at {:.2}ns", clock.time_now_ns());
+            error!(top ; "Deadlock detected at {clock:.2}");
 
             tracker.shutdown();
             return sim_error!("Deadlock");
@@ -202,6 +202,6 @@ fn main() -> Result<(), SimError> {
     if let Some(progress_bar) = progress_bar {
         progress_bar.finish();
     }
-    info!(top ; "Pass ({:.2}ns)", clock.time_now_ns());
+    info!(top ; "Pass ({clock:.2})");
     Ok(())
 }

--- a/gwr-components/Cargo.toml
+++ b/gwr-components/Cargo.toml
@@ -29,10 +29,10 @@ harness = false
 [dependencies]
 async-trait.workspace = true
 futures.workspace = true
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 paste.workspace = true
 

--- a/gwr-components/src/flow_controls/rate_limiter.rs
+++ b/gwr-components/src/flow_controls/rate_limiter.rs
@@ -35,12 +35,13 @@
 //! The rate limiter is configured to run on a 1GHz clock at a rate of 16 bits
 //! per tick.
 //!
-//! As a result, the total time for the simulation should be `20.0ns` because
+//! As a result, the total time for the simulation should be `20ns` because
 //! each of the 10 packets should take 2 clock ticks to pass through the
 //! [Limiter](crate::flow_controls::limiter) and be consumed by the
 //! [Sink](crate::sink::Sink).
 //!
 //! ```rust
+//! # use std::time::Duration;
 //! # use gwr_components::flow_controls::limiter::Limiter;
 //! # use gwr_components::sink::Sink;
 //! # use gwr_components::source::Source;
@@ -86,7 +87,7 @@
 //! run_simulation!(engine);
 //!
 //! // Ensure the time is as expected.
-//! assert_eq!(engine.time_now_ns(), 20.0);
+//! assert_eq!(engine.time_now(), Duration::from_nanos(20));
 //! ```
 
 use std::marker::PhantomData;

--- a/gwr-components/tests/queue.rs
+++ b/gwr-components/tests/queue.rs
@@ -2,6 +2,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::time::Duration;
 
 use futures::executor::block_on;
 use gwr_components::queue::Queue;
@@ -122,7 +123,7 @@ fn bounded_queue_push_waits_until_space_is_available() {
 
     assert!(push_done.get());
     assert_eq!(queue.values(), vec![2]);
-    assert_eq!(clock.time_now_ns(), 1.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(1));
 }
 
 #[test]
@@ -171,5 +172,5 @@ fn queue_changed_event_fires_for_mutations() {
         *snapshots.borrow(),
         vec![vec![10], vec![10, 20], vec![20], Vec::<usize>::new()]
     );
-    assert_eq!(clock.time_now_ns(), 4.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(4));
 }

--- a/gwr-components/tests/rate_limiter.rs
+++ b/gwr-components/tests/rate_limiter.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
 use std::fmt::Display;
+use std::time::Duration;
 
 use gwr_components::flow_controls::rate_limiter::RateLimiter;
 use gwr_engine::engine::Engine;
@@ -70,33 +71,33 @@ fn test_rate_limiter(
 fn one_ghz_1_byte_8_bits() {
     let mut engine = start_test(file!());
     test_rate_limiter(&mut engine, 1000.0, 8, RateLimiterTest::new(1));
-    assert_eq!(engine.time_now_ns(), 1.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(1));
 }
 
 #[test]
 fn one_ghz_1_byte_1_bit() {
     let mut engine = start_test(file!());
     test_rate_limiter(&mut engine, 1000.0, 1, RateLimiterTest::new(1));
-    assert_eq!(engine.time_now_ns(), 8.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(8));
 }
 
 #[test]
 fn one_mhz_1_byte_8_bits() {
     let mut engine = start_test(file!());
     test_rate_limiter(&mut engine, 1.0, 8, RateLimiterTest::new(1));
-    assert_eq!(engine.time_now_ns(), 1000.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(1000));
 }
 
 #[test]
 fn one_ghz_1_byte_7_bits() {
     let mut engine = start_test(file!());
     test_rate_limiter(&mut engine, 1000.0, 7, RateLimiterTest::new(1));
-    assert_eq!(engine.time_now_ns(), 2.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(2));
 }
 
 #[test]
 fn one_ghz_2_byte_8_bits() {
     let mut engine = start_test(file!());
     test_rate_limiter(&mut engine, 1000.0, 7, RateLimiterTest::new(1));
-    assert_eq!(engine.time_now_ns(), 2.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(2));
 }

--- a/gwr-developer-guide/md_src/gwr_engine/time/clocks.md
+++ b/gwr-developer-guide/md_src/gwr_engine/time/clocks.md
@@ -26,8 +26,7 @@ let clock_b = engine.clock_mhz(1000.0);
 ## Advancing Time
 
 Time is advanced by waiting an integer number of ticks on a clock. In the
-snippet below the `println!` will be called when the time has advanced to
-`1.0ns`
+snippet below the `println!` will be called when the time has advanced to `1ns`
 
 ```rust,no_run
 # use gwr_engine::engine::Engine;
@@ -37,7 +36,7 @@ snippet below the `println!` will be called when the time has advanced to
 let clock = engine.clock_ghz(1.0);
 # spawner.spawn(async move {
 clock.wait_ticks(1).await;
-println!("Time now {:.2}", clock.time_now_ns());
+println!("Time now {clock:.2}");
 # Ok(())
 #  });
 # }
@@ -52,8 +51,7 @@ needs to run as long as the rest of the simulation.
 In order to do this the `wait_ticks_or_exit` function can be called. This lets
 the engine know that it does not have to keep running if this is the only thread
 of activity left. For example, the code below will start a thread of activity
-that prints the current time in `ns` periodically as long as the simulation is
-running:
+that prints the current time periodically as long as the simulation is running:
 
 ```rust,no_run
 # use gwr_engine::engine::Engine;
@@ -64,7 +62,7 @@ let clock = engine.clock_ghz(1.0);
 spawner.spawn(async move {
   loop {
     clock.wait_ticks_or_exit(1000).await;
-    println!("Time now {:.2}", clock.time_now_ns());
+    println!("Time now {clock:.2}");
   }
 });
 # }

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-engine"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 futures.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 mimalloc = { version = "0.1.48", features = ["v3"], optional = true }
 rand.workspace = true

--- a/gwr-engine/src/engine.rs
+++ b/gwr-engine/src/engine.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::future::Future;
 use std::rc::Rc;
+use std::time::Duration;
 
 use gwr_track::entity::{Entity, toplevel};
 use gwr_track::tracker::stdout_tracker;
@@ -140,8 +141,8 @@ impl Engine {
     }
 
     #[must_use]
-    pub fn time_now_ns(&self) -> f64 {
-        self.executor.time_now_ns()
+    pub fn time_now(&self) -> Duration {
+        self.executor.time_now()
     }
 
     #[must_use]

--- a/gwr-engine/src/events/mod.rs
+++ b/gwr-engine/src/events/mod.rs
@@ -16,6 +16,7 @@
 //! An event being created to co-ordinate between two tasks.
 //!
 //! ```rust
+//! # use std::time::Duration;
 //! # use gwr_engine::engine::Engine;
 //! # use gwr_engine::events::once::Once;
 //! # use gwr_engine::run_simulation;
@@ -51,7 +52,7 @@
 //!     spawn_listen(&mut engine, event.clone());
 //!     spawn_notify(&mut engine, event);
 //!     run_simulation!(engine);
-//!     # assert_eq!(engine.time_now_ns(), 10.0);
+//!     # assert_eq!(engine.time_now(), Duration::from_nanos(10));
 //! }
 //! ```
 

--- a/gwr-engine/src/executor.rs
+++ b/gwr-engine/src/executor.rs
@@ -6,6 +6,7 @@ use std::mem;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::time::Duration;
 
 use gwr_track::entity::Entity;
 use rand::SeedableRng;
@@ -189,8 +190,8 @@ impl Executor {
     }
 
     #[must_use]
-    pub fn time_now_ns(&self) -> f64 {
-        self.state.time.borrow().time_now_ns()
+    pub fn time_now(&self) -> Duration {
+        self.state.time.borrow().time_now()
     }
 
     pub fn set_randomize_task_order(&self, randomize: bool) {

--- a/gwr-engine/src/port/monitor.rs
+++ b/gwr-engine/src/port/monitor.rs
@@ -7,6 +7,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use byte_unit::{Byte, Unit};
@@ -23,7 +24,7 @@ pub struct Monitor {
     window_size_ticks: u64,
     bytes_in_window: RefCell<usize>,
     bytes_total: RefCell<usize>,
-    last_time_ns: RefCell<f64>,
+    last_time: RefCell<Duration>,
     bw_unit: Unit,
 }
 
@@ -44,7 +45,7 @@ impl Monitor {
             window_size_ticks,
             bytes_in_window: RefCell::new(0),
             bytes_total: RefCell::new(0),
-            last_time_ns: RefCell::new(clock.time_now_ns()),
+            last_time: RefCell::new(clock.time_now()),
             bw_unit,
         });
 
@@ -71,16 +72,16 @@ impl Runnable for Monitor {
             *self.bytes_in_window.borrow_mut() = 0;
             *self.bytes_total.borrow_mut() += bytes_in_window;
 
-            let time_now_ns = self.clock.time_now_ns();
+            let time_now = self.clock.time_now();
             let window_duration_s =
-                (time_now_ns - *self.last_time_ns.borrow()) / (1000.0 * 1000.0 * 1000.0);
+                (time_now.checked_sub(*self.last_time.borrow()).unwrap()).as_secs_f64();
 
             let per_second = Byte::from_f64(bytes_in_window as f64 / window_duration_s).unwrap();
             let gib_per_second = per_second.get_adjusted_unit(self.bw_unit);
 
             self.entity.track_value(gib_per_second.get_value());
 
-            *self.last_time_ns.borrow_mut() = time_now_ns;
+            *self.last_time.borrow_mut() = time_now;
         }
     }
 }

--- a/gwr-engine/src/time/clock.rs
+++ b/gwr-engine/src/time/clock.rs
@@ -6,11 +6,14 @@
 
 use core::cmp::Ordering;
 use std::cell::{Cell, RefCell};
+use std::fmt::Display;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
+use std::time::Duration;
 
+use crate::time::duration::AppropriateUnitDisplay;
 use crate::traits::{Resolve, Resolver};
 
 /// ClockTick structure for representing a number of Clock ticks and a phase.
@@ -91,7 +94,7 @@ impl PartialOrd for ClockTick {
     }
 }
 
-impl std::fmt::Display for ClockTick {
+impl Display for ClockTick {
     #[cfg(feature = "phase")]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}.{:?}", self.tick, self.phase)
@@ -110,6 +113,12 @@ pub struct Clock {
     freq_mhz: f64,
 
     pub shared_state: Rc<ClockState>,
+}
+
+impl Display for Clock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.time_now().to_appropriate_unit_fmt(f)
+    }
 }
 
 pub struct TaskWaker {
@@ -254,25 +263,36 @@ impl Clock {
         *self.shared_state.now.borrow()
     }
 
-    /// Returns the current time in `ns`.
+    /// Returns the current time.
     #[must_use]
-    pub fn time_now_ns(&self) -> f64 {
+    pub fn time_now(&self) -> Duration {
         let now = *self.shared_state.now.borrow();
-        self.to_ns(&now)
+        self.to_duration(&now)
     }
 
-    /// Returns the time in `ns` of the next event registered with this clock.
+    /// Returns the time of the next event registered with this clock.
     #[must_use]
-    pub fn time_of_next(&self) -> f64 {
+    pub fn time_of_next(&self) -> Duration {
         match self.shared_state.waiting_times.borrow().first() {
-            Some(clock_time) => self.to_ns(clock_time),
+            Some(clock_time) => self.to_duration(clock_time),
+            None => Duration::MAX,
+        }
+    }
+
+    fn ns_of_next(&self) -> f64 {
+        match self.shared_state.waiting_times.borrow().first() {
+            Some(clock_time) => self.to_ns_f64(clock_time),
             None => f64::MAX,
         }
     }
 
-    /// Convert the given [ClockTick] to a time in `ns` for this clock.
+    /// Convert the given [ClockTick] to a time for this clock.
     #[must_use]
-    pub fn to_ns(&self, clock_time: &ClockTick) -> f64 {
+    pub fn to_duration(&self, clock_time: &ClockTick) -> Duration {
+        Duration::from_secs_f64(clock_time.tick as f64 / (self.freq_mhz * 1e6))
+    }
+
+    fn to_ns_f64(&self, clock_time: &ClockTick) -> f64 {
         clock_time.tick as f64 / self.freq_mhz * 1000.0
     }
 
@@ -336,11 +356,10 @@ impl Clock {
     }
 
     /// Advance to the next tick after the specified time.
-    pub fn advance_to(&self, time_ns: f64) {
-        let now_ns = self.time_now_ns();
-        assert!(now_ns < time_ns);
-        let diff_ns = time_ns - now_ns;
-        let ticks = (diff_ns * (self.freq_mhz / 1000.0)).ceil();
+    pub fn advance_to(&self, time: Duration) {
+        let now = self.time_now();
+        let diff_s = (time.checked_sub(now).unwrap()).as_secs_f64();
+        let ticks = (diff_s * self.freq_mhz * 1e6).ceil();
 
         let mut until = self.tick_now();
         until.tick += ticks as u64;
@@ -366,7 +385,7 @@ impl Eq for Clock {}
 
 impl Ord for Clock {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.time_of_next() < other.time_of_next() {
+        if self.ns_of_next() < other.ns_of_next() {
             Ordering::Less
         } else {
             Ordering::Greater
@@ -426,9 +445,15 @@ mod tests {
     #[test]
     fn convert_to_ns() {
         let clk_ghz = Clock::new(1000.0);
-        assert_eq!(1.0, clk_ghz.to_ns(&ClockTick::new().set_tick(1)));
+        assert_eq!(
+            Duration::from_nanos(1),
+            clk_ghz.to_duration(&ClockTick::new().set_tick(1))
+        );
 
         let slow_clk = Clock::new(0.5);
-        assert_eq!(2000.0, slow_clk.to_ns(&ClockTick::new().set_tick(1)));
+        assert_eq!(
+            Duration::from_nanos(2000),
+            slow_clk.to_duration(&ClockTick::new().set_tick(1))
+        );
     }
 }

--- a/gwr-engine/src/time/duration.rs
+++ b/gwr-engine/src/time/duration.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+//! This module provides a mechanism for [Display]ing a [Duration].
+
+use std::fmt::Display;
+use std::time::Duration;
+
+/// The [AppropriateUnitDisplay] trait provides a mechanism for formatting a
+/// type to an appropriate unit.
+pub trait AppropriateUnitDisplay {
+    fn to_appropriate_unit_fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result;
+}
+
+/// Implement [AppropriateUnitDisplay] for [Duration] to allow it to be
+/// formatted to an appropriate unit of time. The unit, chosen based on the
+/// value, will be either seconds (s), milliseconds (ms), microseconds (us), or
+/// nanoseconds (ns).
+///
+/// As [Duration] cannot represent sub-nanosecond times any value formatted to
+/// ns will be done so as an integer.
+impl AppropriateUnitDisplay for Duration {
+    fn to_appropriate_unit_fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let precision = f.precision().unwrap_or(2);
+        let time_s = self.as_secs_f64();
+        if time_s > 1.0 {
+            write!(f, "{time_s:.precision$}s")
+        } else if time_s > 1.0e-3 {
+            write!(f, "{:.precision$}ms", time_s * 1.0e3)
+        } else if time_s > 1.0e-6 {
+            write!(f, "{:.precision$}us", time_s * 1.0e6)
+        } else {
+            write!(f, "{}ns", time_s * 1.0e9)
+        }
+    }
+}
+
+/// Implement [Display] for [AppropriateUnitDisplay] to allow [Duration],
+/// which itself does not implement [Display], to be formatted using the
+/// [AppropriateUnitDisplay] implementation provided by this module.
+///
+/// This enables [Duration]s to be [Display]ed as follows:
+/// ```rust
+/// use std::time::Duration;
+///
+/// use gwr_engine::time::duration::AppropriateUnitDisplay;
+///
+/// println!("{}", &Duration::new(1, 0) as &dyn AppropriateUnitDisplay);
+/// ```
+impl Display for dyn AppropriateUnitDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.to_appropriate_unit_fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn fmt(d: Duration) -> String {
+        format!("{}", &d as &dyn AppropriateUnitDisplay)
+    }
+
+    fn fmt_precision(d: Duration, precision: usize) -> String {
+        format!("{:.precision$}", &d as &dyn AppropriateUnitDisplay)
+    }
+
+    #[test]
+    fn seconds() {
+        assert_eq!(fmt(Duration::from_secs(5)), "5.00s");
+        assert_eq!(fmt(Duration::from_secs_f64(1.5)), "1.50s");
+        assert_eq!(fmt(Duration::from_secs(100)), "100.00s");
+        assert_eq!(fmt(Duration::from_nanos(2_000_567_890)), "2.00s");
+    }
+
+    #[test]
+    fn milliseconds() {
+        assert_eq!(fmt(Duration::from_millis(500)), "500.00ms");
+        assert_eq!(fmt(Duration::from_millis(2)), "2.00ms");
+        assert_eq!(fmt(Duration::from_secs_f64(0.1)), "100.00ms");
+    }
+
+    #[test]
+    fn microseconds() {
+        assert_eq!(fmt(Duration::from_micros(500)), "500.00us");
+        assert_eq!(fmt(Duration::from_micros(2)), "2.00us");
+        assert_eq!(fmt(Duration::from_secs_f64(0.0001)), "100.00us");
+    }
+
+    #[test]
+    fn nanoseconds() {
+        assert_eq!(fmt(Duration::from_nanos(500)), "500ns");
+        assert_eq!(fmt(Duration::from_nanos(1)), "1ns");
+        assert_eq!(fmt(Duration::ZERO), "0ns");
+    }
+
+    #[test]
+    fn duration_precision() {
+        assert_eq!(fmt(Duration::from_nanos(2_009_000_000)), "2.01s");
+    }
+
+    #[test]
+    fn custom_precision() {
+        assert_eq!(fmt_precision(Duration::from_secs(5), 0), "5s");
+        assert_eq!(fmt_precision(Duration::from_millis(500), 4), "500.0000ms");
+        assert_eq!(fmt_precision(Duration::from_micros(3), 1), "3.0us");
+        assert_eq!(fmt_precision(Duration::from_nanos(42), 3), "42ns");
+    }
+
+    #[test]
+    fn boundary_values() {
+        // Exactly at 1s boundary — should format as ms (not > 1.0)
+        assert_eq!(fmt(Duration::from_secs(1)), "1000.00ms");
+        // Exactly at 1ms boundary — should format as us
+        assert_eq!(fmt(Duration::from_millis(1)), "1000.00us");
+        // Exactly at 1us boundary — should format as ns
+        assert_eq!(fmt(Duration::from_micros(1)), "1000ns");
+    }
+}

--- a/gwr-engine/src/time/mod.rs
+++ b/gwr-engine/src/time/mod.rs
@@ -2,18 +2,21 @@
 
 //! Modules that model time within the simulations.
 
+use std::time::Duration;
+
 use byte_unit::{AdjustedByte, Byte, UnitType};
 
 pub mod clock;
+pub mod duration;
 pub mod simtime;
 
 // Convert a number of bytes to a binary-only unit (KiB, MiB, etc)
 #[must_use]
 pub fn compute_adjusted_value_and_rate(
-    time_now_ns: f64,
+    elapsed: Duration,
     num_bytes: usize,
 ) -> (AdjustedByte, AdjustedByte) {
-    let time_now_s = time_now_ns / (1000.0 * 1000.0 * 1000.0);
+    let time_now_s = elapsed.as_secs_f64();
     let count = Byte::from_u64(num_bytes as u64).get_appropriate_unit(UnitType::Binary);
     let per_second = if time_now_s == 0.0 {
         Byte::from_f64(0.0).unwrap()

--- a/gwr-engine/src/time/simtime.rs
+++ b/gwr-engine/src/time/simtime.rs
@@ -5,6 +5,7 @@
 //! Time is made up of a cycle count and a phase.
 
 use std::rc::Rc;
+use std::time::Duration;
 
 use gwr_track::entity::Entity;
 use gwr_track::set_time;
@@ -14,12 +15,12 @@ use crate::time::clock::TaskWaker;
 
 /// The overall owner of time within a simulation.
 ///
-/// Contains all Clocks and the current simulation time in ns.
+/// Contains all Clocks and the current simulation time.
 #[derive(Clone)]
 pub struct SimTime {
     entity: Rc<Entity>,
 
-    current_ns: f64,
+    current_time: Duration,
 
     /// Clocks are auto-created as required and kept in a HashMap.
     ///
@@ -33,7 +34,7 @@ impl SimTime {
     pub fn new(parent: &Rc<Entity>) -> Self {
         Self {
             entity: Rc::new(Entity::new(parent, "time")),
-            current_ns: 0.0,
+            current_time: Duration::ZERO,
             clocks: Vec::new(),
         }
     }
@@ -53,10 +54,10 @@ impl SimTime {
     pub fn advance_time(&mut self) -> Option<Vec<TaskWaker>> {
         if let Some(next_clock) = self.clocks.iter().min_by(|a, b| a.cmp(b)) {
             if let Some(clock_time) = next_clock.shared_state.waiting_times.borrow_mut().pop() {
-                let next_ns = next_clock.to_ns(&clock_time);
-                if self.current_ns != next_ns {
-                    set_time!(self.entity ; next_ns);
-                    self.current_ns = next_ns;
+                let next_time = next_clock.to_duration(&clock_time);
+                if self.current_time != next_time {
+                    set_time!(self.entity ; next_time);
+                    self.current_time = next_time;
                 }
                 next_clock.advance_time(clock_time);
                 next_clock.shared_state.waiting.borrow_mut().pop()
@@ -69,8 +70,8 @@ impl SimTime {
     }
 
     #[must_use]
-    pub fn time_now_ns(&self) -> f64 {
-        self.current_ns
+    pub fn time_now(&self) -> Duration {
+        self.current_time
     }
 
     /// The simulation can exit if all scheduled tasks can exit.

--- a/gwr-engine/tests/clocks.rs
+++ b/gwr-engine/tests/clocks.rs
@@ -2,6 +2,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::time::Duration;
 
 use futures::{FutureExt, select};
 use gwr_engine::test_helpers::start_test;
@@ -25,7 +26,7 @@ fn dual_clock() {
     engine.spawn(async move {
         for _ in 0..5 {
             clk1.wait_ticks(1).await;
-            values.borrow_mut().push((1, clk1.time_now_ns()));
+            values.borrow_mut().push((1, clk1.time_now()));
         }
         Ok(())
     });
@@ -34,27 +35,25 @@ fn dual_clock() {
     engine.spawn(async move {
         for _ in 0..5 {
             clk2.wait_ticks(1).await;
-            values.borrow_mut().push((2, clk2.time_now_ns()));
+            values.borrow_mut().push((2, clk2.time_now()));
         }
         Ok(())
     });
 
     engine.run().unwrap();
 
-    let ns1 = 1000.0 / mhz1;
-    let ns2 = 1000.0 / mhz2;
     assert_eq!(
         vec![
-            (2, 1.0 * ns2),
-            (1, 1.0 * ns1),
-            (2, 2.0 * ns2),
-            (2, 3.0 * ns2),
-            (1, 2.0 * ns1),
-            (2, 4.0 * ns2),
-            (2, 5.0 * ns2),
-            (1, 3.0 * ns1),
-            (1, 4.0 * ns1),
-            (1, 5.0 * ns1),
+            (2, Duration::from_secs_f64(1.0 / (mhz2 * 1e6))),
+            (1, Duration::from_secs_f64(1.0 / (mhz1 * 1e6))),
+            (2, Duration::from_secs_f64(2.0 / (mhz2 * 1e6))),
+            (2, Duration::from_secs_f64(3.0 / (mhz2 * 1e6))),
+            (1, Duration::from_secs_f64(2.0 / (mhz1 * 1e6))),
+            (2, Duration::from_secs_f64(4.0 / (mhz2 * 1e6))),
+            (2, Duration::from_secs_f64(5.0 / (mhz2 * 1e6))),
+            (1, Duration::from_secs_f64(3.0 / (mhz1 * 1e6))),
+            (1, Duration::from_secs_f64(4.0 / (mhz1 * 1e6))),
+            (1, Duration::from_secs_f64(5.0 / (mhz1 * 1e6))),
         ],
         *all_values.borrow()
     );
@@ -89,7 +88,7 @@ fn wait_ticks_or_exit() {
     engine.run().unwrap();
 
     // Simulation should have finished when the first loop completed
-    assert_eq!(engine.time_now_ns(), 5.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(5));
 }
 
 struct PendingUpdate {
@@ -181,11 +180,11 @@ fn cancelled_wait_ticks_does_not_leave_stale_schedule() {
             }
 
             clock.wait_ticks(5).await;
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
 
     engine.run().unwrap();
-    assert_eq!(engine.time_now_ns(), 10.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(10));
 }

--- a/gwr-engine/tests/events_all_of.rs
+++ b/gwr-engine/tests/events_all_of.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+use std::time::Duration;
+
 use gwr_engine::events::all_of::AllOf;
 use gwr_engine::test_helpers::start_test;
 use gwr_engine::traits::Event;
@@ -20,7 +22,7 @@ fn allof_once_and_allof_once() {
     spawn_activity(&mut engine);
     engine.run_until(allof_2).unwrap();
 
-    assert_eq!(engine.time_now_ns(), 20.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(20));
 }
 
 #[test]
@@ -39,7 +41,7 @@ fn multiple_listen() {
         let clock = clock.clone();
         engine.spawn(async move {
             allof.listen().await;
-            assert_eq!(clock.time_now_ns(), 30.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(30));
             Ok(())
         });
     }
@@ -47,13 +49,13 @@ fn multiple_listen() {
     engine.spawn(async move {
         clock.wait_ticks(1).await;
         allof.listen().await;
-        assert_eq!(clock.time_now_ns(), 30.0);
+        assert_eq!(clock.time_now(), Duration::from_nanos(30));
         Ok(())
     });
 
     engine.run().unwrap();
 
-    assert_eq!(engine.time_now_ns(), 30.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(30));
 }
 
 #[test]
@@ -68,10 +70,10 @@ fn default_value() {
         let res = allof.listen().await;
         assert_eq!(res, i32::default());
 
-        assert_eq!(clock.time_now_ns(), 10.0);
+        assert_eq!(clock.time_now(), Duration::from_nanos(10));
         Ok(())
     });
 
     engine.run().unwrap();
-    assert_eq!(engine.time_now_ns(), 10.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(10));
 }

--- a/gwr-engine/tests/events_any_of.rs
+++ b/gwr-engine/tests/events_any_of.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+use std::time::Duration;
+
 use gwr_engine::events::any_of::AnyOf;
 use gwr_engine::test_helpers::start_test;
 use gwr_engine::traits::Event;
@@ -26,7 +28,7 @@ fn anyof_once_and_anyof_once() {
     spawn_activity(&mut engine);
     engine.run_until(anyof_2).unwrap();
 
-    assert_eq!(engine.time_now_ns(), 10.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -46,7 +48,7 @@ fn multiple_listen() {
         engine.spawn(async move {
             let res = anyof.listen().await;
             assert_eq!(res, 1);
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -55,14 +57,14 @@ fn multiple_listen() {
         clock.wait_ticks(1).await;
         let res = anyof.listen().await;
         assert_eq!(res, 1);
-        assert_eq!(clock.time_now_ns(), 10.0);
+        assert_eq!(clock.time_now(), Duration::from_nanos(10));
         Ok(())
     });
 
     engine.run().unwrap();
 
     // The simulation doesn't complete until all events have fired
-    assert_eq!(engine.time_now_ns(), 30.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(30));
 }
 
 #[test]
@@ -79,10 +81,10 @@ fn using_enum() {
             EventResults::Result1 => panic!("Wrong event fired"),
             EventResults::Result2 => println!("Correct event fired"),
         }
-        assert_eq!(clock.time_now_ns(), 5.0);
+        assert_eq!(clock.time_now(), Duration::from_nanos(5));
         Ok(())
     });
 
     engine.run().unwrap();
-    assert_eq!(engine.time_now_ns(), 10.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(10));
 }

--- a/gwr-engine/tests/events_once.rs
+++ b/gwr-engine/tests/events_once.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use gwr_engine::events::once::Once;
 use gwr_engine::run_simulation;
@@ -26,7 +27,7 @@ fn notify_zero_listeners() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 0.0);
+    assert_eq!(clock.time_now(), Duration::ZERO);
 }
 
 #[test]
@@ -44,7 +45,7 @@ fn notify_one_listener() {
             assert_eq!(res, 123);
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -60,7 +61,7 @@ fn notify_one_listener() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -79,7 +80,7 @@ fn notify_before_listener() {
             assert_eq!(res, 1234);
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -91,7 +92,7 @@ fn notify_before_listener() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -113,7 +114,7 @@ fn notify_multiple_listeners() {
             assert_eq!(res, "ok");
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             *count.borrow_mut() += 1;
             Ok(())
         });
@@ -137,7 +138,7 @@ fn notify_multiple_listeners() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
     assert_eq!(*count.borrow(), num_listen);
 }
 

--- a/gwr-engine/tests/events_once_default.rs
+++ b/gwr-engine/tests/events_once_default.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Duration;
 
 use gwr_engine::events::once::Once;
 use gwr_engine::run_simulation;
@@ -22,7 +23,7 @@ fn notify_zero_listeners() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 0.0);
+    assert_eq!(clock.time_now(), Duration::ZERO);
 }
 
 #[test]
@@ -38,7 +39,7 @@ fn notify_one_listener() {
         engine.spawn(async move {
             once.listen().await;
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -54,7 +55,7 @@ fn notify_one_listener() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -71,7 +72,7 @@ fn notify_before_listener() {
             clock.wait_ticks(10).await;
             once.listen().await;
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -83,7 +84,7 @@ fn notify_before_listener() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -103,7 +104,7 @@ fn notify_multiple_listeners() {
         engine.spawn(async move {
             once.listen().await;
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             *count.borrow_mut() += 1;
             Ok(())
         });
@@ -120,7 +121,7 @@ fn notify_multiple_listeners() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
     assert_eq!(*count.borrow(), num_listen);
 }
 

--- a/gwr-engine/tests/events_repeated.rs
+++ b/gwr-engine/tests/events_repeated.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use futures::{FutureExt, select};
 use gwr_engine::events::repeated::Repeated;
@@ -28,7 +29,7 @@ fn notify_one_listener() {
             assert_eq!(res, usize::default());
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -44,7 +45,7 @@ fn notify_one_listener() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -63,7 +64,7 @@ fn notify_one_listener_result() {
             assert_eq!(res, result);
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -79,7 +80,7 @@ fn notify_one_listener_result() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -106,7 +107,7 @@ fn notify_before_listen() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -128,7 +129,7 @@ fn notify_multiple_listeners() {
             assert_eq!(res, "");
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             *count.borrow_mut() += 1;
             Ok(())
         });
@@ -152,7 +153,7 @@ fn notify_multiple_listeners() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
     assert_eq!(*count.borrow(), num_listen);
 }
 
@@ -170,13 +171,13 @@ fn notify_listen_twice() {
             let res = repeated.listen().await;
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             assert_eq!(res, usize::default());
 
             let res = repeated.listen().await;
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 20.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(20));
             assert_eq!(res, usize::default());
             Ok(())
         });
@@ -195,7 +196,7 @@ fn notify_listen_twice() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 20.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(20));
 }
 
 #[test]
@@ -214,7 +215,10 @@ fn notify_listen_loop() {
             for i in 0..COUNTER {
                 let res = repeated.listen().await;
                 assert_eq!(res, i + 1);
-                assert_eq!(clock.time_now_ns(), 10.0 * (i + 1) as f64);
+                assert_eq!(
+                    clock.time_now(),
+                    Duration::from_nanos((10 * (i + 1)) as u64)
+                );
             }
             Ok(())
         });
@@ -233,7 +237,10 @@ fn notify_listen_loop() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0 * COUNTER as f64);
+    assert_eq!(
+        clock.time_now(),
+        Duration::from_nanos((10 * COUNTER) as u64)
+    );
 }
 
 #[test]
@@ -251,7 +258,7 @@ fn notify_once_listen_twice() {
             assert_eq!(res, usize::default());
 
             // Ensure this hasn't completed early
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
 
             let _ = repeated.listen().await;
             panic!("I should not be awoken twice");
@@ -269,7 +276,7 @@ fn notify_once_listen_twice() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -286,7 +293,7 @@ fn notify_repeated_two_listeners() {
         engine.spawn(async move {
             let res = repeated.listen().await;
             assert_eq!(res, usize::default());
-            assert_eq!(clock.time_now_ns(), 10.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(10));
             Ok(())
         });
     }
@@ -313,7 +320,7 @@ fn notify_repeated_two_listeners() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 11.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(11));
 }
 
 #[test]
@@ -375,5 +382,5 @@ fn cancelled_listener_is_removed() {
 
     run_simulation!(engine);
 
-    assert_eq!(clock.time_now_ns(), 10.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(10));
 }

--- a/gwr-engine/tests/ports.rs
+++ b/gwr-engine/tests/ports.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
+use std::time::Duration;
+
 use futures::select;
 use gwr_engine::port::{InPort, OutPort};
 use gwr_engine::run_simulation;
@@ -22,7 +24,7 @@ fn put_get_synced() {
             tx_port.put(1)?.await;
 
             // The `put()` should not have completed until the matching `get()` happens
-            assert!(clock.time_now_ns() == 1.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(1));
 
             tx_port.put(2)?.await;
             Ok(())
@@ -39,7 +41,7 @@ fn put_get_synced() {
             assert_eq!(i, 2);
 
             // Time should not change for any other reason than the `wait_ticks()`
-            assert!(clock.time_now_ns() == 1.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(1));
 
             Ok(())
         });
@@ -47,7 +49,7 @@ fn put_get_synced() {
 
     run_simulation!(engine);
 
-    assert_eq!(engine.time_now_ns(), 1.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(1));
 }
 
 #[test]
@@ -70,13 +72,13 @@ fn select_on_ports() {
             tx_port1.put(1)?.await;
 
             // Time will depend on order of select
-            let ns = clock.time_now_ns();
-            assert!(ns == 1.0 || ns == 3.0);
+            let time = clock.time_now();
+            assert!(time == Duration::from_nanos(1) || time == Duration::from_nanos(3));
 
             // Wait to ensure that data from port2 will be received before we send again
             clock.wait_ticks(3).await;
             tx_port1.put(3)?.await;
-            assert_eq!(clock.time_now_ns(), 5.0);
+            assert_eq!(clock.time_now(), Duration::from_nanos(5));
             Ok(())
         });
     }
@@ -87,11 +89,11 @@ fn select_on_ports() {
             tx_port2.put(2)?.await;
 
             // Time will depend on order of select
-            let ns = clock.time_now_ns();
-            if ns == 1.0 {
+            let time = clock.time_now();
+            if time == Duration::from_nanos(1) {
                 clock.wait_ticks(10).await;
             } else {
-                assert_eq!(ns, 3.0);
+                assert_eq!(time, Duration::from_nanos(3));
                 clock.wait_ticks(8).await;
             }
             tx_port2.put(4)?.await;
@@ -139,5 +141,5 @@ fn select_on_ports() {
 
     run_simulation!(engine);
 
-    assert_eq!(engine.time_now_ns(), 11.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(11));
 }

--- a/gwr-engine/tests/run_until.rs
+++ b/gwr-engine/tests/run_until.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+use std::time::Duration;
+
 use gwr_engine::events::all_of::AllOf;
 use gwr_engine::events::any_of::AnyOf;
 use gwr_engine::test_helpers::start_test;
@@ -16,7 +18,7 @@ fn run_until_once() {
     spawn_activity(&mut engine);
     engine.run_until(once).unwrap();
 
-    assert_eq!(engine.time_now_ns(), 5.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(5));
 }
 
 #[test]
@@ -30,7 +32,7 @@ fn run_until_allof_5_10() {
     spawn_activity(&mut engine);
     engine.run_until(allof).unwrap();
 
-    assert_eq!(engine.time_now_ns(), 10.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -44,7 +46,7 @@ fn run_until_allof_10_5() {
     spawn_activity(&mut engine);
     engine.run_until(allof).unwrap();
 
-    assert_eq!(engine.time_now_ns(), 10.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(10));
 }
 
 #[test]
@@ -58,7 +60,7 @@ fn run_until_any_of_5_10() {
     spawn_activity(&mut engine);
     engine.run_until(anyf).unwrap();
 
-    assert_eq!(engine.time_now_ns(), 5.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(5));
 }
 
 #[test]
@@ -72,5 +74,5 @@ fn run_until_any_of_10_5() {
     spawn_activity(&mut engine);
     engine.run_until(anyof).unwrap();
 
-    assert_eq!(engine.time_now_ns(), 5.0);
+    assert_eq!(engine.time_now(), Duration::from_nanos(5));
 }

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -31,10 +31,10 @@ async-trait.workspace = true
 clap.workspace = true
 futures.workspace = true
 gwr-components = { path = "../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 paste.workspace = true
 rand.workspace = true

--- a/gwr-models/src/memory/mod.rs
+++ b/gwr-models/src/memory/mod.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use gwr_components::delay::Delay;
@@ -159,13 +160,13 @@ where
         self.config.capacity_bytes
     }
 
-    pub fn dump_stats(&self, time_now_ns: f64) {
+    pub fn dump_stats(&self, elapsed: Duration) {
         let stats = self.stats.borrow();
 
         let (read_value, read_per_second) =
-            compute_adjusted_value_and_rate(time_now_ns, stats.bytes_read);
+            compute_adjusted_value_and_rate(elapsed, stats.bytes_read);
         let (write_value, write_per_second) =
-            compute_adjusted_value_and_rate(time_now_ns, stats.bytes_written);
+            compute_adjusted_value_and_rate(elapsed, stats.bytes_written);
 
         info!(self.entity ; "Memory {}:", self.entity.full_name());
         info!(self.entity ;

--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -23,6 +23,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use gwr_engine::engine::Engine;
@@ -178,9 +179,9 @@ impl ProcessingElement {
         }
     }
 
-    pub fn dump_stats(&self, time_now_ns: f64) {
+    pub fn dump_stats(&self, elapsed: Duration) {
         let stats = self.stats.borrow();
-        let time_now_s = time_now_ns / 1e9;
+        let time_now_s = elapsed.as_secs_f64();
         let total_gflops = stats.total_flops as f64 / 1e9;
         let average_gflops_per_second = if time_now_s == 0.0 {
             0.0

--- a/gwr-models/tests/ethernet_link.rs
+++ b/gwr-models/tests/ethernet_link.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
 use std::rc::Rc;
+use std::time::Duration;
 
 use gwr_components::sink::Sink;
 use gwr_components::source::Source;
@@ -69,8 +70,8 @@ fn latency() {
     let num_sunk = sink_b.num_sunk();
     assert_eq!(num_sunk, num_puts_b);
 
-    let expected_time = ethernet_link::DELAY_TICKS as f64;
-    assert_eq!(clock.time_now_ns(), expected_time);
+    let expected_time = Duration::from_nanos(ethernet_link::DELAY_TICKS as u64);
+    assert_eq!(clock.time_now(), expected_time);
 }
 
 #[test]
@@ -86,14 +87,14 @@ fn throughput() {
     let num_sunk = sink_b.num_sunk();
     assert_eq!(num_sunk, num_puts_b);
 
-    let latency = ethernet_link::DELAY_TICKS as f64;
+    let latency = Duration::from_nanos(ethernet_link::DELAY_TICKS as u64);
     let frame_bits = (payload_bytes + FRAME_OVERHEAD_BYTES) * 8;
     let frame_ticks = frame_bits.div_ceil(ethernet_link::BITS_PER_TICK);
 
     // Assume each tick is 1ns (1GHz clock) and that the throughput of the last
     // frame doesn't need to be counted
-    let frames_time = (frame_ticks * (num_puts_a - 1)) as f64;
-    assert_eq!(clock.time_now_ns(), (latency + frames_time));
+    let frames_time = Duration::from_nanos((frame_ticks * (num_puts_a - 1)) as u64);
+    assert_eq!(clock.time_now(), latency + frames_time);
 }
 
 #[test]
@@ -127,6 +128,6 @@ fn change_delay() {
     let num_sunk = sink_a.num_sunk();
     assert_eq!(num_sunk, 1);
 
-    let expected_time = DELAY_TICKS as f64;
-    assert_eq!(clock.time_now_ns(), expected_time);
+    let expected_time = Duration::from_nanos(DELAY_TICKS as u64);
+    assert_eq!(clock.time_now(), expected_time);
 }

--- a/gwr-models/tests/memory.rs
+++ b/gwr-models/tests/memory.rs
@@ -2,6 +2,7 @@
 
 use std::cmp::max;
 use std::rc::Rc;
+use std::time::Duration;
 
 use gwr_components::sink::Sink;
 use gwr_components::source::Source;
@@ -85,7 +86,7 @@ fn memory_read() {
     let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
     let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
     let last_event_time = max(last_bw_limit_event, last_packet_ack);
-    assert_eq!(engine.time_now_ns(), last_event_time as f64);
+    assert_eq!(engine.time_now(), Duration::from_nanos(last_event_time));
 }
 
 #[test]
@@ -102,7 +103,7 @@ fn memory_write() {
     // delay imposed by the data it is carrying
     let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
     let last_event_time = last_bw_limit_event;
-    assert_eq!(engine.time_now_ns(), last_event_time as f64);
+    assert_eq!(engine.time_now(), Duration::from_nanos(last_event_time));
 }
 
 #[test]
@@ -119,7 +120,7 @@ fn memory_write_np() {
     let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
     let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
     let last_event_time = max(last_bw_limit_event, last_packet_ack);
-    assert_eq!(engine.time_now_ns(), last_event_time as f64);
+    assert_eq!(engine.time_now(), Duration::from_nanos(last_event_time));
 }
 
 #[test]
@@ -165,5 +166,5 @@ fn read_becomes_read_response() {
 
     run_simulation!(engine);
 
-    assert_eq!(engine.time_now_ns(), DELAY_TICKS as f64);
+    assert_eq!(engine.time_now(), Duration::from_nanos(DELAY_TICKS as u64));
 }

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -23,10 +23,10 @@ async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/gwr-platform/src/lib.rs
+++ b/gwr-platform/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::fmt::{self, Display};
 use std::path::Path;
 use std::rc::Rc;
+use std::time::Duration;
 
 use gwr_engine::engine::Engine;
 use gwr_engine::sim_error;
@@ -189,12 +190,12 @@ impl Platform {
         }
     }
 
-    pub fn dump_stats(&self, time_now_ns: f64) {
+    pub fn dump_stats(&self, elapsed: Duration) {
         for mem in &self.memories {
-            mem.dump_stats(time_now_ns);
+            mem.dump_stats(elapsed);
         }
         for pe in &self.processing_elements {
-            pe.dump_stats(time_now_ns);
+            pe.dump_stats(elapsed);
         }
     }
 }

--- a/gwr-platform/tests/simple_platforms.rs
+++ b/gwr-platform/tests/simple_platforms.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use gwr_engine::engine::Engine;
@@ -184,7 +185,7 @@ fn simple_pe_mem_one_request() {
 
     // There are two 128 bytes requested over a 32-byte interface. Each request has
     // a 10ns delay.
-    assert_eq!(clock.time_now_ns(), 80.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(80));
 }
 
 #[test]
@@ -194,7 +195,7 @@ fn simple_pe_mem_two_requests() {
     // There are 128 bytes requested over a 32-byte interface with a 10ns delay, but
     // the LSU supports two outstanding requests. So, the first two access take
     // 11ns, but the remainder take 10ns because they overlap.
-    assert_eq!(clock.time_now_ns(), 41.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(41));
 }
 
 #[test]
@@ -252,5 +253,5 @@ connections:
 
     // Expect 4 cache misses which need to go to memory (30ns each)
     // and 4 cache hits (5ns each)
-    assert_eq!(clock.time_now_ns(), 140.0);
+    assert_eq!(clock.time_now(), Duration::from_nanos(140));
 }

--- a/gwr-protocols/Cargo.toml
+++ b/gwr-protocols/Cargo.toml
@@ -23,5 +23,5 @@ paste.workspace = true
 
 [dev-dependencies]
 gwr-components = { path = "../gwr-components", version = "0.8.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }

--- a/gwr-resources/Cargo.toml
+++ b/gwr-resources/Cargo.toml
@@ -19,7 +19,7 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 
 [dev-dependencies]
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }

--- a/gwr-spotter/Cargo.toml
+++ b/gwr-spotter/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-spotter"
-version = "0.8.0"
+version = "0.9.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -22,7 +22,7 @@ publish.workspace = true
 capnp.workspace = true
 clap.workspace = true
 crossterm.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 itertools.workspace = true
 log.workspace = true
 ratatui.workspace = true

--- a/gwr-spotter/frontend/index.html
+++ b/gwr-spotter/frontend/index.html
@@ -48,7 +48,7 @@
             <input id="trace-position" type="range" min="0" max="0" value="0" step="1">
           </li>
           <li class="level2 trace-position-label" id="trace-position-label">
-            0 / 0 @ 0.0ns
+            0 / 0 @ 0ns
           </li>
         </ul>
       </li>

--- a/gwr-spotter/src/app/mod.rs
+++ b/gwr-spotter/src/app/mod.rs
@@ -5,6 +5,7 @@ use std::error;
 use std::path::PathBuf;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::filter::{Filter, start_background_filter};
 use crate::renderer::Renderer;
@@ -21,7 +22,7 @@ pub const CHUNK_SIZE: usize = 50000;
 pub const INITIAL_SIZE: usize = CHUNK_SIZE;
 
 pub trait ToTime {
-    fn time(&self) -> f64;
+    fn time_ns(&self) -> u128;
 }
 
 pub trait ToFullness {
@@ -33,47 +34,47 @@ pub enum EventLine {
     Create {
         // Only need to keep the ID to be rendered.
         id: u64,
-        time: f64,
+        time: Duration,
     },
     Connect {
         from_id: u64,
         to_id: u64,
-        time: f64,
+        time: Duration,
     },
     Log {
         level: log::Level,
         id: u64,
         msg: String,
-        time: f64,
+        time: Duration,
     },
     Enter {
         id: u64,
         entered: u64,
         fullness: u64,
-        time: f64,
+        time: Duration,
     },
     Exit {
         id: u64,
         exited: u64,
         fullness: u64,
-        time: f64,
+        time: Duration,
     },
     Value {
         id: u64,
         value: f64,
-        time: f64,
+        time: Duration,
     },
 }
 
 impl ToTime for EventLine {
-    fn time(&self) -> f64 {
+    fn time_ns(&self) -> u128 {
         match self {
-            EventLine::Create { time, .. } => *time,
-            EventLine::Connect { time, .. } => *time,
-            EventLine::Enter { time, .. } => *time,
-            EventLine::Exit { time, .. } => *time,
-            EventLine::Value { time, .. } => *time,
-            EventLine::Log { time, .. } => *time,
+            EventLine::Create { time, .. } => time.as_nanos(),
+            EventLine::Connect { time, .. } => time.as_nanos(),
+            EventLine::Enter { time, .. } => time.as_nanos(),
+            EventLine::Exit { time, .. } => time.as_nanos(),
+            EventLine::Value { time, .. } => time.as_nanos(),
+            EventLine::Log { time, .. } => time.as_nanos(),
         }
     }
 }

--- a/gwr-spotter/src/bin_loader.rs
+++ b/gwr-spotter/src/bin_loader.rs
@@ -6,6 +6,7 @@ use std::io::BufReader;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use gwr_track::Id;
 use gwr_track::entity::Capacity;
@@ -25,7 +26,7 @@ struct BinLoader {
     id_to_name: Option<HashMap<u64, String>>,
     id_to_details: Option<HashMap<u64, String>>,
     id_to_req_type: Option<HashMap<u64, u8>>,
-    current_time_ns: f64,
+    current_time: Duration,
 }
 
 impl BinLoader {
@@ -39,7 +40,7 @@ impl BinLoader {
             id_to_name: Some(HashMap::new()),
             id_to_details: Some(HashMap::new()),
             id_to_req_type: Some(HashMap::new()),
-            current_time_ns: 0.0,
+            current_time: Duration::new(0, 0),
         }
     }
 
@@ -94,7 +95,7 @@ impl TraceVisitor for BinLoader {
             level,
             id: id.0,
             msg: message.to_owned(),
-            time: self.current_time_ns,
+            time: self.current_time,
         });
     }
 
@@ -110,7 +111,7 @@ impl TraceVisitor for BinLoader {
             .insert(id.0, name.to_owned());
         self.add_event(EventLine::Create {
             id: id.0,
-            time: self.current_time_ns,
+            time: self.current_time,
         });
     }
 
@@ -126,7 +127,7 @@ impl TraceVisitor for BinLoader {
             .insert(id.0, name.to_owned());
         self.add_event(EventLine::Create {
             id: id.0,
-            time: self.current_time_ns,
+            time: self.current_time,
         });
     }
 
@@ -159,7 +160,7 @@ impl TraceVisitor for BinLoader {
         self.id_to_req_type.as_mut().unwrap().insert(id.0, req_type);
         self.add_event(EventLine::Create {
             id: id.0,
-            time: self.current_time_ns,
+            time: self.current_time,
         });
     }
 
@@ -171,7 +172,7 @@ impl TraceVisitor for BinLoader {
             .unwrap()
             .connections
             .push(format!("{connect_from} -> {connect_to}").to_string());
-        let time = self.current_time_ns;
+        let time = self.current_time;
         self.add_event(EventLine::Connect {
             from_id: connect_from.0,
             to_id: connect_to.0,
@@ -195,7 +196,7 @@ impl TraceVisitor for BinLoader {
             }
             *fullness
         };
-        let time = self.current_time_ns;
+        let time = self.current_time;
         self.add_event(EventLine::Enter {
             id: id.0,
             entered: entered.0,
@@ -221,7 +222,7 @@ impl TraceVisitor for BinLoader {
             }
             *fullness
         };
-        let time = self.current_time_ns;
+        let time = self.current_time;
         self.add_event(EventLine::Exit {
             id: id.0,
             exited: exited.0,
@@ -231,7 +232,7 @@ impl TraceVisitor for BinLoader {
     }
 
     fn value(&mut self, id: Id, value: f64) {
-        let time = self.current_time_ns;
+        let time = self.current_time;
         self.add_event(EventLine::Value {
             id: id.0,
             value,
@@ -251,8 +252,8 @@ impl TraceVisitor for BinLoader {
             .set_capacity(id.0, capacity.value as u64, capacity.units);
     }
 
-    fn time(&mut self, _id: Id, time_ns: f64) {
-        self.current_time_ns = time_ns;
+    fn time(&mut self, _id: Id, time: Duration) {
+        self.current_time = time;
     }
 }
 

--- a/gwr-spotter/src/filter.rs
+++ b/gwr-spotter/src/filter.rs
@@ -351,6 +351,7 @@ fn run_filter_pass(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::time::Duration;
 
     use super::SearchState;
     use crate::app::EventLine;
@@ -370,17 +371,20 @@ mod tests {
     fn plain_text_search_matches_numeric_ids() {
         let search_state = build_search_state("41");
 
-        assert!(search_state.search_matches(&EventLine::Create { id: 41, time: 0.0 }));
+        assert!(search_state.search_matches(&EventLine::Create {
+            id: 41,
+            time: Duration::new(0, 0)
+        }));
         assert!(search_state.search_matches(&EventLine::Enter {
             id: 40,
             entered: 41,
             fullness: 1,
-            time: 0.0,
+            time: Duration::new(0, 0),
         }));
         assert!(search_state.search_matches(&EventLine::Connect {
             from_id: 41,
             to_id: 99,
-            time: 0.0,
+            time: Duration::new(0, 0),
         }));
     }
 }

--- a/gwr-spotter/src/log_parser.rs
+++ b/gwr-spotter/src/log_parser.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use itertools::Itertools;
 use log::Level;
@@ -29,7 +30,7 @@ struct LogParser {
     time_re: Regex,
     text_re: Regex,
 
-    current_time: f64,
+    current_time: Duration,
 }
 
 impl LogParser {
@@ -56,7 +57,7 @@ impl LogParser {
             time_re: Regex::new(r"\d+: set time to ([^n]+)ns").unwrap(),
             text_re: Regex::new(r"(\d+): (\d+) entered$").unwrap(),
 
-            current_time: 0.0,
+            current_time: Duration::new(0, 0),
         }
     }
 
@@ -219,7 +220,8 @@ impl LogParser {
             return false;
         };
         let time_str = e.get(1).unwrap().as_str();
-        self.current_time = time_str.parse().unwrap();
+        let nanos: u128 = time_str.parse().unwrap();
+        self.current_time = Duration::from_nanos_u128(nanos);
         true
     }
 
@@ -385,7 +387,7 @@ pub fn start_background_load(
                             level: log::Level::Error,
                             id: 0,
                             msg: e.to_string(),
-                            time: 0.0,
+                            time: Duration::new(0, 0),
                         };
                         events.push(err_line);
                     }

--- a/gwr-spotter/src/perfetto.rs
+++ b/gwr-spotter/src/perfetto.rs
@@ -3,6 +3,7 @@
 use std::fs::File;
 use std::io::{BufReader, Write};
 use std::path::Path;
+use std::time::Duration;
 
 use gwr_track::Id;
 use gwr_track::perfetto_trace_builder::PerfettoTraceBuilder;
@@ -130,8 +131,8 @@ impl TraceVisitor for PerfettoGenerator {
             .expect("`output` should be writable file");
     }
 
-    fn time(&mut self, _id: Id, time_ns: f64) {
-        self.current_time_ns = time_ns as u64;
+    fn time(&mut self, _id: Id, time: Duration) {
+        self.current_time_ns = time.as_nanos().try_into().expect("Simulations should span less time than the maximum range supported by Perfetto timestamps (approximately 584 years)");
     }
 }
 

--- a/gwr-spotter/src/renderer.rs
+++ b/gwr-spotter/src/renderer.rs
@@ -89,7 +89,7 @@ impl Renderer {
     }
 
     /// Return the timestamp for the current rendered line.
-    pub fn current_time(&self) -> f64 {
+    pub fn current_time(&self) -> u128 {
         self.line_time(self.current_absolute_index())
     }
 
@@ -168,11 +168,11 @@ impl Renderer {
         chunk.get(chunk_offset)
     }
 
-    pub fn line_time(&self, line_index: usize) -> f64 {
+    pub fn line_time(&self, line_index: usize) -> u128 {
         if let Some(line) = self.line_from_index(line_index) {
-            line.time()
+            line.time_ns()
         } else {
-            0.0
+            0
         }
     }
 
@@ -226,7 +226,7 @@ impl Renderer {
         let event_line = event_line.unwrap();
         let mut tmp0 = String::new();
         let mut tmp1 = String::new();
-        let (mut line, time) = match event_line {
+        let (mut line, line_time) = match event_line {
             EventLine::Enter {
                 id,
                 entered,
@@ -292,7 +292,7 @@ impl Renderer {
         };
 
         if self.print_times {
-            let _ = write!(line, " @{time:.1}ns");
+            let _ = write!(line, " @{}ns", line_time.as_nanos());
         }
 
         line

--- a/gwr-spotter/src/rocket.rs
+++ b/gwr-spotter/src/rocket.rs
@@ -16,7 +16,7 @@ pub struct SharedState {
     pub selected: Option<u64>,
     pub current_line: usize,
     pub num_lines: usize,
-    pub current_time_ns: f64,
+    pub current_time_ns: u128,
     pub seek_line: Option<usize>,
 }
 
@@ -31,7 +31,7 @@ impl SharedState {
             selected: None,
             current_line: 0,
             num_lines: 0,
-            current_time_ns: 0.0,
+            current_time_ns: 0,
             seek_line: None,
         }
     }
@@ -45,7 +45,7 @@ impl SharedState {
         self.selected = None;
         self.current_line = 0;
         self.num_lines = 0;
-        self.current_time_ns = 0.0;
+        self.current_time_ns = 0;
         self.seek_line = None;
     }
 }

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -22,11 +22,11 @@ publish.workspace = true
 async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.16.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.3.0" }
-gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true
 rand.workspace = true

--- a/gwr-timetable/src/main.rs
+++ b/gwr-timetable/src/main.rs
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
         return Err(err.into());
     }
 
-    println!("Ran simulation. Time now {}ns", clock.time_now_ns());
+    println!("Ran simulation. Time now {clock:.2}");
 
     if let Err(err) = timetable.check_tasks_complete() {
         write_error_mermaid(&timetable, &args.error_mermaid);
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
 
     if args.dump_stats {
         timetable.dump_stats()?;
-        platform.dump_stats(clock.time_now_ns());
+        platform.dump_stats(clock.time_now());
     }
 
     Ok(())

--- a/gwr-track/Cargo.toml
+++ b/gwr-track/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-track"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-track/schemas/gwr_track.capnp
+++ b/gwr-track/schemas/gwr_track.capnp
@@ -47,12 +47,17 @@ struct Create @0xc95443fd58b475bb {
   id        @0 :UInt64;
 }
 
+struct Duration @0xbb9dea1ae271789d {
+  nanosecs @1  :UInt32;
+  seconds  @0  :UInt32; # Approximately 136 years of range
+}
+
 struct Event @0xc13b4d9cc5ead95b {
   union {
     capacity @9 :Capacity;
     value   @8  :Float64;
     connect @7  :UInt64;
-    time    @6  :Float64;
+    time    @6  :Duration;
     enter   @5  :UInt64;
     exit    @4  :UInt64;
     destroy @3  :UInt64;

--- a/gwr-track/src/test_helpers.rs
+++ b/gwr-track/src/test_helpers.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::io::BufWriter;
 use std::path::Path;
 use std::rc::Rc;
+use std::time::Duration;
 
 use regex::Regex;
 
@@ -123,8 +124,8 @@ impl Track for TestTracker {
         self.add_event(format!("{id}:{level}: {msg}"));
     }
 
-    fn time(&self, set_by: Id, time_ns: f64) {
-        self.add_event(format!("{set_by}: set time {time_ns:.1}ns"));
+    fn time(&self, set_by: Id, time: Duration) {
+        self.add_event(format!("{set_by}: set time {}ns", time.as_nanos()));
     }
 
     fn shutdown(&self) {

--- a/gwr-track/src/trace_visitor.rs
+++ b/gwr-track/src/trace_visitor.rs
@@ -4,6 +4,7 @@
 //! data.
 
 use std::io::BufRead;
+use std::time::Duration;
 
 use capnp::serialize_packed;
 
@@ -161,11 +162,11 @@ pub trait TraceVisitor {
     /// # Arguments
     ///
     /// * `id` - The originator of this event.
-    /// * `time_ns` - The new simulation time in `ns`.
-    fn time(&mut self, id: Id, time_ns: f64) {
+    /// * `time` - The new simulation time.
+    fn time(&mut self, id: Id, time: Duration) {
         // Remove the unused variable warnings
         let _ = id;
-        let _ = time_ns;
+        let _ = time;
     }
 }
 
@@ -360,8 +361,16 @@ fn handle_capacity(
     );
 }
 
-fn handle_time(visitor: &mut dyn TraceVisitor, id: Id, time: f64) {
-    visitor.time(id, time);
+fn handle_time(
+    visitor: &mut dyn TraceVisitor,
+    id: Id,
+    time: capnp::Result<gwr_track_capnp::duration::Reader<'_>>,
+) {
+    let time = time.expect("should be able to parse Duration");
+    visitor.time(
+        id,
+        Duration::new(time.get_seconds().into(), time.get_nanosecs()),
+    );
 }
 
 fn to_log_level(level: LogLevel) -> log::Level {

--- a/gwr-track/src/tracker/capnp.rs
+++ b/gwr-track/src/tracker/capnp.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Duration;
 
 use capnp::serialize_packed;
 
@@ -180,9 +181,11 @@ impl Track for CapnProtoTracker {
         }
     }
 
-    fn time(&self, set_by: Id, time_ns: f64) {
-        self.write_event(set_by, |mut event| {
-            event.set_time(time_ns);
+    fn time(&self, set_by: Id, time: Duration) {
+        self.write_event(set_by, |event| {
+            let mut duration = event.init_time();
+            duration.set_seconds(time.as_secs().try_into().expect("Simulations should span less time than the maximum range supported by GWR Track Durations (approximately 136 years)"));
+            duration.set_nanosecs(time.subsec_nanos());
         });
     }
 

--- a/gwr-track/src/tracker/dev_null.rs
+++ b/gwr-track/src/tracker/dev_null.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020 Graphcore Ltd. All rights reserved.
 
 use std::str::FromStr;
+use std::time::Duration;
 
 use crate::Id;
 use crate::entity::Capacity;
@@ -42,7 +43,7 @@ impl Track for DevNullTracker {
     fn destroy(&self, _id: Id, _obj: Id) {}
     fn connect(&self, _connect_from: Id, _connect_to: Id) {}
     fn log(&self, _id: Id, _level: log::Level, _msg: std::fmt::Arguments) {}
-    fn time(&self, _set_by: Id, _time_ns: f64) {}
+    fn time(&self, _set_by: Id, _time: Duration) {}
     fn shutdown(&self) {}
 }
 

--- a/gwr-track/src/tracker/mod.rs
+++ b/gwr-track/src/tracker/mod.rs
@@ -23,6 +23,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io;
 use std::rc::Rc;
+use std::time::Duration;
 
 pub use capnp::CapnProtoTracker;
 pub use dev_null::DevNullTracker;
@@ -91,8 +92,8 @@ pub trait Track {
     /// Track a log message of the given level.
     fn log(&self, msg_by: Id, level: log::Level, msg: std::fmt::Arguments);
 
-    /// Advance the time to the time specified in `ns`.
-    fn time(&self, set_by: Id, time_ns: f64);
+    /// Advance the time to the time specified.
+    fn time(&self, set_by: Id, time: Duration);
 
     /// Perform any pre-exit shutdown/cleanup
     fn shutdown(&self);

--- a/gwr-track/src/tracker/multi_tracker.rs
+++ b/gwr-track/src/tracker/multi_tracker.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+use std::time::Duration;
+
 use crate::Id;
 use crate::entity::Capacity;
 use crate::tracker::aka::AlternativeNames;
@@ -126,9 +128,9 @@ impl Track for MultiTracker {
         }
     }
 
-    fn time(&self, set_by: Id, time_ns: f64) {
+    fn time(&self, set_by: Id, time: Duration) {
         for tracker in &self.trackers {
-            tracker.time(set_by, time_ns);
+            tracker.time(set_by, time);
         }
     }
 

--- a/gwr-track/src/tracker/perfetto.rs
+++ b/gwr-track/src/tracker/perfetto.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Duration;
 
 use crate::entity::Capacity;
 use crate::perfetto_trace_builder::PerfettoTraceBuilder;
@@ -152,8 +153,8 @@ impl Track for PerfettoTracker {
         // todo!()
     }
 
-    fn time(&self, _set_by: Id, time_ns: f64) {
-        *self.current_time_ns.borrow_mut() = time_ns as u64;
+    fn time(&self, _set_by: Id, time: Duration) {
+        *self.current_time_ns.borrow_mut() = time.as_nanos().try_into().expect("");
     }
 
     fn shutdown(&self) {

--- a/gwr-track/src/tracker/text.rs
+++ b/gwr-track/src/tracker/text.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Duration;
 
 pub use log;
 
@@ -154,11 +155,11 @@ impl Track for TextTracker {
         }
     }
 
-    fn time(&self, set_by: Id, time_ns: f64) {
+    fn time(&self, set_by: Id, time: Duration) {
         if self.is_entity_enabled(set_by, log::Level::Trace) {
             self.writer
                 .borrow_mut()
-                .write_all(format!("{set_by}: set time to {time_ns:.1}ns\n").as_bytes())
+                .write_all(format!("{set_by}: set time to {}ns\n", time.as_nanos()).as_bytes())
                 .unwrap();
         }
     }

--- a/gwr-track/tests/smoke_macros.rs
+++ b/gwr-track/tests/smoke_macros.rs
@@ -4,6 +4,7 @@
 
 use std::fmt::Display;
 use std::rc::Rc;
+use std::time::Duration;
 
 use gwr_track::entity::{Entity, toplevel};
 use gwr_track::id::Unique;
@@ -135,6 +136,6 @@ fn set_time() {
     let top = toplevel(&tracker, "top");
     test_helpers::check_and_clear(&test_tracker, &["0: created entity 321, top"]);
 
-    set_time!(top ; 10.0);
-    test_helpers::check_and_clear(&test_tracker, &["321: set time 10.0ns"]);
+    set_time!(top ; Duration::from_nanos(10));
+    test_helpers::check_and_clear(&test_tracker, &["321: set time 10ns"]);
 }

--- a/licenses.html
+++ b/licenses.html
@@ -8345,7 +8345,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-developer-guide 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-doc-builder 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-docpp 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.11.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.12.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-model-builder 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.16.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx 0.1.0</a></li>
@@ -8355,10 +8355,10 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.3.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.8.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.9.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-terminus 0.3.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-timetable 0.2.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.11.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.12.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 


### PR DESCRIPTION
The gwr-engine now uses the std::time::Duration type, instead of f64, to
represent durations during simulations.

As std::time::Duration does not implement std::fmt::Display the
gwr-engine::time::duration modules provides the AppropriateUnitDisplay
trait, with an implementation of this for std::fmt::Display. An
implementation of AppropriateUnitDisplay for std::time::Duration then
allows durations to be displayed using, for example,
`println!("{}", &Duration::new(1, 0) as &dyn AppropriateUnitDisplay);`.

The Duration type added to the gwr_track.capnp schema allows
serialisation of std::time::Durations, up to a maximum of approximately
136 years, as it represents the seconds component as a u32 rather than
as a u64. This to avoid inflating the size of binary trace files whilst
there is no current known use case for simulations spanning larger
timescales.

Perfetto traces use a u64 to represent nanosecond durations, which
allow for simulations spanning almost 584 years.

For reference, the std::time::Duration type uses a u64 to represent
the second component so within gwr-engine simulations can theoretically
span almost 584 billion years...