### PR TITLE
infra: stop caching mdbook build directories in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,10 +92,6 @@ jobs:
         with:
           command: cargo test --all-features --verbose
           cache-name: ${{ github.job }}
-          paths: |
-            target/
-            gwr-developer-guide/doctest_cache/
-            gwr-developer-guide/rustdoc_cache/
 
   benchmark:
     strategy:


### PR DESCRIPTION
We have seen mdbook builds pass which should have failed when the cache
contianed build objects prior to API changes in packages used in example
code embedded in the book.
