### PR TITLE
refactor(gwr-engine): Add Unpin to SimObject to allow PortPut to auto-derive Unpin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/examples/flaky-component/Cargo.toml
+++ b/examples/flaky-component/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.11.0" }
 rand.workspace = true

--- a/examples/flaky-with-delay/Cargo.toml
+++ b/examples/flaky-with-delay/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.11.0" }
 rand.workspace = true

--- a/examples/scrambler/Cargo.toml
+++ b/examples/scrambler/Cargo.toml
@@ -22,6 +22,6 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.11.0" }

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }

--- a/examples/sim-restaurant/Cargo.toml
+++ b/examples/sim-restaurant/Cargo.toml
@@ -21,7 +21,7 @@ clap.workspace = true
 crossterm.workspace = true
 futures.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
 log.workspace = true
 rand.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -21,7 +21,7 @@ publish.workspace = true
 [dependencies]
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }

--- a/gwr-components/Cargo.toml
+++ b/gwr-components/Cargo.toml
@@ -30,7 +30,7 @@ harness = false
 async-trait.workspace = true
 futures.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
 gwr-track = { path = "../gwr-track", version = "0.11.0" }

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-engine"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-engine/src/port/mod.rs
+++ b/gwr-engine/src/port/mod.rs
@@ -216,8 +216,8 @@ where
         };
         Ok(PortPut {
             state,
-            value: RefCell::new(Some(value)),
-            done: RefCell::new(false),
+            value: Some(value),
+            done: false,
         })
     }
 
@@ -236,8 +236,8 @@ where
     T: SimObject,
 {
     state: Rc<PortState<T>>,
-    value: RefCell<Option<T>>,
-    done: RefCell<bool>,
+    value: Option<T>,
+    done: bool,
 }
 
 impl<T> Future for PortPut<T>
@@ -246,7 +246,7 @@ where
 {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.value.take() {
             Some(value) => {
                 // The state is designed to be shared between one put/get pair so it should
@@ -262,7 +262,7 @@ where
             }
             None => {
                 // Value already sent, woken because it has been consumed
-                *self.done.borrow_mut() = true;
+                self.done = true;
                 Poll::Ready(())
             }
         }
@@ -274,7 +274,7 @@ where
     T: SimObject,
 {
     fn is_terminated(&self) -> bool {
-        *self.done.borrow()
+        self.done
     }
 }
 
@@ -566,8 +566,8 @@ mod tests {
         let state = test_state::<i32>();
         let put = PortPut {
             state: state.clone(),
-            value: RefCell::new(Some(123)),
-            done: RefCell::new(false),
+            value: Some(123),
+            done: false,
         };
         let mut put = Box::pin(put);
         let waker = noop_waker();

--- a/gwr-engine/src/port/mod.rs
+++ b/gwr-engine/src/port/mod.rs
@@ -34,6 +34,7 @@ where
     T: SimObject,
 {
     value: RefCell<Option<T>>,
+    put_released: RefCell<bool>,
     waiting_get: RefCell<Option<Waker>>,
     waiting_put: RefCell<Option<Waker>>,
     pub in_port_entity: Rc<Entity>,
@@ -55,6 +56,7 @@ where
         });
         Self {
             value: RefCell::new(None),
+            put_released: RefCell::new(true),
             waiting_get: RefCell::new(None),
             waiting_put: RefCell::new(None),
             in_port_entity,
@@ -143,6 +145,7 @@ where
 
     /// Must be matched with a `start_get ` to consume the value.
     pub fn finish_get(&self) {
+        *self.state.put_released.borrow_mut() = true;
         if let Some(waker) = self.state.waiting_put.borrow_mut().take() {
             waker.wake();
         }
@@ -254,6 +257,7 @@ where
                 assert!(self.state.value.borrow().is_none());
 
                 *self.state.value.borrow_mut() = Some(value);
+                *self.state.put_released.borrow_mut() = false;
                 if let Some(waker) = self.state.waiting_get.borrow_mut().take() {
                     waker.wake();
                 }
@@ -261,9 +265,16 @@ where
                 Poll::Pending
             }
             None => {
-                // Value already sent, woken because it has been consumed
-                self.done = true;
-                Poll::Ready(())
+                if *self.state.put_released.borrow() {
+                    // Getter has consumed the value and released the putter.
+                    self.done = true;
+                    Poll::Ready(())
+                } else {
+                    // Stay pending as the task was woken before the getter has removed
+                    // the value and released the putter.
+                    *self.state.waiting_put.borrow_mut() = Some(cx.waker().clone());
+                    Poll::Pending
+                }
             }
         }
     }
@@ -331,6 +342,7 @@ where
         if let Some(value) = value {
             self.done = true;
             self.state.waiting_get.borrow_mut().take();
+            *self.state.put_released.borrow_mut() = true;
 
             // Track the object through the port monitor if there is one
             if let Some(monitor) = self.state.monitor.as_ref() {
@@ -562,7 +574,7 @@ mod tests {
     }
 
     #[test]
-    fn port_put_reports_termination_after_second_poll() {
+    fn port_put_waits_until_value_is_consumed_before_terminating() {
         let state = test_state::<i32>();
         let put = PortPut {
             state: state.clone(),
@@ -577,6 +589,42 @@ mod tests {
         assert!(!put.is_terminated());
         assert_eq!(*state.value.borrow(), Some(123));
         assert!(state.waiting_put.borrow().is_some());
+
+        assert_eq!(put.as_mut().poll(&mut cx), Poll::Pending);
+        assert!(!put.is_terminated());
+
+        assert_eq!(state.value.borrow_mut().take(), Some(123));
+        *state.put_released.borrow_mut() = true;
+
+        assert_eq!(put.as_mut().poll(&mut cx), Poll::Ready(()));
+        assert!(put.is_terminated());
+    }
+
+    #[test]
+    fn port_put_waits_for_start_get_to_finish_before_terminating() {
+        let state = test_state::<i32>();
+        let put = PortPut {
+            state: state.clone(),
+            value: Some(123),
+            done: false,
+        };
+        let mut put = Box::pin(put);
+        let start_get = PortStartGet {
+            state: state.clone(),
+            done: false,
+        };
+        let mut start_get = Box::pin(start_get);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(put.as_mut().poll(&mut cx), Poll::Pending);
+        assert_eq!(start_get.as_mut().poll(&mut cx), Poll::Ready(123));
+        assert!(state.value.borrow().is_none());
+
+        assert_eq!(put.as_mut().poll(&mut cx), Poll::Pending);
+        assert!(!put.is_terminated());
+
+        *state.put_released.borrow_mut() = true;
 
         assert_eq!(put.as_mut().poll(&mut cx), Poll::Ready(()));
         assert!(put.is_terminated());

--- a/gwr-engine/src/traits.rs
+++ b/gwr-engine/src/traits.rs
@@ -39,12 +39,13 @@ pub trait Routable {
 ///    Debug. We could require Display, but that requires explicit
 ///    implementation.
 ///  - Routable:    Allows routing.
-///  - TotalBytes:  Allows rate limiting.
 ///  - Unique:      Allows for unique identification of `Entities`.
+///  - TotalBytes:  Allows rate limiting.
+///  - Unpin:       Required in order to be able to Unpin in port futures.
 ///  - 'static:     Due to the way that futures are implemented, the lifetimes
 ///    need to be `static. This means that objects may have to be placed in
 ///    `Box` to make the static.
-pub trait SimObject: Clone + Debug + Display + Unique + TotalBytes + 'static {}
+pub trait SimObject: Clone + Debug + Display + Unique + TotalBytes + Unpin + 'static {}
 
 // Implementations for basic types that can be sent around the simulation for
 // testing

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -32,7 +32,7 @@ clap.workspace = true
 futures.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-components = { path = "../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
 gwr-track = { path = "../gwr-track", version = "0.11.0" }

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.19.0" }
 gwr-track = { path = "../gwr-track", version = "0.11.0" }

--- a/gwr-protocols/Cargo.toml
+++ b/gwr-protocols/Cargo.toml
@@ -23,5 +23,5 @@ paste.workspace = true
 
 [dev-dependencies]
 gwr-components = { path = "../gwr-components", version = "0.9.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-track = { path = "../gwr-track", version = "0.11.0" }

--- a/gwr-resources/Cargo.toml
+++ b/gwr-resources/Cargo.toml
@@ -19,7 +19,7 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 
 [dev-dependencies]
 gwr-track = { path = "../gwr-track", version = "0.11.0" }

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -27,7 +27,7 @@ publish.workspace = true
 async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
-gwr-engine = { path = "../gwr-engine", version = "0.11.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.12.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.19.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.4.0" }

--- a/licenses.html
+++ b/licenses.html
@@ -8346,7 +8346,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-developer-guide 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-doc-builder 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-docpp 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.11.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.12.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-model-builder 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.19.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx 0.1.0</a></li>


### PR DESCRIPTION
This allows the tools to derive `DerefMut` and therefore use the `PortPut` as mutable so no longer requiring the `RefCell` around members. This should speed up the benchmarks slightly.