### PR TITLE
chore: ignore proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -77,7 +77,8 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0436", reason = "ignoring as the RFC states the paste 1.0.15 crate is unmaintained not insecure" },
-    { id = "RUSTSEC-2025-0141", reason = "ignoring as the RFC states the bincode 1.3.3 crate is unmaintained not insecure" }
+    { id = "RUSTSEC-2025-0141", reason = "ignoring as the RFC states the bincode 1.3.3 crate is unmaintained not insecure" },
+    { id = "RUSTSEC-2026-0173", reason = "ignoring as the RFC states the proc-macro-error2 2.0.1 crate is unmaintained not insecure" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
The proc-macro-error2 crate is now unmaintained, as confirmed by the
author in https://github.com/GnomedDev/proc-macro-error-2/issues/17.

The one-shot benchmarking crate used by GWR, gungraun, currently depends
on proc-macro-error2, though have an update in developemnt to move away
from it: https://github.com/gungraun/gungraun/pull/657.
