### PR TITLE
feat: Add support for emitting entity capacity.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-spotter"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "capnp",
  "clap",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-track"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/examples/flaky-component/Cargo.toml
+++ b/examples/flaky-component/Cargo.toml
@@ -24,5 +24,5 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../../gwr-track", version = "0.9.0" }
 rand.workspace = true

--- a/examples/flaky-with-delay/Cargo.toml
+++ b/examples/flaky-with-delay/Cargo.toml
@@ -24,5 +24,5 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../../gwr-track", version = "0.9.0" }
 rand.workspace = true

--- a/examples/scrambler/Cargo.toml
+++ b/examples/scrambler/Cargo.toml
@@ -24,4 +24,4 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../../gwr-track", version = "0.9.0" }

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -25,7 +25,7 @@ gwr-components = { path = "../../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.8.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.9.0" }
 indicatif.workspace = true
 log.workspace = true
 rand_xoshiro = "0.7.0"

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -25,7 +25,7 @@ gwr-components = { path = "../../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.8.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.9.0" }
 indicatif.workspace = true
 log.workspace = true
 serde.workspace = true

--- a/examples/sim-restaurant/Cargo.toml
+++ b/examples/sim-restaurant/Cargo.toml
@@ -22,7 +22,7 @@ crossterm.workspace = true
 futures.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.8.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.9.0" }
 log.workspace = true
 rand.workspace = true
 ratatui.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -24,6 +24,6 @@ gwr-components = { path = "../../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.8.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.9.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/gwr-components/Cargo.toml
+++ b/gwr-components/Cargo.toml
@@ -32,7 +32,7 @@ futures.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../gwr-track", version = "0.9.0" }
 log.workspace = true
 paste.workspace = true
 

--- a/gwr-components/src/queue.rs
+++ b/gwr-components/src/queue.rs
@@ -50,8 +50,13 @@ where
             return sim_error!("Unsupported Queue with 0 capacity");
         }
 
+        let entity = Rc::new(Entity::new(parent, name));
+        if let Some(capacity) = capacity {
+            entity.track_capacity(capacity, "objects");
+        }
+
         Ok(Self {
-            entity: Rc::new(Entity::new(parent, name)),
+            entity,
             capacity,
             data: RefCell::new(VecDeque::new()),
             queue_changed: Repeated::default(),

--- a/gwr-components/src/store.rs
+++ b/gwr-components/src/store.rs
@@ -234,6 +234,7 @@ where
             return sim_error!("Unsupported Store with 0 capacity");
         }
         let entity = Rc::new(Entity::new(parent, name));
+        entity.track_capacity(capacity, "objects");
         let state = Rc::new(State::new(&entity, capacity));
         let tx = OutPort::new_with_renames(&entity, "tx", aka);
         let rx = InPort::new_with_renames(engine, clock, &entity, "rx", aka);

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 futures.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../gwr-track", version = "0.9.0" }
 log.workspace = true
 mimalloc = { version = "0.1.48", features = ["v3"], optional = true }
 rand.workspace = true

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -34,7 +34,7 @@ gwr-components = { path = "../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../gwr-track", version = "0.9.0" }
 log.workspace = true
 paste.workspace = true
 rand.workspace = true

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -26,7 +26,7 @@ gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.16.0" }
-gwr-track = { path = "../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../gwr-track", version = "0.9.0" }
 log.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/gwr-protocols/Cargo.toml
+++ b/gwr-protocols/Cargo.toml
@@ -24,4 +24,4 @@ paste.workspace = true
 [dev-dependencies]
 gwr-components = { path = "../gwr-components", version = "0.8.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
-gwr-track = { path = "../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../gwr-track", version = "0.9.0" }

--- a/gwr-resources/Cargo.toml
+++ b/gwr-resources/Cargo.toml
@@ -22,4 +22,4 @@ publish.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
 
 [dev-dependencies]
-gwr-track = { path = "../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../gwr-track", version = "0.9.0" }

--- a/gwr-spotter/Cargo.toml
+++ b/gwr-spotter/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-spotter"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -22,7 +22,7 @@ publish.workspace = true
 capnp.workspace = true
 clap.workspace = true
 crossterm.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.8.0" }
+gwr-track = { path = "../gwr-track", version = "0.9.0" }
 itertools.workspace = true
 log.workspace = true
 ratatui.workspace = true

--- a/gwr-spotter/frontend/index.html
+++ b/gwr-spotter/frontend/index.html
@@ -35,7 +35,23 @@
               <select id="plot"></select>
             </a>
           </li>
+        </ul>
+      </li>
 
+      <li class="level1 trace-position">
+        <a href="#" class="trace-position-btn">Trace position
+          <span class="fas fa-caret-down trace-position">+</span>
+        </a>
+        <ul class="trace-position-show level2 show rotate">
+          <li class="level2 trace-position-control">
+            <label for="trace-position">Line</label>
+            <input id="trace-position" type="range" min="0" max="0" value="0" step="1">
+          </li>
+          <li class="level2 trace-position-label" id="trace-position-label">
+            0 / 0 @ 0.0ns
+          </li>
+        </ul>
+      </li>
     </ul>
   </nav>
 
@@ -50,6 +66,11 @@ $('.menu-btn').click(function() {
   $('.chart-type-btn').click(function() {
     $('nav ul .chart-type-show').toggleClass("show");
     $('nav ul .chart-type').toggleClass("rotate");
+  });
+
+  $('.trace-position-btn').click(function() {
+    $('nav ul .trace-position-show').toggleClass("show");
+    $('nav ul .trace-position').toggleClass("rotate");
   });
 
   /***********************************************************************
@@ -98,6 +119,10 @@ $('.menu-btn').click(function() {
   const renderer = new Renderer(serverUrl);
   const controls = renderer.controls;
   const guiElements = renderer.guiElements;
+  renderer.set_position_controls(
+      d3.select("#trace-position"),
+      d3.select("#trace-position-label"));
+  renderer.start_position_sync();
 
   // Setup all the different color scales that are available
   const plotElement = d3.select(`#plot`);
@@ -135,21 +160,19 @@ function redraw() {
   renderer.render();
 }
 
-d3.text(serverUrl + "/entities")
-    .then(function(text) {
-      let root = []
-      let max_depth = parse_entities(text, root);
+Promise.all([
+  d3.text(serverUrl + "/capacities"),
+  d3.text(serverUrl + "/entities"),
+  d3.text(serverUrl + "/connections"),
+])
+    .then(function([capacity_text, entity_text, connection_text]) {
+      const capacities = parse_capacities(capacity_text);
+      const root = [];
+      const max_depth = parse_entities(entity_text, root, capacities);
+      const connections = parse_connections(connection_text);
       renderer.set_entities(root[0], max_depth);
-
-      d3.text(serverUrl + "/connections")
-          .then(function(text) {
-            let connections = parse_connections(text);
-            renderer.set_connections(connections);
-            renderer.render();
-          })
-          .catch(function(error) {
-            console.log(error);
-          });
+      renderer.set_connections(connections);
+      renderer.render();
     })
     .catch(function(error) {
       console.log(error);

--- a/gwr-spotter/frontend/lib/force_tree.js
+++ b/gwr-spotter/frontend/lib/force_tree.js
@@ -43,6 +43,53 @@ function define_arrow(svg) {
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+function force_tree_fill(d) {
+  if (d.data.capacity > 0) {
+    return fullness_color(fullness_ratio(d.data, d.data.capacity));
+  }
+
+  return d.children ? null : "#000";
+}
+
+function force_tree_stroke(d) {
+  if (d.data.capacity > 0) {
+    return "#202020";
+  }
+
+  return d.children ? null : "#fff";
+}
+
+function force_tree_opacity(d) {
+  if (d.data.capacity > 0) {
+    return 1;
+  }
+
+  return d.children ? 0.5 : 1;
+}
+
+function force_tree_title(d) {
+  if (d.data.capacity > 0) {
+    const format = d3.format(",d");
+    const units = d.data.capacity_units ? ` ${d.data.capacity_units}` : "";
+    const percentage = d3.format(".1%")(fullness_ratio(d.data, d.data.capacity));
+    return `${d.data.full_name}\n${format(d.data.capacity)}${units} capacity\n${format(d.data.fullness || 0)} full (${percentage})`;
+  }
+
+  return d.data.full_name;
+}
+
+function update_force_tree_fullness() {
+  d3.select(`#${chartElement}`)
+      .selectAll("circle.node")
+      .attr("fill", force_tree_fill)
+      .attr("stroke", force_tree_stroke)
+      .attr("opacity", force_tree_opacity);
+
+  d3.select(`#${chartElement}`)
+      .selectAll("circle.node title")
+      .text(force_tree_title);
+}
+
 function force_tree(serverUrl, data, connections, max_depth) {
   // Specify the chart’s dimensions.
   var chartDiv = document.getElementById(chartElement);
@@ -121,14 +168,14 @@ function force_tree(serverUrl, data, connections, max_depth) {
       .each(d => d.id = `node_${d.data.id}`)
       .attr("id", d => d.id)
       .attr("class", "node")
-      .attr("fill", d => d.children ? null : "#000")
-      .attr("stroke", d => d.children ? null : "#fff")
-      .attr("opacity", d => d.children ? 0.5 : 1)
+      .attr("fill", force_tree_fill)
+      .attr("stroke", force_tree_stroke)
+      .attr("opacity", force_tree_opacity)
       .attr("r", d => d.r)
       .call(drag(simulation));
 
   node.append("title")
-      .text(d => d.data.full_name);
+      .text(force_tree_title);
 
   // When clicking on a block highlight it by setting the "selected" class
   node.on("click", d => select_and_send(serverUrl, svg, d.target.id, d.target.__data__.data.id));

--- a/gwr-spotter/frontend/lib/tree_map.js
+++ b/gwr-spotter/frontend/lib/tree_map.js
@@ -16,12 +16,44 @@
 // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+function tree_map_fill(d, hierarchyColor) {
+  if (d.value > 0 && d.data.fullness != undefined) {
+    return fullness_color(fullness_ratio(d.data, d.value));
+  }
+
+  return hierarchyColor(d.height);
+}
+
+function tree_map_title(d, format) {
+  const capacity = format(d.value || d.data.capacity || 0);
+  const units = d.data.capacity_units ? ` ${d.data.capacity_units}` : "";
+  const fullness = format(d.data.fullness || 0);
+  const percentage = d3.format(".1%")(fullness_ratio(d.data, d.value));
+  return `${d.data.full_name}\n${capacity}${units} capacity\n${fullness} full (${percentage})`;
+}
+
+function update_tree_map_fullness() {
+  const hierarchyColor = d3.scaleSequential([0, 8], d3.interpolateGnBu);
+  const format = d3.format(",d");
+
+  d3.select(`#${chartElement}`)
+      .selectAll("rect.node")
+      .attr("fill", d => tree_map_fill(d, hierarchyColor));
+
+  d3.select(`#${chartElement}`)
+      .selectAll("g.tree-map-node title")
+      .text(d => tree_map_title(d, format));
+}
+
 function tree_map(serverUrl, data) {
   var chartDiv = document.getElementById(chartElement);
   var width = Math.max(600, chartDiv.clientWidth);
   var height = Math.max(400, chartDiv.clientHeight - buttonBarPadding);
 
-  const color = d3.scaleSequential([0, 8], d3.interpolateGnBu);
+  const hierarchyColor = d3.scaleSequential([0, 8], d3.interpolateGnBu);
+  const hasCapacity = d3.hierarchy(data)
+      .descendants()
+      .some(d => d.data.capacity> 0);
 
   // Create the treemap layout.
   const treemap = data => d3.treemap()
@@ -31,7 +63,7 @@ function tree_map(serverUrl, data) {
     .paddingInner(1)
     .round(true)
   (d3.hierarchy(data)
-      .sum(d => d.value)
+      .sum(d => hasCapacity ? d.capacity: d.value)
       .sort((a, b) => b.value - a.value));
   const root = treemap(data);
 
@@ -61,16 +93,17 @@ function tree_map(serverUrl, data) {
     .data(d => d[1])
     .join("g")
       .attr("transform", d => `translate(${d.x0},${d.y0})`)
+      .attr("class", "tree-map-node")
       .on("click", (event, d) => select_and_send(serverUrl, svg, d.id, d.data.id));
 
   const format = d3.format(",d");
   node.append("title")
-      .text(d => d.data.full_name);
+      .text(d => tree_map_title(d, format));
 
   node.append("rect")
       .attr("id", d => (d.id = `node_${d.data.id}`))
       .attr("class", "node")
-      .attr("fill", d => color(d.height))
+      .attr("fill", d => tree_map_fill(d, hierarchyColor))
       .attr("width", d => d.x1 - d.x0)
       .attr("height", d => d.y1 - d.y0);
 

--- a/gwr-spotter/frontend/main.js
+++ b/gwr-spotter/frontend/main.js
@@ -1,11 +1,12 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
 // Add an entity within a hierarchical tree of nodes
-function add_entity(depth, nodes, path_remaining, full_name, id) {
+function add_entity(depth, nodes, path_remaining, full_name, id, capacities) {
   if (path_remaining.length == 0) {
     return nodes;
   }
 
+  const is_leaf = path_remaining.length == 1;
   const name = path_remaining[0];
   path_remaining = path_remaining.slice(1);
 
@@ -22,9 +23,21 @@ function add_entity(depth, nodes, path_remaining, full_name, id) {
       name: name,
       full_name: full_name,
       depth: depth,
-      id: id,
+      id: is_leaf ? id : undefined,
+      capacity: 0,
+      capacity_units: "",
     }
     nodes.push(node);
+  }
+
+  if (is_leaf && id != undefined) {
+    node.id = id;
+  }
+
+  if (is_leaf && id != undefined && capacities.has(id)) {
+    const capacity = capacities.get(id);
+    node.capacity = capacity.value;
+    node.capacity_units = capacity.units;
   }
 
   if (Object.hasOwn(node, "children")) {
@@ -32,7 +45,7 @@ function add_entity(depth, nodes, path_remaining, full_name, id) {
   } else {
     children = [];
   }
-  children = add_entity(depth + 1, children, path_remaining, full_name, id);
+  children = add_entity(depth + 1, children, path_remaining, full_name, id, capacities);
 
   if (children.length > 0) {
     node.children = children;
@@ -113,14 +126,17 @@ function set_initial_xy(node, min_x, max_x, min_y, max_y) {
 
 // Parse create messages of the form:
 //   hierarchical::name=id
-function parse_entities(text, entities) {
+function parse_entities(text, entities, capacities) {
   const lines = text.split("\n");
   let max_depth = 0;
   lines.forEach(function(line) {
+    if (line.trim().length == 0) {
+      return;
+    }
     const [name, id] = line.split("=");
     const name_path = name.split("::");
     max_depth = Math.max(max_depth, name_path.length);
-    add_entity(0, entities, name_path, name, id);
+    add_entity(0, entities, name_path, name, id, capacities);
   });
 
   annotate_num_children(entities[0]);
@@ -128,6 +144,77 @@ function parse_entities(text, entities) {
   let max_xy = entities[0].num_children * 10;
   set_initial_xy(entities[0], 0, max_xy, 0, max_xy);
   return max_depth - 1;
+}
+
+// Parse capacity messages of the form:
+//   id=capacity,units
+// Older servers may still send:
+//   id=capacity
+function parse_capacities(text) {
+  let capacities = new Map();
+  const lines = text.split("\n");
+  lines.forEach(function(line) {
+    if (line.trim().length == 0) {
+      return;
+    }
+    const [id, capacity_str] = line.split("=");
+    const [value_str, units = ""] = capacity_str.split(",");
+    const value = Number(value_str);
+    if (!Number.isNaN(value)) {
+      capacities.set(id.trim(), {
+        value: value,
+        units: units.trim(),
+      });
+    }
+  });
+  return capacities;
+}
+
+// Parse fullness messages of the form:
+//   id=fullness
+function parse_fullnesses(text) {
+  let fullnesses = new Map();
+  const lines = text.split("\n");
+  lines.forEach(function(line) {
+    if (line.trim().length == 0) {
+      return;
+    }
+    const [id, fullness_str] = line.split("=");
+    const fullness = Number(fullness_str);
+    if (!Number.isNaN(fullness)) {
+      fullnesses.set(id.trim(), fullness);
+    }
+  });
+  return fullnesses;
+}
+
+function apply_fullnesses(node, fullnesses) {
+  let fullness = 0;
+  if (node.id != undefined) {
+    fullness += fullnesses.get(String(node.id)) || 0;
+  }
+
+  (node.children || []).forEach(function(child) {
+    fullness += apply_fullnesses(child, fullnesses);
+  });
+
+  node.fullness = fullness;
+  return fullness;
+}
+
+function fullness_ratio(data, capacity) {
+  if (capacity <= 0) {
+    return 0.0;
+  }
+
+  return Math.min(1.0, Math.max(0.0, (data.fullness || 0) / capacity));
+}
+
+function fullness_color(ratio) {
+  return d3.scaleLinear()
+      .domain([0.0, 0.5, 1.0])
+      .range(["#35a853", "#f2c14e", "#d64545"])
+      .clamp(true)(ratio);
 }
 
 function add_connection(connections, line_data) {
@@ -146,9 +233,46 @@ function parse_connections(text) {
   let connections = [];
   const lines = text.split("\n")
   lines.forEach(function(line) {
+    if (line.trim().length == 0) {
+      return;
+    }
     add_connection(connections, line.split("->"));
   });
   return connections;
+}
+
+// Parse position messages of the form:
+//   line=123
+//   lines=456
+//   time=78.9
+function parse_position(text) {
+  const position = {
+    line: 0,
+    lines: 0,
+    time: 0.0,
+  };
+
+  text.split("\n").forEach(function(line) {
+    const [key, value] = line.split("=");
+    if (key == "line") {
+      position.line = Number(value);
+    } else if (key == "lines") {
+      position.lines = Number(value);
+    } else if (key == "time") {
+      position.time = Number(value);
+    }
+  });
+
+  if (Number.isNaN(position.line)) {
+    position.line = 0;
+  }
+  if (Number.isNaN(position.lines)) {
+    position.lines = 0;
+  }
+  if (Number.isNaN(position.time)) {
+    position.time = 0.0;
+  }
+  return position;
 }
 
 //---------------------------------------------------------------------------------------
@@ -170,6 +294,20 @@ class Renderer {
     this.max_depth = 0;
     this.connections = null;
     this.simulation = null;
+    this.positionSlider = null;
+    this.positionLabel = null;
+    this.positionPoll = null;
+    this.positionSeekTimer = null;
+    this.positionUserActive = false;
+    this.pendingSeekLine = null;
+    this.pendingSeekStartedAt = 0;
+    this.pendingSeekTimeoutMs = 2000;
+    this.fullnesses = new Map();
+    this.lastPosition = {
+      line: 0,
+      lines: 0,
+      time: 0.0,
+    };
   }
 
   /**
@@ -213,6 +351,136 @@ class Renderer {
     this.connections = connections;
   }
 
+  set_fullnesses(fullnesses) {
+    this.fullnesses = fullnesses;
+    if (this.entities != null) {
+      apply_fullnesses(this.entities, fullnesses);
+      if (this.controls.plot.value == "tree_map") {
+        update_tree_map_fullness(this.entities);
+      } else if (this.controls.plot.value == "force_tree") {
+        update_force_tree_fullness(this.entities);
+      }
+    }
+  }
+
+  set_position_controls(slider, label) {
+    this.positionSlider = slider;
+    this.positionLabel = label;
+
+    const renderer = this;
+    slider.on("input", function() {
+      renderer.positionUserActive = true;
+      const line = Number(slider.property("value"));
+      renderer._render_position({
+        line: line,
+        lines: renderer.lastPosition.lines,
+        time: renderer.lastPosition.time,
+      });
+      renderer._debounced_seek(line);
+    });
+    slider.on("change", function() {
+      const line = Number(slider.property("value"));
+      renderer._seek(line);
+      renderer.positionUserActive = false;
+    });
+    slider.on("pointerdown", function() {
+      renderer.positionUserActive = true;
+    });
+    slider.on("pointerup", function() {
+      const line = Number(slider.property("value"));
+      renderer._seek(line);
+      renderer.positionUserActive = false;
+    });
+  }
+
+  start_position_sync() {
+    if (this.positionPoll != null) {
+      return;
+    }
+
+    this._poll_position();
+    this.positionPoll = setInterval(() => this._poll_position(), 500);
+  }
+
+  _poll_position() {
+    if (this.positionSlider == null) {
+      return;
+    }
+
+    Promise.all([
+      d3.text(this.serverUrl + "/position"),
+      d3.text(this.serverUrl + "/fullnesses"),
+    ])
+        .then(([positionText, fullnessText]) => {
+          const position = parse_position(positionText);
+          if (!this._server_position_is_current(position)) {
+            return;
+          }
+
+          this.lastPosition = position;
+          this.set_fullnesses(parse_fullnesses(fullnessText));
+          if (!this.positionUserActive) {
+            this._render_position(position);
+          }
+        })
+        .catch(function(error) {
+          console.log(error);
+        });
+  }
+
+  _server_position_is_current(position) {
+    if (this.pendingSeekLine == null) {
+      return true;
+    }
+
+    if (position.line == this.pendingSeekLine) {
+      this.pendingSeekLine = null;
+      return true;
+    }
+
+    // If something went wrong or the TUI clamped differently, eventually trust
+    // the server again rather than freezing the control forever.
+    if (Date.now() - this.pendingSeekStartedAt > this.pendingSeekTimeoutMs) {
+      this.pendingSeekLine = null;
+      return true;
+    }
+
+    return false;
+  }
+
+  _render_position(position) {
+    if (this.positionSlider == null || this.positionLabel == null) {
+      return;
+    }
+
+    const maxLine = Math.max(0, position.lines);
+    const line = Math.min(Math.max(0, position.line), maxLine);
+    this.positionSlider
+        .attr("min", maxLine > 0 ? 1 : 0)
+        .attr("max", maxLine)
+        .property("value", line);
+    this.positionLabel.text(`${line} / ${maxLine} @ ${position.time.toFixed(1)}ns`);
+  }
+
+  _debounced_seek(line) {
+    clearTimeout(this.positionSeekTimer);
+    this.positionSeekTimer = setTimeout(() => this._seek(line), 80);
+  }
+
+  _seek(line) {
+    if (Number.isNaN(line)) {
+      return;
+    }
+
+    this.pendingSeekLine = line;
+    this.pendingSeekStartedAt = Date.now();
+
+    d3.text(this.serverUrl + `/seek/${line}`)
+        .catch(function(error) {
+          console.log(error);
+        });
+  }
+
   render() {
     if (this.entities == null) {
       console.log("Nothing to render");
@@ -229,6 +497,7 @@ class Renderer {
     const controls = this.controls;
     const guiElements = this.guiElements;
     const plot = guiElements.plotTypes.get(controls.plot.value);
+    apply_fullnesses(this.entities, this.fullnesses);
     this.simulation = plot(this.serverUrl, this.entities, this.connections, this.max_depth);
   }
 }

--- a/gwr-spotter/frontend/style.css
+++ b/gwr-spotter/frontend/style.css
@@ -192,6 +192,31 @@ li.level2 select {
   width: 50%;
 }
 
+li.trace-position-control {
+  color: var(--color-light);
+  padding: 10px 20px 4px 40px;
+  line-height: 24px;
+}
+
+li.trace-position-control label {
+  display: block;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+li.trace-position-control input {
+  left: 0;
+  width: 100%;
+  accent-color: var(--color-hover);
+}
+
+li.trace-position-label {
+  color: var(--color-light);
+  font-size: 14px;
+  line-height: 24px;
+  padding: 0 20px 12px 40px;
+}
+
 /***********************************************************************
  * Properties of the chart render area needed to make it play nicely
  * with the sidebar

--- a/gwr-spotter/src/app/mod.rs
+++ b/gwr-spotter/src/app/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+use std::collections::HashMap;
 use std::error;
 use std::path::PathBuf;
 use std::sync::mpsc::channel;
@@ -110,6 +111,10 @@ pub struct App {
     pub filter: Arc<Mutex<Filter>>,
     pub input_state: InputState,
     pub numbers: String,
+    trace_absolute_index: usize,
+    last_renderer_absolute_index: Option<usize>,
+    fullness_absolute_index: Option<usize>,
+    fullness_by_id: HashMap<u64, u64>,
 }
 
 impl App {
@@ -141,6 +146,10 @@ impl App {
             filter,
             input_state: InputState::Default,
             numbers: String::new(),
+            trace_absolute_index: 0,
+            last_renderer_absolute_index: None,
+            fullness_absolute_index: None,
+            fullness_by_id: HashMap::new(),
         }
     }
 
@@ -152,7 +161,14 @@ impl App {
             // Move to the top. Otherwise the current line index is often after
             // the matching lines.
             self.move_top();
+            self.note_renderer_position_without_moving_trace();
         }
+
+        if let Some(line_number) = SHARED_STATE.lock().unwrap().seek_line.take() {
+            self.move_to_absolute_line(line_number);
+        }
+
+        self.publish_position();
     }
 
     /// Set running to false to quit the application.
@@ -168,6 +184,23 @@ impl App {
     pub fn move_bottom(&mut self) {
         let mut guard = self.renderer.lock().unwrap();
         guard.move_bottom();
+    }
+
+    pub fn move_to_line(&mut self, line_number: usize) {
+        let mut guard = self.renderer.lock().unwrap();
+        guard.move_to_index(line_number.saturating_sub(1));
+    }
+
+    pub fn move_to_absolute_line(&mut self, line_number: usize) {
+        self.trace_absolute_index = line_number.saturating_sub(1);
+        let mut guard = self.renderer.lock().unwrap();
+        guard.move_to_absolute_index(line_number.saturating_sub(1));
+        self.last_renderer_absolute_index = Some(guard.current_absolute_index());
+    }
+
+    fn note_renderer_position_without_moving_trace(&mut self) {
+        let renderer = self.renderer.lock().unwrap();
+        self.last_renderer_absolute_index = Some(renderer.current_absolute_index());
     }
 
     pub fn move_down_lines(&mut self, num_lines: usize) {
@@ -194,9 +227,7 @@ impl App {
 
     pub fn move_to_number(&mut self) {
         if let Ok(line_number) = self.numbers.parse::<usize>() {
-            let mut guard = self.renderer.lock().unwrap();
-            // Position is 0-based while line numbers are not (hence -1).
-            guard.move_to_index(line_number - 1);
+            self.move_to_line(line_number);
         }
         self.numbers.clear();
     }
@@ -213,9 +244,45 @@ impl App {
         if let Ok(percent) = self.numbers.parse::<usize>() {
             let mut guard = self.renderer.lock().unwrap();
             let line_number = guard.num_render_lines * percent / 100;
-            guard.move_to_index(line_number - 1);
+            guard.move_to_index(line_number.saturating_sub(1));
         }
         self.numbers.clear();
+    }
+
+    fn publish_position(&mut self) {
+        let renderer = self.renderer.lock().unwrap();
+        let renderer_absolute_index = renderer.current_absolute_index();
+        if self.last_renderer_absolute_index.is_none()
+            || self.last_renderer_absolute_index != Some(renderer_absolute_index)
+        {
+            self.trace_absolute_index = renderer_absolute_index;
+            self.last_renderer_absolute_index = Some(renderer_absolute_index);
+        }
+
+        if renderer.num_lines > 0 {
+            self.trace_absolute_index = self.trace_absolute_index.min(renderer.num_lines - 1);
+        } else {
+            self.trace_absolute_index = 0;
+        }
+
+        if self.fullness_absolute_index != Some(self.trace_absolute_index) {
+            self.fullness_by_id = renderer.fullnesses_at(self.trace_absolute_index);
+            self.fullness_absolute_index = Some(self.trace_absolute_index);
+        }
+
+        let mut shared_state = SHARED_STATE.lock().unwrap();
+        shared_state.current_line = if renderer.num_lines == 0 {
+            0
+        } else {
+            self.trace_absolute_index + 1
+        };
+        shared_state.num_lines = renderer.num_lines;
+        shared_state.current_time_ns = renderer.line_time(self.trace_absolute_index);
+        shared_state.fullnesses = self
+            .fullness_by_id
+            .iter()
+            .map(|(id, fullness)| format!("{id}={fullness}"))
+            .collect();
     }
 
     #[must_use]

--- a/gwr-spotter/src/app/tests.rs
+++ b/gwr-spotter/src/app/tests.rs
@@ -3,6 +3,7 @@
 // Note that all tests need to be run serially as spotter uses a global state
 // shared between threads.
 
+use std::collections::HashMap;
 use std::sync::mpsc::{Receiver, channel};
 use std::sync::{Arc, Mutex};
 
@@ -46,6 +47,10 @@ fn create_test_app_with(renderer: Renderer, filter: Filter) -> App {
         filter: Arc::new(Mutex::new(filter)),
         input_state: InputState::Default,
         numbers: String::new(),
+        trace_absolute_index: 0,
+        last_renderer_absolute_index: None,
+        fullness_absolute_index: None,
+        fullness_by_id: HashMap::new(),
     }
 }
 
@@ -149,6 +154,78 @@ fn tick_does_nothing_when_no_command() {
             6,
             "tick() should not move the view when there is no command"
         );
+    }
+}
+
+#[test]
+#[serial]
+fn tick_publishes_absolute_trace_position_when_filtered() {
+    let (mut app, _rx) = create_test_app();
+
+    {
+        let mut r = app.renderer.lock().unwrap();
+        r.num_lines = 1000;
+        r.set_render_indices(vec![9, 99, 199]);
+        r.move_to_index(1);
+    }
+
+    app.tick();
+
+    {
+        let guard = SHARED_STATE.lock().unwrap();
+        assert_eq!(guard.current_line, 100);
+        assert_eq!(guard.num_lines, 1000);
+    }
+}
+
+#[test]
+#[serial]
+fn web_seek_can_move_beyond_last_filtered_line() {
+    let (mut app, _rx) = create_test_app();
+
+    {
+        let mut r = app.renderer.lock().unwrap();
+        r.num_lines = 1000;
+        r.set_render_indices(vec![9, 99, 499]);
+    }
+
+    {
+        let mut guard = SHARED_STATE.lock().unwrap();
+        guard.seek_line = Some(900);
+    }
+
+    app.tick();
+
+    {
+        let guard = SHARED_STATE.lock().unwrap();
+        assert_eq!(guard.current_line, 900);
+        assert_eq!(guard.num_lines, 1000);
+    }
+}
+
+#[test]
+#[serial]
+fn filter_command_does_not_move_global_trace_position() {
+    let (mut app, _rx) = create_test_app();
+
+    {
+        let mut r = app.renderer.lock().unwrap();
+        r.num_lines = 1000;
+        r.set_render_indices(vec![9, 99, 499]);
+    }
+    app.move_to_absolute_line(900);
+
+    {
+        let mut guard = SHARED_STATE.lock().unwrap();
+        guard.command = Some("id=1".to_string());
+    }
+
+    app.tick();
+
+    {
+        let guard = SHARED_STATE.lock().unwrap();
+        assert_eq!(guard.current_line, 900);
+        assert_eq!(guard.num_lines, 1000);
     }
 }
 

--- a/gwr-spotter/src/bin_loader.rs
+++ b/gwr-spotter/src/bin_loader.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use gwr_track::Id;
+use gwr_track::entity::Capacity;
 use gwr_track::trace_visitor::{TraceVisitor, process_capnp};
 
 use crate::app::{CHUNK_SIZE, EventLine};
@@ -136,7 +137,7 @@ impl TraceVisitor for BinLoader {
             if *self.id_is_source.get(&id.0).unwrap() {
                 *fullness += 1;
             } else {
-                *fullness -= 1;
+                *fullness = fullness.saturating_sub(1);
             }
             *fullness
         };
@@ -160,7 +161,7 @@ impl TraceVisitor for BinLoader {
             }
 
             if *self.id_is_source.get(&id.0).unwrap() {
-                *fullness -= 1;
+                *fullness = fullness.saturating_sub(1);
             } else {
                 *fullness += 1;
             }
@@ -182,6 +183,18 @@ impl TraceVisitor for BinLoader {
             value,
             time,
         });
+    }
+
+    fn capacity(&mut self, id: Id, capacity: Capacity) {
+        SHARED_STATE
+            .lock()
+            .unwrap()
+            .capacities
+            .push(format!("{id}={},{}", capacity.value, capacity.units));
+        self.renderer
+            .lock()
+            .unwrap()
+            .set_capacity(id.0, capacity.value as u64, capacity.units);
     }
 
     fn time(&mut self, _id: Id, time_ns: f64) {

--- a/gwr-spotter/src/renderer.rs
+++ b/gwr-spotter/src/renderer.rs
@@ -9,6 +9,8 @@ const UNKNOWN: &str = "???";
 
 pub struct Renderer {
     id_to_name: HashMap<u64, String>,
+    id_to_capacity: HashMap<u64, u64>,
+    id_to_capacity_units: HashMap<u64, String>,
 
     /// Current location within the file
     render_index: usize,
@@ -38,6 +40,8 @@ impl Renderer {
         const INITIAL_FRAME_HEIGHT: usize = 60;
         Self {
             id_to_name: HashMap::with_capacity(INITIAL_SIZE),
+            id_to_capacity: HashMap::with_capacity(INITIAL_SIZE),
+            id_to_capacity_units: HashMap::with_capacity(INITIAL_SIZE),
             blocks: Vec::with_capacity(INITIAL_SIZE),
             render_indices: None,
             num_render_lines: 0,
@@ -59,7 +63,30 @@ impl Renderer {
 
     /// Return the line number at which the current rendering starts
     pub fn current_render_line_number(&self) -> usize {
-        self.render_index + 1
+        if self.num_render_lines == 0 {
+            0
+        } else {
+            self.render_index + 1
+        }
+    }
+
+    /// Return the absolute trace index for the current rendered line.
+    pub fn current_absolute_index(&self) -> usize {
+        self.render_index_to_absolute_index(self.render_index)
+    }
+
+    /// Return the absolute trace line number for the current rendered line.
+    pub fn current_absolute_line_number(&self) -> usize {
+        if self.num_lines == 0 {
+            0
+        } else {
+            self.current_absolute_index() + 1
+        }
+    }
+
+    /// Return the timestamp for the current rendered line.
+    pub fn current_time(&self) -> f64 {
+        self.line_time(self.current_absolute_index())
     }
 
     pub fn set_frame_size(&mut self, frame_height: usize) {
@@ -118,7 +145,7 @@ impl Renderer {
 
     pub fn line_from_index(&self, line_index: usize) -> Option<&EventLine> {
         let block_index = line_index / CHUNK_SIZE;
-        let chunk = &self.blocks[block_index];
+        let chunk = self.blocks.get(block_index)?;
         if chunk.is_none() {
             return None;
         }
@@ -141,6 +168,39 @@ impl Renderer {
         } else {
             0
         }
+    }
+
+    pub fn line_capacity(&self, line_index: usize) -> Option<u64> {
+        let id = match self.line_from_index(line_index)? {
+            EventLine::Create { id, .. }
+            | EventLine::Enter { id, .. }
+            | EventLine::Exit { id, .. }
+            | EventLine::Value { id, .. }
+            | EventLine::Log { id, .. } => *id,
+            EventLine::Connect { .. } => {
+                return Some(0);
+            }
+        };
+        self.id_to_capacity.get(&id).copied()
+    }
+
+    pub fn fullnesses_at(&self, absolute_index: usize) -> HashMap<u64, u64> {
+        let mut fullnesses = HashMap::new();
+        if self.num_lines == 0 {
+            return fullnesses;
+        }
+
+        let last_index = absolute_index.min(self.num_lines - 1);
+        for line_index in 0..=last_index {
+            match self.line_from_index(line_index) {
+                Some(EventLine::Enter { id, fullness, .. })
+                | Some(EventLine::Exit { id, fullness, .. }) => {
+                    fullnesses.insert(*id, *fullness);
+                }
+                _ => {}
+            }
+        }
+        fullnesses
     }
 
     pub fn render_line(&self, line_index: usize) -> String {
@@ -220,6 +280,11 @@ impl Renderer {
         self.id_to_name.extend(id_to_name);
     }
 
+    pub fn set_capacity(&mut self, id: u64, capacity: u64, units: String) {
+        self.id_to_capacity.insert(id, capacity);
+        self.id_to_capacity_units.insert(id, units);
+    }
+
     fn render_index_to_absolute_index(&self, line: usize) -> usize {
         if let Some(indices) = &self.render_indices {
             if let Some(index) = indices.get(line) {
@@ -229,7 +294,7 @@ impl Renderer {
                 return *index;
             }
         }
-        0
+        line
     }
 
     fn absoulte_index_to_render_index(&self, index: usize) -> usize {
@@ -241,7 +306,7 @@ impl Renderer {
             }
             return indices.len();
         }
-        0
+        index
     }
 
     /// Change the current indices for a new set of ones to render.
@@ -260,11 +325,18 @@ impl Renderer {
     ///
     /// Indices start at 0, line numbers shown to the user start at 1.
     pub fn move_to_index(&mut self, index: usize) {
-        if index > self.num_render_lines {
+        if self.num_render_lines == 0 {
+            self.render_index = 0;
+        } else if index >= self.num_render_lines {
             self.render_index = self.num_render_lines - 1;
         } else {
             self.render_index = index;
         }
+    }
+
+    /// Move to an absolute trace index, mapping onto the current filtered view.
+    pub fn move_to_absolute_index(&mut self, index: usize) {
+        self.move_to_index(self.absoulte_index_to_render_index(index));
     }
 
     pub fn move_top(&mut self) {

--- a/gwr-spotter/src/rocket.rs
+++ b/gwr-spotter/src/rocket.rs
@@ -9,26 +9,44 @@ use rocket::{Request, Response, get, launch, routes};
 
 pub struct SharedState {
     pub entity_names: Vec<String>,
+    pub capacities: Vec<String>,
+    pub fullnesses: Vec<String>,
     pub connections: Vec<String>,
     pub command: Option<String>,
     pub selected: Option<u64>,
+    pub current_line: usize,
+    pub num_lines: usize,
+    pub current_time_ns: f64,
+    pub seek_line: Option<usize>,
 }
 
 impl SharedState {
     const fn new() -> Self {
         Self {
             entity_names: Vec::new(),
+            capacities: Vec::new(),
+            fullnesses: Vec::new(),
             connections: Vec::new(),
             command: None,
             selected: None,
+            current_line: 0,
+            num_lines: 0,
+            current_time_ns: 0.0,
+            seek_line: None,
         }
     }
 
     pub fn reset(&mut self) {
         self.entity_names.clear();
+        self.capacities.clear();
+        self.fullnesses.clear();
         self.connections.clear();
         self.command = None;
         self.selected = None;
+        self.current_line = 0;
+        self.num_lines = 0;
+        self.current_time_ns = 0.0;
+        self.seek_line = None;
     }
 }
 
@@ -85,6 +103,16 @@ fn entities() -> String {
     SHARED_STATE.lock().unwrap().entity_names.join("\n")
 }
 
+#[get("/capacities")]
+fn capacities() -> String {
+    SHARED_STATE.lock().unwrap().capacities.join("\n")
+}
+
+#[get("/fullnesses")]
+fn fullnesses() -> String {
+    SHARED_STATE.lock().unwrap().fullnesses.join("\n")
+}
+
 #[get("/connections")]
 fn connections() -> String {
     SHARED_STATE.lock().unwrap().connections.join("\n")
@@ -105,10 +133,35 @@ async fn selected() -> String {
     }
 }
 
+#[get("/position")]
+async fn position() -> String {
+    let guard = SHARED_STATE.lock().unwrap();
+    format!(
+        "line={}\nlines={}\ntime={:.1}",
+        guard.current_line, guard.num_lines, guard.current_time_ns
+    )
+}
+
+#[get("/seek/<line>")]
+async fn seek(line: usize) -> String {
+    SHARED_STATE.lock().unwrap().seek_line = Some(line);
+    format!("seek {line}")
+}
+
 #[launch]
 #[must_use]
 pub fn rocket() -> _ {
-    rocket::build()
-        .attach(CORS)
-        .mount("/", routes![entities, connections, select, selected])
+    rocket::build().attach(CORS).mount(
+        "/",
+        routes![
+            entities,
+            capacities,
+            fullnesses,
+            connections,
+            select,
+            selected,
+            position,
+            seek
+        ],
+    )
 }

--- a/gwr-spotter/src/ui.rs
+++ b/gwr-spotter/src/ui.rs
@@ -266,16 +266,23 @@ fn render_chart(app: &mut App, frame: &mut Frame, area: Rect) {
         data.push(("", value));
     }
 
-    let mut max_value = u64::MIN;
+    let mut max_value = 0;
+    let mut max_capacity: Option<u64> = None;
     if let Some(indices) = renderer.render_indices.as_ref() {
         for index in indices {
             let value = if plot_fullness {
+                if let Some(capacity) = renderer.line_capacity(*index) {
+                    max_capacity = Some(max_capacity.map_or(capacity, |max| max.max(capacity)));
+                }
                 renderer.line_fullness(*index)
             } else {
                 renderer.line_time(*index) as u64
             };
             max_value = max(max_value, value);
         }
+    }
+    if plot_fullness && let Some(capacity) = max_capacity {
+        max_value = capacity;
     }
 
     let title = if plot_fullness { "Fullness:" } else { "Time:" };

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -26,7 +26,7 @@ gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.16.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.3.0" }
-gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.8.0" }
+gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.9.0" }
 indicatif.workspace = true
 log.workspace = true
 rand.workspace = true

--- a/gwr-track/Cargo.toml
+++ b/gwr-track/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-track"
-version = "0.8.0"
+version = "0.9.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-track/schemas/gwr_track.capnp
+++ b/gwr-track/schemas/gwr_track.capnp
@@ -18,6 +18,11 @@ struct Log @0x835154066f85a612 {
   }
 }
 
+struct Capacity @0xac486acbf54c747d {
+  units    @1  :Text;
+  value    @0  :UInt64;
+}
+
 struct Entity @0xbc946b85a6484339 {
   name     @3  :Text;
   reqType  @2  :Int8;
@@ -27,6 +32,7 @@ struct Entity @0xbc946b85a6484339 {
 
 struct Event @0xc13b4d9cc5ead95b {
   union {
+    capacity @9 :Capacity;
     value   @8  :Float64;
     connect @7  :UInt64;
     time    @6  :Float64;

--- a/gwr-track/src/entity.rs
+++ b/gwr-track/src/entity.rs
@@ -12,6 +12,27 @@ use std::rc::Rc;
 use crate::tracker::aka::{Aka, get_alternative_names};
 use crate::{Id, Tracker, create, destroy, trace};
 
+/// A capacity value and its units.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Capacity {
+    /// Capacity value.
+    pub value: usize,
+
+    /// Capacity units, for example "objects" or "bytes".
+    pub units: String,
+}
+
+impl Capacity {
+    /// Construct a new [`Capacity`].
+    #[must_use]
+    pub fn new(value: usize, units: impl Into<String>) -> Self {
+        Self {
+            value,
+            units: units.into(),
+        }
+    }
+}
+
 /// A simulation entity
 ///
 /// An entity is a part of a hierarchical simulation in which it must have a
@@ -104,6 +125,13 @@ impl Entity {
                 name
             }
             None => self.name.clone(),
+        }
+    }
+
+    /// Emit the capacity represented by this simulation entity.
+    pub fn track_capacity(&self, value: usize, units: impl Into<String>) {
+        if self.tracker.is_entity_enabled(self.id, log::Level::Trace) {
+            self.tracker.capacity(self.id, Capacity::new(value, units));
         }
     }
 }

--- a/gwr-track/src/test_helpers.rs
+++ b/gwr-track/src/test_helpers.rs
@@ -17,6 +17,7 @@ use std::rc::Rc;
 
 use regex::Regex;
 
+use crate::entity::Capacity;
 use crate::tracker::aka::AlternativeNames;
 use crate::tracker::{CapnProtoTracker, EntityManager};
 use crate::{Id, Track, Tracker, Writer};
@@ -82,6 +83,13 @@ impl Track for TestTracker {
     fn create(&self, created_by: Id, id: Id, num_bytes: usize, req_type: i8, name: &str) {
         self.add_event(format!(
             "{created_by}: created {id}, {name}, {req_type}, {num_bytes} bytes"
+        ));
+    }
+
+    fn capacity(&self, id: Id, capacity: Capacity) {
+        self.add_event(format!(
+            "{id}: capacity {} {}",
+            capacity.value, capacity.units
         ));
     }
 

--- a/gwr-track/src/trace_visitor.rs
+++ b/gwr-track/src/trace_visitor.rs
@@ -7,6 +7,7 @@ use std::io::BufRead;
 
 use capnp::serialize_packed;
 
+use crate::entity::Capacity;
 use crate::gwr_track_capnp::log::LogLevel;
 use crate::{Id, gwr_track_capnp};
 
@@ -106,6 +107,18 @@ pub trait TraceVisitor {
         // Remove the unused variable warnings
         let _ = id;
         let _ = value;
+    }
+
+    /// A capacity has been set for the specified ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The originator of this event.
+    /// * `capacity` - The entity capacity and its units.
+    fn capacity(&mut self, id: Id, capacity: Capacity) {
+        // Remove the unused variable warnings
+        let _ = id;
+        let _ = capacity;
     }
 
     /// Advance simulation time.
@@ -220,6 +233,20 @@ where
             }
             Ok(gwr_track_capnp::event::Which::Value(value)) => {
                 visitor.value(id, value);
+            }
+            Ok(gwr_track_capnp::event::Which::Capacity(capacity)) => {
+                let capacity = capacity.expect("failed to parse Capacity event");
+                visitor.capacity(
+                    id,
+                    Capacity::new(
+                        capacity.get_value() as usize,
+                        capacity
+                            .get_units()
+                            .expect("failed to parse Capacity units")
+                            .to_str()
+                            .expect("Capacity units is not a valid UTF-8 string"),
+                    ),
+                );
             }
             Ok(gwr_track_capnp::event::Which::Time(time)) => {
                 visitor.time(id, time);

--- a/gwr-track/src/tracker/capnp.rs
+++ b/gwr-track/src/tracker/capnp.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 
 use capnp::serialize_packed;
 
+use crate::entity::Capacity;
 use crate::gwr_track_capnp::event;
 use crate::gwr_track_capnp::log::LogLevel;
 use crate::tracker::aka::AlternativeNames;
@@ -102,6 +103,14 @@ impl Track for CapnProtoTracker {
             entity.set_num_bytes(num_bytes as u64);
             entity.set_req_type(req_type);
             entity.set_name(name);
+        });
+    }
+
+    fn capacity(&self, id: Id, capacity: Capacity) {
+        self.write_event(id, |event| {
+            let mut event_capacity = event.init_capacity();
+            event_capacity.set_value(capacity.value as u64);
+            event_capacity.set_units(&capacity.units);
         });
     }
 

--- a/gwr-track/src/tracker/dev_null.rs
+++ b/gwr-track/src/tracker/dev_null.rs
@@ -3,6 +3,7 @@
 use std::str::FromStr;
 
 use crate::Id;
+use crate::entity::Capacity;
 use crate::tracker::Track;
 use crate::tracker::aka::AlternativeNames;
 
@@ -26,6 +27,7 @@ impl Track for DevNullTracker {
     fn exit(&self, _id: Id, _obj: Id) {}
     fn value(&self, _id: Id, _value: f64) {}
     fn create(&self, _id: Id, _obj: Id, _num_bytes: usize, _req_type: i8, _name: &str) {}
+    fn capacity(&self, _id: Id, _capacity: Capacity) {}
     fn destroy(&self, _id: Id, _obj: Id) {}
     fn connect(&self, _connect_from: Id, _connect_to: Id) {}
     fn log(&self, _id: Id, _level: log::Level, _msg: std::fmt::Arguments) {}

--- a/gwr-track/src/tracker/in_memory.rs
+++ b/gwr-track/src/tracker/in_memory.rs
@@ -7,6 +7,7 @@ use num_traits::FromPrimitive;
 
 use super::types::ReqType;
 use crate::Id;
+use crate::entity::Capacity;
 use crate::tracker::aka::AlternativeNames;
 use crate::tracker::{EntityManager, Track};
 
@@ -40,12 +41,14 @@ enum Event {
     Enter { entered: Id },
     Exit { exited: Id },
     Value { value: f64 },
+    Capacity { capacity: Capacity },
 }
 
 struct TrackedState {
     events: Vec<EventCommon>,
     id_to_num_bytes: HashMap<Id, usize>,
     id_to_req_type: HashMap<Id, i8>,
+    id_to_capacity: HashMap<Id, Capacity>,
     name_to_id: HashMap<String, Id>,
 }
 
@@ -56,6 +59,7 @@ impl TrackedState {
             events: Vec::with_capacity(INITIAL_CAPACITY),
             id_to_num_bytes: HashMap::with_capacity(INITIAL_CAPACITY),
             id_to_req_type: HashMap::with_capacity(INITIAL_CAPACITY),
+            id_to_capacity: HashMap::with_capacity(INITIAL_CAPACITY),
             name_to_id: HashMap::with_capacity(INITIAL_CAPACITY),
         }
     }
@@ -70,6 +74,10 @@ impl TrackedState {
 
     fn add_id_to_req_type(&mut self, id: Id, req_type: i8) {
         self.id_to_req_type.insert(id, req_type);
+    }
+
+    fn add_id_to_capacity(&mut self, id: Id, capacity: Capacity) {
+        self.id_to_capacity.insert(id, capacity);
     }
 
     fn add_name_to_id(&mut self, name: &str, id: Id) {
@@ -340,6 +348,16 @@ impl Track for InMemoryTracker {
         state_guard.add_id_to_num_bytes(id, num_bytes);
         state_guard.add_id_to_req_type(id, req_type);
         state_guard.add_name_to_id(name, id);
+    }
+
+    fn capacity(&self, id: Id, capacity: Capacity) {
+        let time = self.time();
+        let capacity_event = Event::Capacity {
+            capacity: capacity.clone(),
+        };
+        let mut state_guard = self.state.borrow_mut();
+        state_guard.add_event(EventCommon::new(id, time, capacity_event));
+        state_guard.add_id_to_capacity(id, capacity);
     }
 
     /// Track when an entity with the given ID is destroyed.

--- a/gwr-track/src/tracker/mod.rs
+++ b/gwr-track/src/tracker/mod.rs
@@ -32,6 +32,7 @@ pub use in_memory::InMemoryTracker;
 use regex::Regex;
 pub use text::TextTracker;
 
+use crate::entity::Capacity;
 use crate::tracker::aka::AlternativeNames;
 use crate::{Id, ROOT};
 
@@ -66,6 +67,9 @@ pub trait Track {
 
     /// Track when an entity with the given ID is created.
     fn create(&self, created_by: Id, created_obj: Id, num_bytes: usize, req_type: i8, name: &str);
+
+    /// Track the capacity available in an entity.
+    fn capacity(&self, id: Id, capacity: Capacity);
 
     /// Track when an entity with the given ID is destroyed.
     fn destroy(&self, destroyed_by: Id, destroyed_obj: Id);

--- a/gwr-track/src/tracker/multi_tracker.rs
+++ b/gwr-track/src/tracker/multi_tracker.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
 use crate::Id;
+use crate::entity::Capacity;
 use crate::tracker::aka::AlternativeNames;
 use crate::tracker::{EntityManager, Track, Tracker};
 
@@ -85,6 +86,14 @@ impl Track for MultiTracker {
         for tracker in &self.trackers {
             if tracker.is_entity_enabled(id, log::Level::Trace) {
                 tracker.create(created_by, id, num_bytes, req_type, name);
+            }
+        }
+    }
+
+    fn capacity(&self, id: Id, capacity: Capacity) {
+        for tracker in &self.trackers {
+            if tracker.is_entity_enabled(id, log::Level::Trace) {
+                tracker.capacity(id, capacity.clone());
             }
         }
     }

--- a/gwr-track/src/tracker/perfetto.rs
+++ b/gwr-track/src/tracker/perfetto.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate::entity::Capacity;
 use crate::perfetto_trace_builder::PerfettoTraceBuilder;
 use crate::tracker::EntityManager;
 use crate::tracker::aka::AlternativeNames;
@@ -90,6 +91,10 @@ impl Track for PerfettoTracker {
         };
         let buf = guard.build_trace_to_bytes(vec![trace_packet]);
         self.writer.borrow_mut().write_all(&buf).unwrap();
+    }
+
+    fn capacity(&self, _id: Id, _capacity: Capacity) {
+        // todo!()
     }
 
     fn destroy(&self, _destroyed_by: Id, _destroyed_obj: Id) {

--- a/gwr-track/src/tracker/text.rs
+++ b/gwr-track/src/tracker/text.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 
 pub use log;
 
+use crate::entity::Capacity;
 use crate::tracker::aka::AlternativeNames;
 use crate::tracker::{EntityManager, Track};
 use crate::{Id, SharedWriter, Writer};
@@ -74,6 +75,13 @@ impl Track for TextTracker {
                 format!("{created_by}: created {id}, {name}, {req_type}, {num_bytes} bytes\n")
                     .as_bytes(),
             )
+            .unwrap();
+    }
+
+    fn capacity(&self, id: Id, capacity: Capacity) {
+        self.writer
+            .borrow_mut()
+            .write_all(format!("{id}: capacity {} {}\n", capacity.value, capacity.units).as_bytes())
             .unwrap();
     }
 

--- a/licenses.html
+++ b/licenses.html
@@ -8355,10 +8355,10 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.3.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.6.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.7.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-terminus 0.3.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-timetable 0.2.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.8.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 


### PR DESCRIPTION
This allows components like the `Queue` and `Store` to emit their
capacity and the visual trace front-ends can then use it.

Updated TreeMap and ForceTree to take this into account in their
entity colouring.
