### PR TITLE
feat: Add support for generating branch coverage

### DIFF
--- a/gwr-config/tests/macro_properties/missing_path.rs
+++ b/gwr-config/tests/macro_properties/missing_path.rs
@@ -9,11 +9,3 @@ struct Config {
     #[arg(long)]
     a: Option<String>,
 }
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            a: Default::default(),
-        }
-    }
-}

--- a/gwr-config/tests/macro_properties/missing_path.stderr
+++ b/gwr-config/tests/macro_properties/missing_path.stderr
@@ -6,14 +6,8 @@ error: unexpected end of input, expected string literal
   |
   = note: this error originates in the attribute macro `multi_source_config` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0425]: cannot find type `Config` in this scope
-  --> tests/macro_properties/missing_path.rs:13:18
-   |
-13 | impl Default for Config {
-   |                  ^^^^^^ not found in this scope
-
 error[E0601]: `main` function not found in crate `$CRATE`
-  --> tests/macro_properties/missing_path.rs:19:2
+  --> tests/macro_properties/missing_path.rs:11:2
    |
-19 | }
+11 | }
    |  ^ consider adding a `main` function to `$DIR/tests/macro_properties/missing_path.rs`

--- a/gwr-config/tests/macro_properties/name_only.rs
+++ b/gwr-config/tests/macro_properties/name_only.rs
@@ -9,11 +9,3 @@ struct Config {
     #[arg(long)]
     a: Option<String>,
 }
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            a: Default::default(),
-        }
-    }
-}

--- a/gwr-config/tests/macro_properties/name_only.stderr
+++ b/gwr-config/tests/macro_properties/name_only.stderr
@@ -6,14 +6,8 @@ error: expected `=`
   |
   = note: this error originates in the attribute macro `multi_source_config` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0425]: cannot find type `Config` in this scope
-  --> tests/macro_properties/name_only.rs:13:18
-   |
-13 | impl Default for Config {
-   |                  ^^^^^^ not found in this scope
-
 error[E0601]: `main` function not found in crate `$CRATE`
-  --> tests/macro_properties/name_only.rs:19:2
+  --> tests/macro_properties/name_only.rs:11:2
    |
-19 | }
+11 | }
    |  ^ consider adding a `main` function to `$DIR/tests/macro_properties/name_only.rs`

--- a/gwr-config/tests/macro_properties/unsupported.rs
+++ b/gwr-config/tests/macro_properties/unsupported.rs
@@ -9,11 +9,3 @@ struct Config {
     #[arg(long)]
     a: Option<String>,
 }
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            a: Default::default(),
-        }
-    }
-}

--- a/gwr-config/tests/macro_properties/unsupported.stderr
+++ b/gwr-config/tests/macro_properties/unsupported.stderr
@@ -4,14 +4,8 @@ error: unsupported property
 5 | #[multi_source_config(path = "foo.toml")]
   |                       ^^^^
 
-error[E0425]: cannot find type `Config` in this scope
-  --> tests/macro_properties/unsupported.rs:13:18
-   |
-13 | impl Default for Config {
-   |                  ^^^^^^ not found in this scope
-
 error[E0601]: `main` function not found in crate `$CRATE`
-  --> tests/macro_properties/unsupported.rs:19:2
+  --> tests/macro_properties/unsupported.rs:11:2
    |
-19 | }
+11 | }
    |  ^ consider adding a `main` function to `$DIR/tests/macro_properties/unsupported.rs`

--- a/gwr-developer-guide/Cargo.toml
+++ b/gwr-developer-guide/Cargo.toml
@@ -23,5 +23,8 @@ exclude = [
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ["cfg(coverage)"] }
+
 [dev-dependencies]
 strip-ansi-escapes = "0.2.1"

--- a/gwr-developer-guide/src/lib.rs
+++ b/gwr-developer-guide/src/lib.rs
@@ -26,6 +26,10 @@ mod tests {
     use strip_ansi_escapes::strip_str;
 
     #[test]
+    #[cfg_attr(
+        coverage,
+        ignore = "mdbook-linkcheck is environment-sensitive and is not useful for Rust coverage"
+    )]
     fn mdbook_build() {
         let mdbook_output = Command::new("mdbook")
             .arg("build")

--- a/gwr-terminus/recipes/branch_coverage.yaml
+++ b/gwr-terminus/recipes/branch_coverage.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+description:
+  Run all workspace tests with code coverage enabled and generate a text
+  coverage report, including branch coverage.
+arguments:
+  - name: REPORT_DIR
+    default: target/llvm-cov
+    comment: Directory to write the generated text coverage report into.
+  - name: EXTRA_ARGS
+    default: ""
+    comment: Additional arguments to append to `cargo +nightly llvm-cov`.
+ingredients:
+  - comment:
+      Check that the nightly toolchain and `cargo llvm-cov` subcommand are
+      available.
+    command: |-
+      if ! cargo +nightly --version >/dev/null 2>&1; then
+        echo "The nightly Rust toolchain is not installed."
+        echo "Install it with: rustup toolchain install nightly"
+        exit 1
+      fi
+      if ! cargo +nightly llvm-cov --version >/dev/null 2>&1; then
+        echo "cargo-llvm-cov is not installed."
+        echo "Install it with: cargo binstall --disable-telemetry --no-confirm --locked cargo-llvm-cov"
+        exit 1
+      fi
+  - comment: Ensure the output directory exists before generating the report.
+    command: mkdir -p "$REPORT_DIR"
+  - comment: Clear any existing coverage artefacts from previous runs.
+    command: cargo +nightly llvm-cov clean --workspace
+  - comment:
+      Run the full workspace test suite with all features enabled and generate a
+      text coverage report with branch coverage.
+    command: |-
+      cargo +nightly llvm-cov \
+        --workspace \
+        --all-features \
+        --branch \
+        --verbose \
+        --text \
+        --output-path "$REPORT_DIR/coverage.txt" \
+        $EXTRA_ARGS
+  - comment: Print the location of the generated coverage report.
+    command: echo "Coverage report generated in $REPORT_DIR/coverage.txt"


### PR DESCRIPTION
This allows you to run:
> cargo run --release --bin terminus -- run --recipe gwr-terminus/recipes/branch_coverage.yaml

in order to generate target/llvm-cov/coverage.txt
