### PR TITLE
refactor(gwr-terminus): Fix arg parsing and remove color-eyre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ flamegraph*
 *.profdata
 node_modules/
 .lycheecache
+mmdc-config.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,21 +191,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
 
 [[package]]
 name = "base64"
@@ -499,33 +469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -904,16 +847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,12 +1109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,7 +1364,6 @@ name = "gwr-terminus"
 version = "0.4.0"
 dependencies = [
  "clap",
- "color-eyre",
  "crossterm",
  "env_logger",
  "log",
@@ -1646,12 +1572,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -1951,15 +1871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,15 +1985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,12 +2010,6 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "page_size"
@@ -2879,12 +2775,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
@@ -3751,16 +3641,6 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
-dependencies = [
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/gwr-terminus/Cargo.toml
+++ b/gwr-terminus/Cargo.toml
@@ -24,7 +24,6 @@ publish.workspace = true
 
 [dependencies]
 clap.workspace = true
-color-eyre = "0.6.3"
 crossterm.workspace = true
 env_logger = "0.11.8"
 log.workspace = true

--- a/gwr-terminus/src/bin/terminus.rs
+++ b/gwr-terminus/src/bin/terminus.rs
@@ -11,12 +11,11 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 use clap::{Parser, Subcommand};
-use color_eyre::Result;
 use crossterm::event::{self, Event};
-use gwr_terminus::CliLogger;
 use gwr_terminus::command::Command;
 use gwr_terminus::recipe::Recipe;
 use gwr_terminus::tui::Tui;
+use gwr_terminus::{CliLogger, Result};
 use log::{LevelFilter, info};
 use ratatui::Terminal;
 use ratatui::prelude::CrosstermBackend;
@@ -216,16 +215,16 @@ fn run_recipe(
     recipe: &String,
     recipe_help: bool,
     args: &[String],
-) -> color_eyre::eyre::Result<()> {
+) -> Result<()> {
     let recipe_path = PathBuf::from(recipe);
     let mut recipe = Recipe::new_from_file(recipe_path.as_path())?;
     if recipe_help {
         recipe.print_help();
     } else {
-        recipe.parse_cli_args(args);
+        recipe.parse_cli_args(args)?;
         recipe.execute(tmp_root, keep_tmp, exit_on_error, &mut CliLogger {})?;
     }
-    color_eyre::eyre::Ok(())
+    Ok(())
 }
 
 fn write_recipe(
@@ -250,11 +249,10 @@ fn write_recipe(
     info!("Writing {recipe}");
     app.write_recipe();
 
-    color_eyre::eyre::Ok(())
+    Ok(())
 }
 
 fn start_write_recipe_tui(history: &PathBuf, recipes_folder: &str) -> Result<()> {
-    color_eyre::install()?;
     let mut app = gwr_terminus::writer::app::App::new(history, recipes_folder, true);
 
     // Initialize the terminal user interface.
@@ -275,7 +273,7 @@ fn start_write_recipe_tui(history: &PathBuf, recipes_folder: &str) -> Result<()>
 
     // Exit the user interface.
     tui.exit()?;
-    color_eyre::eyre::Ok(())
+    Ok(())
 }
 
 fn start_run_recipe_tui(
@@ -284,7 +282,6 @@ fn start_run_recipe_tui(
     keep_tmp: bool,
     exit_on_error: bool,
 ) -> Result<()> {
-    color_eyre::install()?;
     let mut app =
         gwr_terminus::runner::app::App::new(recipes_folder, tmp_root, keep_tmp, exit_on_error);
 
@@ -306,5 +303,5 @@ fn start_run_recipe_tui(
 
     // Exit the user interface.
     tui.exit()?;
-    color_eyre::eyre::Ok(())
+    Ok(())
 }

--- a/gwr-terminus/src/lib.rs
+++ b/gwr-terminus/src/lib.rs
@@ -3,6 +3,8 @@
 use log::{error, info};
 use ratatui::style::{Color, Style};
 
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
 /// Trait defining an error handler function
 pub trait Logger {
     fn error(&mut self, message: &str);

--- a/gwr-terminus/src/recipe/mod.rs
+++ b/gwr-terminus/src/recipe/mod.rs
@@ -6,13 +6,12 @@ use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, ExitStatus, Output, Stdio};
 
-use color_eyre::eyre::Context;
-use log::{debug, error};
+use log::debug;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::Logger;
 use crate::command::Command;
+use crate::{Logger, Result};
 
 pub mod converter;
 
@@ -93,12 +92,17 @@ fn build_regexs() -> (Regex, Regex) {
 }
 
 impl Recipe {
-    pub fn new_from_file(recipe_path: &Path) -> color_eyre::eyre::Result<Self> {
-        let file_contents = fs::read_to_string(recipe_path)
-            .wrap_err_with(|| format!("Failed to read {}", recipe_path.display()));
+    pub fn new_from_file(recipe_path: &Path) -> Result<Self> {
+        let file_contents = fs::read_to_string(recipe_path).map_err(|e| {
+            io::Error::other(format!("Failed to read {}: {e}", recipe_path.display()))
+        });
         let mut recipe_result = match file_contents {
-            Ok(file_contents) => serde_yaml_ng::from_str::<Recipe>(&file_contents)
-                .wrap_err_with(|| format!("Failed to parse contents of {}", recipe_path.display())),
+            Ok(file_contents) => serde_yaml_ng::from_str::<Recipe>(&file_contents).map_err(|e| {
+                io::Error::other(format!(
+                    "Failed to parse contents of {}: {e}",
+                    recipe_path.display()
+                ))
+            }),
             Err(e) => Err(e),
         };
 
@@ -113,7 +117,7 @@ impl Recipe {
                 }
             }
         }
-        recipe_result
+        Ok(recipe_result?)
     }
 
     #[must_use]
@@ -189,8 +193,8 @@ impl Recipe {
     }
 
     /// Parse arguments from the command-line so that all the current
-    pub fn parse_cli_args(&mut self, args: &[String]) {
-        self.parse_args(args);
+    pub fn parse_cli_args(&mut self, args: &[String]) -> Result<()> {
+        self.parse_args(args)
     }
 
     /// Execute a recipe by writing out a single shell script which is called.
@@ -200,11 +204,13 @@ impl Recipe {
         keep_tmp: bool,
         exit_on_error: bool,
         logger: &mut impl Logger,
-    ) -> color_eyre::eyre::Result<()> {
+    ) -> Result<()> {
         let tmp_str = tmp_root.to_string_lossy().to_string() + ".sh";
         let script_path = PathBuf::from(tmp_str);
         self.write_script(&script_path, exit_on_error)
-            .wrap_err_with(|| format!("Failed to write {}", script_path.display()))?;
+            .map_err(|e| {
+                io::Error::other(format!("Failed to write {}: {e}", script_path.display()))
+            })?;
 
         if log::log_enabled!(log::Level::Debug) {
             match fs::read_to_string(&script_path) {
@@ -220,14 +226,20 @@ impl Recipe {
         }
 
         // Ensure the path is absolute so that there are no issues executing it
-        let script_path = fs::canonicalize(&script_path)
-            .wrap_err_with(|| format!("Failed to canonicalize {}", script_path.display()))?;
-        run_script_as_interactive(&script_path, logger, true)
-            .wrap_err_with(|| format!("Running '{}' failed", script_path.display()))?;
+        let script_path = fs::canonicalize(&script_path).map_err(|e| {
+            io::Error::other(format!(
+                "Failed to canonicalize {}: {e}",
+                script_path.display()
+            ))
+        })?;
+        run_script_as_interactive(&script_path, logger, true).map_err(|e| {
+            io::Error::other(format!("Running '{}' failed: {e}", script_path.display()))
+        })?;
 
         if !keep_tmp {
-            fs::remove_file(&script_path)
-                .wrap_err_with(|| format!("Failed to remove {}", script_path.display()))?;
+            fs::remove_file(&script_path).map_err(|e| {
+                io::Error::other(format!("Failed to remove {}: {e}", script_path.display()))
+            })?;
         }
         Ok(())
     }
@@ -235,28 +247,48 @@ impl Recipe {
     /// Parse the arguments passed by the user and track their values
     ///
     /// Assume using default values if the user hasn't set a value.
-    ///
-    /// Returns true if successfully parsed, false on error.
-    fn parse_args(&mut self, args: &[String]) -> bool {
-        let mut args_to_set = HashMap::new();
+    fn parse_args(&mut self, args: &[String]) -> Result<()> {
+        let mut args_to_set: HashMap<String, String> = HashMap::new();
         let mut arg_name = None;
         for arg in args {
             if let Some(name) = arg_name.take() {
-                args_to_set.insert(name, arg);
+                args_to_set.insert(name, arg.to_string());
             } else if arg.starts_with("--") {
-                let name: String = arg.chars().skip(2).collect();
-                arg_name = Some(name);
+                let arg = arg.trim_start_matches("--");
+                if let Some((name, value)) = arg.split_once('=') {
+                    args_to_set.insert(name.to_string(), value.to_string());
+                } else {
+                    arg_name = Some(arg.to_string());
+                }
             } else {
-                error!("Cannot parse '{arg}'");
                 self.print_help();
-                return false;
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Cannot parse recipe argument '{arg}'"),
+                )
+                .into());
             }
         }
 
         if arg_name.is_some() {
-            error!("--{} with no value", arg_name.take().unwrap());
+            let name = arg_name.take().unwrap();
             self.print_help();
-            return false;
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("--{name} with no value"),
+            )
+            .into());
+        }
+
+        for name in args_to_set.keys() {
+            if !self.arguments.iter().any(|arg| arg.name == *name) {
+                self.print_help();
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Unknown recipe argument '--{name}'"),
+                )
+                .into());
+            }
         }
 
         for arg in &mut self.arguments {
@@ -273,7 +305,7 @@ impl Recipe {
                 None => debug!("Not setting {}", arg.name),
             }
         }
-        true
+        Ok(())
     }
 
     fn write_script(&self, script_path: &PathBuf, exit_on_error: bool) -> io::Result<()> {
@@ -353,7 +385,7 @@ enum CommandValue {
     Lines(Vec<String>),
 }
 
-fn deserialize_command<'de, D>(deserializer: D) -> Result<String, D::Error>
+fn deserialize_command<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -536,8 +568,46 @@ ingredients: []
 
         let mut recipe = serde_yaml_ng::from_str::<Recipe>(yaml).unwrap();
         let args = vec!["--EXTRA_ARGS".to_string(), "--routed".to_string()];
-        recipe.parse_cli_args(&args);
+        recipe.parse_cli_args(&args).unwrap();
 
         assert_eq!(recipe.arguments()[0].value(), &Some("--routed".to_string()));
+    }
+
+    #[test]
+    fn parse_cli_args_allows_equals_values() {
+        let yaml = r"
+description: test
+arguments:
+  - name: TIMETABLE
+    default: gwr-timetable/examples/small.yaml
+    comment: timetable
+ingredients: []
+";
+
+        let mut recipe = serde_yaml_ng::from_str::<Recipe>(yaml).unwrap();
+        let args = vec!["--TIMETABLE=timetable.yaml".to_string()];
+        recipe.parse_cli_args(&args).unwrap();
+
+        assert_eq!(
+            recipe.arguments()[0].value(),
+            &Some("timetable.yaml".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_cli_args_rejects_unknown_argument() {
+        let yaml = r"
+description: test
+arguments:
+  - name: TIMETABLE
+    default: gwr-timetable/examples/small.yaml
+    comment: timetable
+ingredients: []
+";
+
+        let mut recipe = serde_yaml_ng::from_str::<Recipe>(yaml).unwrap();
+        let args = vec!["--UNKNOWN=timetable.yaml".to_string()];
+
+        assert!(recipe.parse_cli_args(&args).is_err());
     }
 }

--- a/gwr-terminus/src/tui.rs
+++ b/gwr-terminus/src/tui.rs
@@ -2,13 +2,12 @@
 
 use std::{io, panic};
 
-use color_eyre::Result;
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::Terminal;
 use ratatui::backend::Backend;
 
-use crate::Draw;
+use crate::{Draw, Result};
 
 /// Representation of a terminal user interface.
 ///

--- a/gwr-timetable/recipes/timetable_to_svg.yaml
+++ b/gwr-timetable/recipes/timetable_to_svg.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+description: Convert a GWR timetable YAML file to an SVG diagram via Mermaid.
+arguments:
+  - name: PLATFORM
+    default: gwr-platform/examples/platform.yaml
+    comment: Platform YAML file to pass to timetable-to-mermaid.
+  - name: TIMETABLE
+    default: gwr-timetable/examples/small.yaml
+    comment: Timetable YAML file to render.
+  - name: MERMAID
+    default: timetable.mmd
+    comment: Intermediate Mermaid file to write.
+  - name: SVG
+    default: timetable.svg
+    comment: SVG output file to write.
+  - name: MMDC_CONFIG
+    default: mmdc-config.json
+    comment: Mermaid CLI config file to write.
+  - name: MAX_TEXT_SIZE
+    default: 500000
+    comment: Mermaid maxTextSize config value.
+  - name: MAX_EDGES
+    default: 100000
+    comment: Mermaid maxEdges config value.
+  - name: MMDC
+    default: mmdc
+    comment: Mermaid CLI executable.
+ingredients:
+  - comment: Convert timetable YAML to Mermaid.
+    command:
+      cargo run --bin timetable-to-mermaid -- --platform ${PLATFORM} --timetable
+      ${TIMETABLE} --mermaid ${MERMAID}
+  - comment: Write Mermaid CLI config with larger graph limits.
+    command: >
+      printf '{"maxTextSize": %s, "maxEdges": %s}\n' "${MAX_TEXT_SIZE}"
+      "${MAX_EDGES}" > ${MMDC_CONFIG}
+  - comment: Render Mermaid to SVG.
+    command:
+      ${MMDC} --input ${MERMAID} --output ${SVG} --configFile ${MMDC_CONFIG}

--- a/licenses.html
+++ b/licenses.html
@@ -44,8 +44,8 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (253)</li>
-            <li><a href="#MIT">MIT License</a> (111)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (242)</li>
+            <li><a href="#MIT">MIT License</a> (109)</li>
             <li><a href="#Zlib">zlib License</a> (2)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
@@ -5120,34 +5120,28 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                     <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.0</a></li>
                     <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                     <li><a href=" https://github.com/Amanieu/atomic-rs ">atomic 0.5.3</a></li>
                     <li><a href=" https://github.com/Amanieu/atomic-rs ">atomic 0.6.1</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.76</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.0</a></li>
                     <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                     <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.57</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
-                    <li><a href=" https://github.com/eyre-rs/eyre ">color-eyre 0.6.5</a></li>
-                    <li><a href=" https://github.com/eyre-rs/eyre ">color-spantrace 0.3.0</a></li>
                     <li><a href=" https://github.com/criterion-rs/criterion.rs ">criterion-plot 0.8.2</a></li>
                     <li><a href=" https://github.com/criterion-rs/criterion.rs ">criterion 0.8.2</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
-                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
+                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.20</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.21</a></li>
                     <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
-                    <li><a href=" https://github.com/eyre-rs/eyre ">eyre 0.6.12</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
-                    <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.32.3</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
@@ -5168,7 +5162,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
-                    <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.5</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.12</a></li>
@@ -5183,7 +5176,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
-                    <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
                     <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                     <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
@@ -5838,215 +5830,6 @@ APPENDIX: How to apply the Apache License to your work.
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
                      https://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/oyvindln/adler2 ">adler2 2.0.1</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     https://www.apache.org/licenses/LICENSE-2.0
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -6955,12 +6738,10 @@ limitations under the License.
                     <li><a href=" https://github.com/SergioBenitez/Figment ">figment 0.10.19</a></li>
                     <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
-                    <li><a href=" https://github.com/yaahc/indenter ">indenter 0.3.4</a></li>
                     <li><a href=" https://github.com/dtolnay/indoc ">indoc 2.0.7</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
                     <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.183</a></li>
                     <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
-                    <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Pear ">pear 0.2.9</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Pear ">pear_codegen 0.2.9</a></li>
@@ -7766,7 +7547,6 @@ DEALINGS IN THE SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.31</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.36</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-error 0.2.1</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log 0.2.0</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.23</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.44</a></li>
@@ -8077,35 +7857,6 @@ SOFTWARE.
 
 Copyright (c) 2019 Yoshua Wuyts
 Copyright (c) Tokio Contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/owo-colors/owo-colors ">owo-colors 4.3.0</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2020 - present The owo-colors Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal


### PR DESCRIPTION
I found an issue when running the new terminus recipe for converting timetables
to SVG - it didn't error if I got the argument format wrong. So, this fixes that
by adding checks for valid arguments as well as supporting "--ARG VALUE" as well
as "--ARG=VALUE".

Also cleaned up the use of color-eyre which was adding no value.
