### PR TITLE
test(gwr-engine): close coverage holes

### DIFF
--- a/gwr-engine/src/events/all_of.rs
+++ b/gwr-engine/src/events/all_of.rs
@@ -123,3 +123,34 @@ async fn all_of<T: Default>(events: Vec<Box<dyn Event<T>>>) {
         // Keep waiting till all are done
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_dyn_clones_event() {
+        let event = AllOf::<()>::new(Vec::new());
+
+        let cloned = event.clone_dyn();
+
+        drop(cloned);
+    }
+
+    #[test]
+    fn future_reports_termination_state() {
+        let pending = AllOfFuture {
+            state: Rc::new(AllOfState::new(Vec::<Eventable<()>>::new())),
+            future: None,
+            done: false,
+        };
+        assert!(!pending.is_terminated());
+
+        let done = AllOfFuture {
+            state: Rc::new(AllOfState::new(Vec::<Eventable<()>>::new())),
+            future: None,
+            done: true,
+        };
+        assert!(done.is_terminated());
+    }
+}

--- a/gwr-engine/src/events/any_of.rs
+++ b/gwr-engine/src/events/any_of.rs
@@ -175,3 +175,34 @@ async fn any_of<T>(events: Vec<Box<dyn Event<T>>>) -> T {
 
     futures.next().await.unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_dyn_clones_event() {
+        let event = AnyOf::<()>::new(Vec::new());
+
+        let cloned = event.clone_dyn();
+
+        drop(cloned);
+    }
+
+    #[test]
+    fn future_reports_termination_state() {
+        let pending = AnyOfFuture {
+            state: Rc::new(AnyOfState::new(Vec::<Eventable<()>>::new())),
+            future: None,
+            done: false,
+        };
+        assert!(!pending.is_terminated());
+
+        let done = AnyOfFuture {
+            state: Rc::new(AnyOfState::new(Vec::<Eventable<()>>::new())),
+            future: None,
+            done: true,
+        };
+        assert!(done.is_terminated());
+    }
+}

--- a/gwr-engine/src/events/once.rs
+++ b/gwr-engine/src/events/once.rs
@@ -157,3 +157,42 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_default_uses_unit_result() {
+        let state = OnceState::default();
+
+        assert_eq!(state.result, ());
+        assert!(!*state.triggered.borrow());
+    }
+
+    #[test]
+    fn clone_dyn_clones_event() {
+        let event = Once::default();
+
+        let cloned = event.clone_dyn();
+
+        drop(cloned);
+    }
+
+    #[test]
+    fn future_reports_termination_state() {
+        let pending = OnceFuture {
+            state: Rc::new(OnceState::new(())),
+            done: false,
+            listener_id: None,
+        };
+        assert!(!pending.is_terminated());
+
+        let done = OnceFuture {
+            state: Rc::new(OnceState::new(())),
+            done: true,
+            listener_id: None,
+        };
+        assert!(done.is_terminated());
+    }
+}

--- a/gwr-engine/src/events/repeated.rs
+++ b/gwr-engine/src/events/repeated.rs
@@ -164,3 +164,52 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_default_uses_unit_result() {
+        let state = RepeatedState::default();
+
+        assert_eq!(*state.result.borrow(), ());
+        assert_eq!(state.generation.get(), 0);
+    }
+
+    #[test]
+    fn with_value_sets_initial_result() {
+        let event = Repeated::with_value(123);
+
+        assert_eq!(*event.state.result.borrow(), 123);
+    }
+
+    #[test]
+    fn clone_dyn_clones_event() {
+        let event = Repeated::default();
+
+        let cloned = event.clone_dyn();
+
+        drop(cloned);
+    }
+
+    #[test]
+    fn future_reports_termination_state() {
+        let state = Rc::new(RepeatedState::new(()));
+        let pending = RepeatedFuture {
+            state: state.clone(),
+            done: false,
+            listener_id: None,
+            observed_generation: 0,
+        };
+        assert!(!pending.is_terminated());
+
+        let done = RepeatedFuture {
+            state,
+            done: true,
+            listener_id: None,
+            observed_generation: 0,
+        };
+        assert!(done.is_terminated());
+    }
+}

--- a/gwr-engine/src/events/waiting.rs
+++ b/gwr-engine/src/events/waiting.rs
@@ -54,3 +54,37 @@ impl Default for Waiting {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use futures::task::noop_waker;
+
+    use super::*;
+
+    #[test]
+    fn default_creates_empty_waiting_list() {
+        let waiting = Waiting::default();
+
+        assert!(waiting.listeners.borrow().is_empty());
+        assert_eq!(waiting.next_listener_id.get(), 0);
+    }
+
+    #[test]
+    fn removing_unknown_listener_is_a_noop() {
+        let waiting = Waiting::new();
+
+        waiting.remove_listener(7);
+
+        assert!(waiting.listeners.borrow().is_empty());
+        assert_eq!(waiting.next_listener_id.get(), 0);
+
+        let listener_id = waiting.register_listener(noop_waker());
+        assert_eq!(waiting.listeners.borrow().len(), 1);
+        assert_eq!(waiting.next_listener_id.get(), 1);
+
+        waiting.remove_listener(listener_id);
+
+        assert!(waiting.listeners.borrow().is_empty());
+        assert_eq!(waiting.next_listener_id.get(), 1);
+    }
+}

--- a/gwr-engine/src/executor.rs
+++ b/gwr-engine/src/executor.rs
@@ -227,3 +227,74 @@ pub fn new_executor_and_spawner(top: &Rc<Entity>) -> (Executor, Spawner) {
         Spawner { state },
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::rc::Rc;
+    use std::task::{Context, Poll};
+
+    use futures::task::noop_waker;
+    use gwr_track::entity::toplevel;
+    use gwr_track::tracker::dev_null_tracker;
+
+    use super::*;
+    use crate::time::clock::TaskWaker;
+
+    struct PanicIfPolled;
+
+    impl Future for PanicIfPolled {
+        type Output = SimResult;
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            panic!("finished executor step polled a task");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "finished executor step polled a task")]
+    fn panic_if_polled_panics_when_polled() {
+        let mut future = Box::pin(PanicIfPolled);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let _ = future.as_mut().poll(&mut cx);
+    }
+
+    #[test]
+    fn run_exits_when_time_cannot_advance() {
+        let tracker = dev_null_tracker();
+        let top = toplevel(&tracker, "top");
+        let (executor, _spawner) = new_executor_and_spawner(&top);
+        let clock = executor.get_clock(1000.0);
+
+        clock
+            .shared_state
+            .waiting
+            .borrow_mut()
+            .push(vec![TaskWaker {
+                id: 0,
+                waker: noop_waker(),
+                can_exit: false,
+            }]);
+
+        let finished = Rc::new(RefCell::new(false));
+
+        executor.run(&finished).unwrap();
+    }
+
+    #[test]
+    fn step_stops_polling_when_finished_is_set() {
+        let tracker = dev_null_tracker();
+        let top = toplevel(&tracker, "top");
+        let (executor, spawner) = new_executor_and_spawner(&top);
+
+        spawner.spawn(PanicIfPolled);
+
+        let finished = Rc::new(RefCell::new(true));
+
+        executor.step(&finished).unwrap();
+    }
+}

--- a/gwr-engine/src/lib.rs
+++ b/gwr-engine/src/lib.rs
@@ -122,3 +122,44 @@ macro_rules! spawn_subcomponent {
         $($spawner).+.spawn(async move { sub_block.run().await } );
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    use async_trait::async_trait;
+    use gwr_track::tracker::dev_null_tracker;
+
+    use crate::engine::Engine;
+    use crate::traits::Runnable;
+    use crate::types::SimResult;
+
+    struct TestComponent {
+        ran: Rc<Cell<bool>>,
+    }
+
+    #[async_trait(?Send)]
+    impl Runnable for TestComponent {
+        async fn run(&self) -> SimResult {
+            self.ran.set(true);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn spawn_subcomponent_spawns_and_runs_component() {
+        let tracker = dev_null_tracker();
+        let mut engine = Engine::new(&tracker);
+        let spawner = engine.spawner();
+        let ran = Rc::new(Cell::new(false));
+        let component = RefCell::new(Some(TestComponent { ran: ran.clone() }));
+
+        spawn_subcomponent!(spawner; component);
+
+        engine.run().unwrap();
+
+        assert!(ran.get());
+        assert!(component.borrow().is_none());
+    }
+}

--- a/gwr-engine/src/port/mod.rs
+++ b/gwr-engine/src/port/mod.rs
@@ -330,6 +330,7 @@ where
         let value = self.state.value.borrow_mut().take();
         if let Some(value) = value {
             self.done = true;
+            self.state.waiting_get.borrow_mut().take();
 
             // Track the object through the port monitor if there is one
             if let Some(monitor) = self.state.monitor.as_ref() {
@@ -378,6 +379,7 @@ where
         let value = self.state.value.borrow_mut().take();
         if let Some(value) = value {
             self.done = true;
+            self.state.waiting_get.borrow_mut().take();
 
             // Track the object through the port monitor if there is one
             if let Some(monitor) = self.state.monitor.as_ref() {
@@ -398,5 +400,323 @@ where
 {
     fn is_terminated(&self) -> bool {
         self.done
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Wake, Waker};
+
+    use futures::future::FusedFuture;
+    use futures::task::noop_waker;
+    use gwr_track::Tracker;
+    use gwr_track::entity::Entity;
+    use gwr_track::tracker::dev_null_tracker;
+
+    use super::*;
+    use crate::traits::TotalBytes;
+
+    struct TestContext {
+        // Just kept to ensure it isn't dropped
+        _tracker: Tracker,
+        engine: Engine,
+        clock: Clock,
+    }
+
+    fn test_context() -> TestContext {
+        let tracker = dev_null_tracker();
+        let mut engine = Engine::new(&tracker);
+        let clock = engine.default_clock();
+
+        TestContext {
+            _tracker: tracker,
+            engine,
+            clock,
+        }
+    }
+
+    fn test_state<T: SimObject>() -> Rc<PortState<T>> {
+        let context = test_context();
+        let entity = Rc::new(Entity::new(context.engine.top(), "rx"));
+
+        Rc::new(PortState::new(
+            &context.engine,
+            &context.clock,
+            entity,
+            None,
+        ))
+    }
+
+    fn monitored_test_state<T: SimObject>() -> Rc<PortState<T>> {
+        let context = test_context();
+        let entity = Rc::new(Entity::new(context.engine.top(), "rx"));
+
+        Rc::new(PortState::new(
+            &context.engine,
+            &context.clock,
+            entity,
+            Some(1),
+        ))
+    }
+
+    struct WakeCounter {
+        wakes_count: Arc<AtomicUsize>,
+    }
+
+    impl Wake for WakeCounter {
+        fn wake(self: Arc<Self>) {
+            self.wakes_count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.wakes_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn counting_waker() -> (Arc<AtomicUsize>, Waker) {
+        let wakes_count = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(WakeCounter {
+            wakes_count: wakes_count.clone(),
+        }));
+
+        (wakes_count, waker)
+    }
+
+    #[test]
+    fn wake_counter_counts_wake_and_wake_by_ref() {
+        let (wakes_count, waker) = counting_waker();
+
+        waker.wake_by_ref();
+        assert_eq!(wakes_count.load(Ordering::SeqCst), 1);
+
+        waker.wake();
+        assert_eq!(wakes_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn in_port_state_can_only_connect_once() {
+        let context = test_context();
+        let in_port =
+            InPort::<i32>::new(&context.engine, &context.clock, context.engine.top(), "rx");
+
+        assert!(in_port.state().is_ok());
+
+        let err = in_port
+            .state()
+            .err()
+            .expect("second state call should fail");
+        assert!(format!("{err}").contains("already connected"));
+    }
+
+    #[test]
+    fn out_port_connect_can_only_connect_once() {
+        let context = test_context();
+        let mut out_port = OutPort::<i32>::new(context.engine.top(), "tx");
+        let first_in_port =
+            InPort::new(&context.engine, &context.clock, context.engine.top(), "rx1");
+        let second_in_port =
+            InPort::new(&context.engine, &context.clock, context.engine.top(), "rx2");
+
+        out_port.connect(first_in_port.state()).unwrap();
+
+        let err = out_port.connect(second_in_port.state()).unwrap_err();
+        assert!(format!("{err}").contains("already connected"));
+    }
+
+    #[test]
+    fn out_port_entity_returns_port_entity() {
+        let context = test_context();
+        let out_port = OutPort::<i32>::new(context.engine.top(), "tx");
+
+        assert!(Rc::ptr_eq(out_port.entity(), &out_port.entity));
+    }
+
+    #[test]
+    fn start_get_requires_connection_and_finish_get_wakes_putter() {
+        let context = test_context();
+        let in_port =
+            InPort::<i32>::new(&context.engine, &context.clock, context.engine.top(), "rx");
+
+        assert!(in_port.start_get().is_err());
+        assert!(in_port.state().is_ok());
+        assert!(in_port.start_get().is_ok());
+
+        let waker = noop_waker();
+        *in_port.state.waiting_put.borrow_mut() = Some(waker);
+        in_port.finish_get();
+
+        assert!(in_port.state.waiting_put.borrow().is_none());
+    }
+
+    #[test]
+    fn finish_get_without_waiting_putter_is_a_noop() {
+        let context = test_context();
+        let in_port =
+            InPort::<i32>::new(&context.engine, &context.clock, context.engine.top(), "rx");
+
+        in_port.finish_get();
+
+        assert!(in_port.state.waiting_put.borrow().is_none());
+    }
+
+    #[test]
+    fn port_put_reports_termination_after_second_poll() {
+        let state = test_state::<i32>();
+        let put = PortPut {
+            state: state.clone(),
+            value: RefCell::new(Some(123)),
+            done: RefCell::new(false),
+        };
+        let mut put = Box::pin(put);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(put.as_mut().poll(&mut cx), Poll::Pending);
+        assert!(!put.is_terminated());
+        assert_eq!(*state.value.borrow(), Some(123));
+        assert!(state.waiting_put.borrow().is_some());
+
+        assert_eq!(put.as_mut().poll(&mut cx), Poll::Ready(()));
+        assert!(put.is_terminated());
+    }
+
+    #[test]
+    fn port_try_put_waits_for_getter_then_completes() {
+        let state = test_state::<i32>();
+        let try_put = PortTryPut {
+            state: state.clone(),
+            done: false,
+        };
+        let mut try_put = Box::pin(try_put);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(try_put.as_mut().poll(&mut cx), Poll::Pending);
+        assert!(!try_put.is_terminated());
+        assert!(state.waiting_put.borrow().is_some());
+
+        *state.waiting_get.borrow_mut() = Some(noop_waker());
+
+        assert_eq!(try_put.as_mut().poll(&mut cx), Poll::Ready(()));
+        assert!(try_put.is_terminated());
+    }
+
+    #[test]
+    fn connected_out_port_creates_try_put_future() {
+        let context = test_context();
+        let mut out_port = OutPort::<i32>::new(context.engine.top(), "tx");
+        let in_port = InPort::new(&context.engine, &context.clock, context.engine.top(), "rx");
+
+        out_port.connect(in_port.state()).unwrap();
+
+        assert!(out_port.try_put().is_ok());
+    }
+
+    #[test]
+    fn port_get_waits_then_returns_value_and_reports_termination() {
+        let state = test_state::<i32>();
+        let get = PortGet {
+            state: state.clone(),
+            done: false,
+        };
+        let mut get = Box::pin(get);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(get.as_mut().poll(&mut cx), Poll::Pending);
+        assert!(!get.is_terminated());
+        assert!(state.waiting_get.borrow().is_some());
+
+        *state.value.borrow_mut() = Some(456);
+        *state.waiting_put.borrow_mut() = Some(noop_waker());
+
+        assert_eq!(get.as_mut().poll(&mut cx), Poll::Ready(456));
+        assert!(get.is_terminated());
+        assert!(state.waiting_put.borrow().is_none());
+    }
+
+    #[test]
+    fn port_get_pending_wakes_waiting_putter() {
+        let state = test_state::<i32>();
+        let get = PortGet {
+            state: state.clone(),
+            done: false,
+        };
+        let mut get = Box::pin(get);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        *state.waiting_put.borrow_mut() = Some(noop_waker());
+
+        assert_eq!(get.as_mut().poll(&mut cx), Poll::Pending);
+
+        assert!(state.waiting_put.borrow().is_none());
+        assert!(state.waiting_get.borrow().is_some());
+    }
+
+    #[test]
+    fn port_get_samples_monitored_values() {
+        let state = monitored_test_state::<i32>();
+        let monitor = state
+            .monitor
+            .as_ref()
+            .expect("monitored state should create a monitor");
+        let get = PortGet {
+            state: state.clone(),
+            done: false,
+        };
+        let mut get = Box::pin(get);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        *state.value.borrow_mut() = Some(456);
+
+        assert_eq!(get.as_mut().poll(&mut cx), Poll::Ready(456));
+        assert_eq!(monitor.bytes_in_window(), 456_i32.total_bytes());
+    }
+
+    #[test]
+    fn port_start_get_waits_then_returns_value_without_finishing_put() {
+        let state = test_state::<i32>();
+        let start_get = PortStartGet {
+            state: state.clone(),
+            done: false,
+        };
+        let mut start_get = Box::pin(start_get);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(start_get.as_mut().poll(&mut cx), Poll::Pending);
+        assert!(!start_get.is_terminated());
+        assert!(state.waiting_get.borrow().is_some());
+
+        let (waiting_put_wakes, waiting_put_waker) = counting_waker();
+        *state.waiting_put.borrow_mut() = Some(waiting_put_waker.clone());
+        *state.value.borrow_mut() = Some(789);
+
+        assert_eq!(start_get.as_mut().poll(&mut cx), Poll::Ready(789));
+        assert!(start_get.is_terminated());
+        assert!(state.waiting_get.borrow().is_none());
+        assert_eq!(waiting_put_wakes.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn port_start_get_samples_monitored_values() {
+        let state = monitored_test_state::<i32>();
+        let monitor = state
+            .monitor
+            .as_ref()
+            .expect("monitored state should create a monitor");
+        let start_get = PortStartGet {
+            state: state.clone(),
+            done: false,
+        };
+        let mut start_get = Box::pin(start_get);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        *state.value.borrow_mut() = Some(789);
+
+        assert_eq!(start_get.as_mut().poll(&mut cx), Poll::Ready(789));
+        assert_eq!(monitor.bytes_in_window(), 789_i32.total_bytes());
     }
 }

--- a/gwr-engine/src/port/monitor.rs
+++ b/gwr-engine/src/port/monitor.rs
@@ -59,6 +59,21 @@ impl Monitor {
         let object_bytes = object.total_bytes();
         *self.bytes_in_window.borrow_mut() += object_bytes;
     }
+
+    #[cfg(test)]
+    pub(crate) fn bytes_in_window(&self) -> usize {
+        *self.bytes_in_window.borrow()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn bytes_total(&self) -> usize {
+        *self.bytes_total.borrow()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn last_time_ns(&self) -> f64 {
+        *self.last_time_ns.borrow()
+    }
 }
 
 #[async_trait(?Send)]
@@ -82,5 +97,49 @@ impl Runnable for Monitor {
 
             *self.last_time_ns.borrow_mut() = time_now_ns;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+    use std::rc::Rc;
+
+    use gwr_track::entity::Entity;
+    use gwr_track::tracker::dev_null_tracker;
+
+    use super::*;
+
+    #[test]
+    fn new_and_register_initializes_monitor_and_sample_counts_bytes() {
+        let tracker = dev_null_tracker();
+        let mut engine = Engine::new(&tracker);
+        let clock = engine.default_clock();
+        let parent = engine.top().clone();
+        let entity = Rc::new(Entity::new(&parent, "port"));
+
+        let monitor = Monitor::new_and_register(&engine, &entity, &clock, 4);
+
+        assert_eq!(monitor.window_size_ticks, 4);
+        assert_eq!(monitor.bytes_in_window(), 0);
+        assert_eq!(monitor.bytes_total(), 0);
+        assert_eq!(monitor.last_time_ns(), 0.0);
+
+        monitor.sample(&123_i32);
+
+        assert_eq!(monitor.bytes_in_window(), size_of::<i32>());
+
+        {
+            let clock = clock.clone();
+            engine.spawn(async move {
+                clock.wait_ticks(4).await;
+                Ok(())
+            });
+        }
+
+        engine.run().unwrap();
+
+        assert_eq!(monitor.bytes_in_window(), 0);
+        assert_eq!(monitor.bytes_total(), size_of::<i32>());
     }
 }

--- a/gwr-engine/src/time/clock.rs
+++ b/gwr-engine/src/time/clock.rs
@@ -264,7 +264,7 @@ impl Clock {
     /// Returns the time in `ns` of the next event registered with this clock.
     #[must_use]
     pub fn time_of_next(&self) -> f64 {
-        match self.shared_state.waiting_times.borrow().first() {
+        match self.shared_state.waiting_times.borrow().last() {
             Some(clock_time) => self.to_ns(clock_time),
             None => f64::MAX,
         }
@@ -421,6 +421,11 @@ impl Drop for ClockDelay {
 
 #[cfg(test)]
 mod tests {
+    use std::mem::drop;
+    use std::task::Context;
+
+    use futures::task::noop_waker;
+
     use super::*;
 
     #[test]
@@ -430,5 +435,107 @@ mod tests {
 
         let slow_clk = Clock::new(0.5);
         assert_eq!(2000.0, slow_clk.to_ns(&ClockTick::new().set_tick(1)));
+    }
+
+    #[test]
+    fn clock_tick_accessors_default_display_and_ordering() {
+        let default_tick = ClockTick::default();
+        assert_eq!(default_tick.tick(), 0);
+        #[cfg(not(feature = "phase"))]
+        assert_eq!(default_tick.to_string(), "0");
+        #[cfg(feature = "phase")]
+        assert_eq!(default_tick.to_string(), "0.0");
+
+        let earlier = ClockTick::new().set_tick(1);
+        let later = ClockTick::new().set_tick(2);
+        assert!(earlier < later);
+        assert_eq!(earlier.partial_cmp(&later), Some(Ordering::Less));
+    }
+
+    #[cfg(feature = "phase")]
+    #[test]
+    fn clock_tick_phase_accessors_display_and_ordering() {
+        let tick = ClockTick::new().set_tick(1).set_phase(2);
+        assert_eq!(tick.phase(), 2);
+        assert_eq!(tick.to_string(), "1.2");
+
+        let earlier_phase = ClockTick::new().set_tick(1).set_phase(1);
+        assert!(earlier_phase < tick);
+
+        let later_tick = ClockTick::new().set_tick(2).set_phase(0);
+        assert!(later_tick > tick);
+    }
+
+    #[test]
+    fn clock_default_advance_and_ordering() {
+        let clock = Clock::default();
+        assert_eq!(clock.freq_mhz(), 1000.0);
+
+        clock.advance_to(2.1);
+        assert_eq!(clock.tick_now().tick(), 3);
+        assert_eq!(clock.time_now_ns(), 3.0);
+
+        let earlier = Clock::new(1000.0);
+        let later = Clock::new(1000.0);
+        drop(earlier.wait_ticks(1));
+        drop(later.wait_ticks(2));
+
+        assert!(earlier == later);
+        assert_eq!(earlier.partial_cmp(&later), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn unschedule_unknown_waiter_is_a_noop() {
+        let clock = Clock::new(1000.0);
+        let scheduled_time = ClockTick::new().set_tick(1);
+
+        clock
+            .shared_state
+            .waiting_times
+            .borrow_mut()
+            .push(scheduled_time);
+        clock.shared_state.waiting.borrow_mut().push(Vec::new());
+
+        clock.shared_state.unschedule(scheduled_time, 7);
+
+        assert_eq!(clock.shared_state.waiting_times.borrow().len(), 1);
+        assert_eq!(clock.shared_state.waiting.borrow().len(), 1);
+    }
+
+    #[test]
+    fn unschedule_waiter_keeps_time_when_other_waiters_remain() {
+        let clock = Clock::new(1000.0);
+        let scheduled_time = ClockTick::new().set_tick(1);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let first_waiter_id = clock.shared_state.schedule(scheduled_time, &mut cx, false);
+        let second_waiter_id = clock.shared_state.schedule(scheduled_time, &mut cx, false);
+
+        clock
+            .shared_state
+            .unschedule(scheduled_time, first_waiter_id);
+
+        let waiting_times = clock.shared_state.waiting_times.borrow();
+        let waiting = clock.shared_state.waiting.borrow();
+
+        assert_eq!(waiting_times.as_slice(), &[scheduled_time]);
+        assert_eq!(waiting.len(), 1);
+        assert_eq!(waiting[0].len(), 1);
+        assert_eq!(waiting[0][0].id, second_waiter_id);
+    }
+
+    #[cfg(feature = "phase")]
+    #[test]
+    fn phase_wait_helpers_schedule_phase_delays() {
+        let clock = Clock::new(1000.0);
+
+        let next_tick = clock.next_tick_and_phase(3);
+        assert_eq!(next_tick.until.tick(), 1);
+        assert_eq!(next_tick.until.phase(), 3);
+
+        let same_tick = clock.wait_phase(1);
+        assert_eq!(same_tick.until.tick(), 0);
+        assert_eq!(same_tick.until.phase(), 1);
     }
 }

--- a/gwr-engine/src/time/mod.rs
+++ b/gwr-engine/src/time/mod.rs
@@ -23,3 +23,19 @@ pub fn compute_adjusted_value_and_rate(
     let count_per_second = per_second.get_appropriate_unit(UnitType::Binary);
     (count, count_per_second)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adjusted_value_and_rate_handles_zero_and_elapsed_time() {
+        let (count, rate) = compute_adjusted_value_and_rate(0.0, 1024);
+        assert_eq!(count.get_value(), 1.0);
+        assert_eq!(rate.get_value(), 0.0);
+
+        let (count, rate) = compute_adjusted_value_and_rate(1_000_000_000.0, 2048);
+        assert_eq!(count.get_value(), 2.0);
+        assert_eq!(rate.get_value(), 2.0);
+    }
+}

--- a/gwr-engine/src/time/simtime.rs
+++ b/gwr-engine/src/time/simtime.rs
@@ -92,6 +92,11 @@ impl SimTime {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use futures::task::noop_waker;
     use gwr_track::entity::toplevel;
     use gwr_track::test_helpers::create_tracker;
 
@@ -121,5 +126,51 @@ mod tests {
 
         let _clk2 = time.get_clock(1800.0);
         assert_eq!(time.clocks.len(), 2);
+    }
+
+    #[test]
+    fn advance_time_returns_none_without_waiters() {
+        let tracker = create_tracker(file!());
+        let top = toplevel(&tracker, "top");
+
+        let mut time = SimTime::new(&top);
+        assert!(time.advance_time().is_none());
+
+        let _clock = time.get_clock(1000.0);
+        assert!(time.advance_time().is_none());
+    }
+
+    #[test]
+    fn advance_time_handles_equal_times_on_different_clocks() {
+        let tracker = create_tracker(file!());
+        let top = toplevel(&tracker, "top");
+
+        let mut time = SimTime::new(&top);
+        let clock_1ghz = time.get_clock(1000.0);
+        let clock_2ghz = time.get_clock(2000.0);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut delays = [
+            clock_1ghz.wait_ticks(1),
+            clock_1ghz.wait_ticks(2),
+            clock_2ghz.wait_ticks(2),
+            clock_2ghz.wait_ticks(4),
+        ];
+
+        for delay in &mut delays {
+            assert_eq!(Pin::new(delay).poll(&mut cx), Poll::Pending);
+        }
+
+        for expected_ns in [1.0, 1.0, 2.0, 2.0] {
+            let wakers = time.advance_time().unwrap();
+
+            assert_eq!(wakers.len(), 1);
+            assert_eq!(time.time_now_ns(), expected_ns);
+        }
+
+        assert_eq!(clock_1ghz.tick_now().tick(), 2);
+        assert_eq!(clock_2ghz.tick_now().tick(), 4);
+        assert!(time.advance_time().is_none());
     }
 }

--- a/gwr-engine/src/traits.rs
+++ b/gwr-engine/src/traits.rs
@@ -170,3 +170,44 @@ pub trait Runnable {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests added simply for code coverage
+    #[test]
+    fn integer_sim_object_defaults_are_available() {
+        assert_eq!(0_i32.total_bytes(), size_of::<i32>());
+        assert_eq!(7_i32.destination(), 7);
+        assert_eq!(0_i32.access_type(), AccessType::ReadRequest);
+        assert_eq!(1_i32.access_type(), AccessType::WriteRequest);
+        assert_eq!(2_i32.access_type(), AccessType::WriteNonPostedRequest);
+        assert_eq!(3_i32.access_type(), AccessType::ReadResponse);
+        assert_eq!(4_i32.access_type(), AccessType::WriteNonPostedResponse);
+        assert_eq!(5_i32.access_type(), AccessType::Control);
+
+        assert_eq!(0_usize.total_bytes(), size_of::<usize>());
+        assert_eq!(7_usize.destination(), 7);
+        assert_eq!(0_usize.access_type(), AccessType::ReadRequest);
+        assert_eq!(1_usize.access_type(), AccessType::WriteRequest);
+        assert_eq!(2_usize.access_type(), AccessType::WriteNonPostedRequest);
+        assert_eq!(3_usize.access_type(), AccessType::ReadResponse);
+        assert_eq!(4_usize.access_type(), AccessType::WriteNonPostedResponse);
+        assert_eq!(5_usize.access_type(), AccessType::Control);
+    }
+
+    struct PassiveRunnable;
+
+    #[test]
+    fn runnable_default_run_completes_successfully() {
+        let runnable = PassiveRunnable;
+
+        futures::executor::LocalPool::new()
+            .run_until(runnable.run())
+            .unwrap();
+    }
+
+    #[async_trait(?Send)]
+    impl Runnable for PassiveRunnable {}
+}

--- a/gwr-engine/src/types.rs
+++ b/gwr-engine/src/types.rs
@@ -78,3 +78,25 @@ impl fmt::Display for AccessType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test added for code coverage
+    #[test]
+    fn access_type_display_names_match_variants() {
+        assert_eq!(AccessType::ReadRequest.to_string(), "ReadRequest");
+        assert_eq!(AccessType::WriteRequest.to_string(), "WriteRequest");
+        assert_eq!(
+            AccessType::WriteNonPostedRequest.to_string(),
+            "WriteNonPostedRequest"
+        );
+        assert_eq!(AccessType::ReadResponse.to_string(), "ReadResponse");
+        assert_eq!(
+            AccessType::WriteNonPostedResponse.to_string(),
+            "WriteNonPostedResponse"
+        );
+        assert_eq!(AccessType::Control.to_string(), "Control");
+    }
+}

--- a/gwr-engine/tests/engine.rs
+++ b/gwr-engine/tests/engine.rs
@@ -8,9 +8,11 @@ use std::task::{Context, Poll};
 
 use gwr_components::sink::Sink;
 use gwr_components::source::Source;
+use gwr_engine::engine::Engine;
 use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 use gwr_engine::types::SimResult;
+use gwr_track::tracker::dev_null_tracker;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -44,6 +46,78 @@ fn all_spawned() {
 
     source.connect_port_tx(sink.port_rx()).unwrap();
     run_simulation!(engine);
+}
+
+#[test]
+fn default_engine_runs() {
+    let mut engine = Engine::default();
+    let clock = engine.default_clock();
+
+    engine.spawn(async move {
+        clock.wait_ticks(1).await;
+        Ok(())
+    });
+
+    run_simulation!(engine);
+
+    assert_eq!(engine.time_now_ns(), 1.0);
+}
+
+#[test]
+fn clock_khz_sets_clock_frequency() {
+    let mut engine = start_test(file!());
+    let clock = engine.clock_khz(1.0);
+
+    engine.spawn(async move {
+        clock.wait_ticks(1).await;
+        Ok(())
+    });
+
+    run_simulation!(engine);
+
+    assert_eq!(engine.time_now_ns(), 1_000_000.0);
+}
+
+#[test]
+fn clock_ghz_sets_clock_frequency() {
+    let mut engine = start_test(file!());
+    let clock = engine.clock_ghz(2.0);
+
+    engine.spawn(async move {
+        clock.wait_ticks(1).await;
+        Ok(())
+    });
+
+    run_simulation!(engine);
+
+    assert_eq!(engine.time_now_ns(), 0.5);
+}
+
+#[test]
+fn spawner_can_spawn_tasks() {
+    let mut engine = start_test(file!());
+    let spawner = engine.spawner();
+    let ran = Rc::new(Cell::new(false));
+
+    {
+        let ran = ran.clone();
+        spawner.spawn(async move {
+            ran.set(true);
+            Ok(())
+        });
+    }
+
+    run_simulation!(engine);
+
+    assert!(ran.get());
+}
+
+#[test]
+fn tracker_returns_shared_tracker() {
+    let tracker = dev_null_tracker();
+    let engine = Engine::new(&tracker);
+
+    assert!(Rc::ptr_eq(&tracker, &engine.tracker()));
 }
 
 #[test]


### PR DESCRIPTION
Coverage before:
gwr-engine/src/engine.rs           86.96% (20/23)  89.13% (82/92)    89.80% (132/147)
gwr-engine/src/events/all_of.rs    77.78% (7/9)    88.68% (47/53)    89.71% (61/68)
gwr-engine/src/events/any_of.rs    77.78% (7/9)    88.46% (46/52)    89.71% (61/68)
gwr-engine/src/events/once.rs      81.82% (9/11)   90.32% (56/62)    89.23% (58/65)
gwr-engine/src/events/repeated.rs  66.67% (8/12)   78.12% (50/64)    80.00% (60/75)
gwr-engine/src/events/waiting.rs   83.33% (5/6)    91.18% (31/34)    91.89% (34/37)
gwr-engine/src/executor.rs        100.00% (17/17) 100.00% (124/124) 100.00% (165/165)
gwr-engine/src/lib.rs             100.00% (1/1)   100.00% (1/1)      75.00% (3/4)
gwr-engine/src/port/mod.rs         83.33% (20/24)  90.64% (155/171)  87.50% (182/208)
gwr-engine/src/port/monitor.rs      0.00% (0/3)     0.00% (0/28)      0.00% (0/31)
gwr-engine/src/test_helpers.rs    100.00% (1/1)   100.00% (6/6)     100.00% (10/10)
gwr-engine/src/time/clock.rs       75.68% (28/37)  77.63% (177/228)  78.28% (227/290)
gwr-engine/src/time/mod.rs          0.00% (0/1)     0.00% (0/12)      0.00% (0/20)
gwr-engine/src/time/simtime.rs    100.00% (8/8)    96.67% (58/60)    97.30% (108/111)
gwr-engine/src/traits.rs           62.50% (5/8)    40.00% (14/35)    40.00% (14/35)
gwr-engine/src/types.rs           100.00% (2/2)    83.33% (10/12)    78.95% (15/19)

Coverage with this diff
gwr-engine/src/engine.rs          100.00% (23/23) 100.00% (92/92)   100.00% (147/147)
gwr-engine/src/events/all_of.rs   100.00% (11/11) 100.00% (72/72)   100.00% (93/93)
gwr-engine/src/events/any_of.rs   100.00% (11/11) 100.00% (71/71)   100.00% (93/93)
gwr-engine/src/events/once.rs     100.00% (14/14) 100.00% (86/86)   100.00% (96/96)
gwr-engine/src/events/repeated.rs 100.00% (16/16) 100.00% (95/95)   100.00% (115/115)
gwr-engine/src/events/waiting.rs  100.00% (8/8)   100.00% (51/51)   100.00% (74/74)
gwr-engine/src/executor.rs        100.00% (21/21) 100.00% (157/157) 100.00% (225/225)
gwr-engine/src/lib.rs             100.00% (3/3)   100.00% (14/14)   100.00% (30/30)
gwr-engine/src/port/mod.rs        100.00% (44/44)  99.75% (392/393)  99.84% (643/644)
gwr-engine/src/port/monitor.rs    100.00% (6/6)   100.00% (54/54)   100.00% (86/86)
gwr-engine/src/test_helpers.rs    100.00% (1/1)   100.00% (6/6)     100.00% (10/10)
gwr-engine/src/time/clock.rs      100.00% (43/43)  99.66% (297/298)  99.55% (440/442)
gwr-engine/src/time/mod.rs        100.00% (2/2)   100.00% (20/20)   100.00% (40/40)
gwr-engine/src/time/simtime.rs    100.00% (10/10) 100.00% (92/92)   100.00% (191/191)
gwr-engine/src/traits.rs          100.00% (10/10) 100.00% (59/59)   100.00% (94/94)
gwr-engine/src/types.rs           100.00% (3/3)   100.00% (22/22)   100.00% (39/39)
