### PR TITLE
infra: remove dependency on build-deps cache from dev-deps installer

### DIFF
--- a/.github/actions/install-dev-dependencies/action.yaml
+++ b/.github/actions/install-dev-dependencies/action.yaml
@@ -16,12 +16,16 @@ runs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-dev-deps-${{ hashFiles('./.github/actions/install-dev-dependencies/**') }}
+        key: ${{ runner.os }}-cargo-dev-deps-${{ hashFiles('./.github/actions/install-dev-dependencies/**','./.github/actions/install-build-dependencies/**') }}
         restore-keys: |
           ${{ runner.os }}-cargo-dev-deps-
           ${{ runner.os }}-cargo-build-deps-
 
-    - name: Run install.sh
-      id: run-install
+    - name: Run build dependencies install.sh
+      id: run-build-deps-install
+      run: ./.github/actions/install-build-dependencies/install.sh
+      shell: bash
+    - name: Run dev dependencies install.sh
+      id: run-dev-deps-install
       run: ./.github/actions/install-dev-dependencies/install.sh
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,20 +22,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-build-dependencies
 
-  warm-dev-deps-cache:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    needs: warm-build-deps-cache
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/install-dev-dependencies
-
   lint:
     runs-on: macos-latest
-    needs: warm-dev-deps-cache
+    needs: warm-build-deps-cache
     env:
       RUSTFLAGS: -D warnings
 
@@ -54,7 +43,7 @@ jobs:
 
   check-semantic-versioning:
     runs-on: ubuntu-latest
-    needs: warm-dev-deps-cache
+    needs: warm-build-deps-cache
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     runs-on: macos-latest
-    needs: [warm-build-deps-cache, warm-dev-deps-cache]
+    needs: warm-dev-deps-cache
     env:
       RUSTFLAGS: -D warnings
 
@@ -47,7 +47,6 @@ jobs:
         with:
           path: .lycheecache
           key: lycheecache-${{ hashFiles('lychee.toml') }}
-      - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/install-dev-dependencies
 
       - name: Lint with pre-commit
@@ -55,14 +54,13 @@ jobs:
 
   check-semantic-versioning:
     runs-on: ubuntu-latest
-    needs: [warm-build-deps-cache, warm-dev-deps-cache]
+    needs: warm-dev-deps-cache
 
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required to cause the main branch to also be fetched
           submodules: true
-      - uses: ./.github/actions/install-build-dependencies
       - uses: ./.github/actions/install-dev-dependencies
       - run: pre-commit run --hook-stage manual --all-files cargo-semver-checks
 


### PR DESCRIPTION
- **infra: remove dependency on build-deps cache from dev-deps installer**
- **infra: remove warm-dev-deps-cache job**

  Warming the dev dependencies cache is unnecessary as the cached
  output for each OS is only used by a single job:
  
  - The `lint` job uses the cached Linux output.
  - The `check-semantic-versioning` jobs uses the cached MacOS output.
  
  When these jobs run the `install-dev-dependencies` action the installed
  dev dependencies will still be cached/restored from the cache if
  available.