### PR TITLE
feat(gwr-track): Add support for lanes, groups and activity and use them in the PE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-spotter"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "capnp",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-track"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/examples/flaky-component/Cargo.toml
+++ b/examples/flaky-component/Cargo.toml
@@ -24,5 +24,5 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", version = "0.12.0" }
 rand.workspace = true

--- a/examples/flaky-with-delay/Cargo.toml
+++ b/examples/flaky-with-delay/Cargo.toml
@@ -24,5 +24,5 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", version = "0.12.0" }
 rand.workspace = true

--- a/examples/scrambler/Cargo.toml
+++ b/examples/scrambler/Cargo.toml
@@ -24,4 +24,4 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", version = "0.12.0" }

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -25,7 +25,7 @@ gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true
 rand_xoshiro = "0.7.0"

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -25,7 +25,7 @@ gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true
 serde.workspace = true

--- a/examples/sim-restaurant/Cargo.toml
+++ b/examples/sim-restaurant/Cargo.toml
@@ -22,7 +22,7 @@ crossterm.workspace = true
 futures.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 log.workspace = true
 rand.workspace = true
 ratatui.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -24,6 +24,6 @@ gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/gwr-components/Cargo.toml
+++ b/gwr-components/Cargo.toml
@@ -34,7 +34,7 @@ gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 paste.workspace = true
 

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 futures.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 mimalloc = { version = "0.1.48", features = ["v3"], optional = true }
 rand.workspace = true
@@ -35,4 +35,3 @@ gwr-components = { path = "../gwr-components", version = "0.11.0" }
 [features]
 default = ["global_allocator"]
 global_allocator = ["dep:mimalloc"]
-phase = []

--- a/gwr-engine/src/time/clock.rs
+++ b/gwr-engine/src/time/clock.rs
@@ -15,6 +15,11 @@ use futures::future::FusedFuture;
 
 use crate::traits::{Resolve, Resolver};
 
+pub mod phase {
+    pub const BEGIN: u32 = 0;
+    pub const END: u32 = u32::MAX;
+}
+
 /// ClockTick structure for representing a number of Clock ticks and a phase.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ClockTick {
@@ -22,7 +27,6 @@ pub struct ClockTick {
     tick: u64,
 
     /// Clock phase.
-    #[cfg(feature = "phase")]
     phase: u32,
 }
 
@@ -31,9 +35,7 @@ impl ClockTick {
     pub fn new() -> Self {
         Self {
             tick: 0,
-
-            #[cfg(feature = "phase")]
-            phase: 0,
+            phase: phase::BEGIN,
         }
     }
 
@@ -45,7 +47,6 @@ impl ClockTick {
 
     /// Get the current clock phase.
     #[must_use]
-    #[cfg(feature = "phase")]
     pub fn phase(&self) -> u32 {
         self.phase
     }
@@ -57,7 +58,6 @@ impl ClockTick {
     }
 
     /// Change the default constructor value of `phase`.
-    #[cfg(feature = "phase")]
     pub fn set_phase(&mut self, phase: u32) -> ClockTick {
         self.phase = phase;
         *self
@@ -72,18 +72,12 @@ impl Default for ClockTick {
 
 /// Define the comparison operation for SimTime.
 impl Ord for ClockTick {
-    #[cfg(feature = "phase")]
     fn cmp(&self, other: &Self) -> Ordering {
         match self.tick.cmp(&other.tick) {
             Ordering::Greater => Ordering::Greater,
             Ordering::Less => Ordering::Less,
             Ordering::Equal => self.phase.cmp(&other.phase),
         }
-    }
-
-    #[cfg(not(feature = "phase"))]
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.tick.cmp(&other.tick)
     }
 }
 
@@ -94,13 +88,8 @@ impl PartialOrd for ClockTick {
 }
 
 impl std::fmt::Display for ClockTick {
-    #[cfg(feature = "phase")]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}.{:?}", self.tick, self.phase)
-    }
-    #[cfg(not(feature = "phase"))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.tick)
     }
 }
 
@@ -224,8 +213,7 @@ impl Clock {
         let shared_state = Rc::new(ClockState {
             now: RefCell::new(ClockTick {
                 tick: 0,
-                #[cfg(feature = "phase")]
-                phase: 0,
+                phase: phase::BEGIN,
             }),
             next_waiter_id: Cell::new(0),
             waiting: RefCell::new(Vec::new()),
@@ -272,6 +260,15 @@ impl Clock {
         }
     }
 
+    /// Returns the phase of the next event registered with this clock.
+    #[must_use]
+    pub fn phase_of_next(&self) -> u32 {
+        match self.shared_state.waiting_times.borrow().last() {
+            Some(clock_time) => clock_time.phase(),
+            None => u32::MAX,
+        }
+    }
+
     /// Convert the given [ClockTick] to a time in `ns` for this clock.
     #[must_use]
     pub fn to_ns(&self, clock_time: &ClockTick) -> f64 {
@@ -284,6 +281,7 @@ impl Clock {
     pub fn wait_ticks(&self, ticks: u64) -> ClockDelay {
         let mut until = self.tick_now();
         until.tick += ticks;
+        until.phase = phase::BEGIN;
         ClockDelay {
             shared_state: self.shared_state.clone(),
             until,
@@ -302,6 +300,7 @@ impl Clock {
     pub fn wait_ticks_or_exit(&self, ticks: u64) -> ClockDelay {
         let mut until = self.tick_now();
         until.tick += ticks;
+        until.phase = phase::BEGIN;
         ClockDelay {
             shared_state: self.shared_state.clone(),
             until,
@@ -312,7 +311,6 @@ impl Clock {
     }
 
     #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
-    #[cfg(feature = "phase")]
     pub fn next_tick_and_phase(&self, phase: u32) -> ClockDelay {
         let mut until = self.tick_now();
         until.tick += 1;
@@ -327,10 +325,9 @@ impl Clock {
     }
 
     #[must_use = "Futures do nothing unless you `.await` or otherwise use them"]
-    #[cfg(feature = "phase")]
     pub fn wait_phase(&self, phase: u32) -> ClockDelay {
         let mut until = self.tick_now();
-        assert!(phase > until.phase, "Time going backwards");
+        assert!(phase >= until.phase, "Time going backwards");
         until.phase = phase;
         ClockDelay {
             shared_state: self.shared_state.clone(),
@@ -350,6 +347,7 @@ impl Clock {
 
         let mut until = self.tick_now();
         until.tick += ticks as u64;
+        until.phase = phase::BEGIN;
 
         self.shared_state.advance_time(until);
     }
@@ -365,18 +363,16 @@ impl Default for Clock {
 /// The comparison operators for Clocks - use the next pending Waker time.
 impl PartialEq for Clock {
     fn eq(&self, other: &Self) -> bool {
-        self.time_of_next() == other.time_of_next()
+        self.time_of_next() == other.time_of_next() && self.phase_of_next() == other.phase_of_next()
     }
 }
 impl Eq for Clock {}
 
 impl Ord for Clock {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.time_of_next() < other.time_of_next() {
-            Ordering::Less
-        } else {
-            Ordering::Greater
-        }
+        self.time_of_next()
+            .total_cmp(&other.time_of_next())
+            .then_with(|| self.phase_of_next().cmp(&other.phase_of_next()))
     }
 }
 
@@ -461,9 +457,7 @@ mod tests {
     fn clock_tick_accessors_default_display_and_ordering() {
         let default_tick = ClockTick::default();
         assert_eq!(default_tick.tick(), 0);
-        #[cfg(not(feature = "phase"))]
-        assert_eq!(default_tick.to_string(), "0");
-        #[cfg(feature = "phase")]
+        assert_eq!(default_tick.phase(), phase::BEGIN);
         assert_eq!(default_tick.to_string(), "0.0");
 
         let earlier = ClockTick::new().set_tick(1);
@@ -472,7 +466,6 @@ mod tests {
         assert_eq!(earlier.partial_cmp(&later), Some(Ordering::Less));
     }
 
-    #[cfg(feature = "phase")]
     #[test]
     fn clock_tick_phase_accessors_display_and_ordering() {
         let tick = ClockTick::new().set_tick(1).set_phase(2);
@@ -493,6 +486,7 @@ mod tests {
 
         clock.advance_to(2.1);
         assert_eq!(clock.tick_now().tick(), 3);
+        assert_eq!(clock.tick_now().phase(), phase::BEGIN);
         assert_eq!(clock.time_now_ns(), 3.0);
 
         let earlier = Clock::new(1000.0);
@@ -501,7 +495,7 @@ mod tests {
         drop(later.wait_ticks(2));
 
         assert!(earlier == later);
-        assert_eq!(earlier.partial_cmp(&later), Some(Ordering::Greater));
+        assert_eq!(earlier.partial_cmp(&later), Some(Ordering::Equal));
     }
 
     #[test]
@@ -563,7 +557,6 @@ mod tests {
         assert!(delay.is_terminated());
     }
 
-    #[cfg(feature = "phase")]
     #[test]
     fn phase_wait_helpers_schedule_phase_delays() {
         let clock = Clock::new(1000.0);
@@ -575,5 +568,20 @@ mod tests {
         let same_tick = clock.wait_phase(1);
         assert_eq!(same_tick.until.tick(), 0);
         assert_eq!(same_tick.until.phase(), 1);
+    }
+
+    #[test]
+    fn tick_waits_resume_in_end_phase() {
+        let clock = Clock::new(1000.0);
+
+        let begin = clock.wait_phase(phase::END);
+        assert_eq!(begin.until.tick(), 0);
+        assert_eq!(begin.until.phase(), phase::END);
+
+        clock.advance_time(ClockTick::new().set_phase(phase::END));
+
+        let delay = clock.wait_ticks(1);
+        assert_eq!(delay.until.tick(), 1);
+        assert_eq!(delay.until.phase(), phase::BEGIN);
     }
 }

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -35,7 +35,7 @@ gwr-components = { path = "../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 paste.workspace = true
 rand.workspace = true

--- a/gwr-models/src/processing_element/load_store_unit.rs
+++ b/gwr-models/src/processing_element/load_store_unit.rs
@@ -20,23 +20,25 @@ use std::rc::Rc;
 use async_trait::async_trait;
 use gwr_components::{connect_tx, port_rx};
 use gwr_engine::engine::Engine;
+use gwr_engine::events::once::Once;
 use gwr_engine::events::repeated::Repeated;
 use gwr_engine::executor::Spawner;
 use gwr_engine::port::{InPort, OutPort, PortStateResult};
 use gwr_engine::sim_error;
-use gwr_engine::time::clock::Clock;
+use gwr_engine::time::clock::{Clock, phase};
 use gwr_engine::traits::{Event, Runnable};
 use gwr_engine::types::{AccessType, SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
 use gwr_resources::Resource;
+use gwr_resources::base::ResourceGuard;
 use gwr_track::debug;
-use gwr_track::entity::Entity;
+use gwr_track::entity::{Entity, EntityGroup};
 use gwr_track::tracker::aka::Aka;
 
 use crate::memory::memory_access::MemoryAccess;
 use crate::memory::memory_map::{DeviceId, MemoryMap};
 use crate::memory::traits::AccessMemory;
-use crate::processing_element::ProcessingElementConfig;
+use crate::processing_element::{ActivityLanes, ProcessingElementConfig};
 
 /// Each active request slot manages the request from the Processing Element
 /// and ensures the corresponding response is handled.
@@ -231,6 +233,7 @@ impl LsuState {
 pub struct LoadStoreUnit {
     entity: Rc<Entity>,
     spawner: Spawner,
+    clock: Clock,
 
     /// Max bytes the LSU can request at once
     max_access_size_bytes: usize,
@@ -288,6 +291,7 @@ impl LoadStoreUnit {
         let rc_self = Rc::new(Self {
             entity,
             spawner,
+            clock: clock.clone(),
             max_access_size_bytes,
             rx: RefCell::new(Some(rx)),
             tx: RefCell::new(Some(tx)),
@@ -305,15 +309,16 @@ impl LoadStoreUnit {
         port_rx!(self.rx, state)
     }
 
-    /// Perform a memory access
-    ///
-    /// This will break a larger request down into requests of the maximum size
-    /// permitted by the LSU
+    /// Perform a memory access and emit an activity once the LSU has been
+    /// acquired.
     pub async fn do_access(
         &self,
         access_type: AccessType,
         access_size_bytes: usize,
         dst_addr: u64,
+        activity_lanes: &Rc<RefCell<ActivityLanes>>,
+        activity_name: &str,
+        group: &Rc<EntityGroup>,
     ) -> SimResult {
         if access_size_bytes > self.state.sram_bytes {
             return sim_error!(
@@ -325,8 +330,11 @@ impl LoadStoreUnit {
         let mut bytes_remaining = access_size_bytes;
         let mut access_address = dst_addr;
 
-        // Ensure only one load/store Task uses the LSU at a time
-        self.state.serialiser.request().await;
+        let mut completed_requests = Vec::new();
+
+        // Ensure only one load/store Task uses the LSU request issue path at a time.
+        let serialiser_guard = ResourceGuard::new(self.state.serialiser.clone()).await;
+        let mut activity_guard = None;
 
         loop {
             if bytes_remaining == 0 {
@@ -335,6 +343,20 @@ impl LoadStoreUnit {
 
             // Wait until there is a request slot available
             let request_slot_idx = self.state.allocate_request_slot().await;
+            if activity_guard.is_none() {
+                // Lanes cannot support overlapping activity. If a lane will be released
+                // in the current clock cycle then we want to re-use it rather than allocate
+                // a new lane. Hence we wait here for the end of the current clock cycle
+                // to ensure all lanes that will be released in this cycle have been.
+                self.clock.wait_phase(phase::END).await;
+
+                activity_guard = Some(ActivityLanes::begin_in_group(
+                    activity_lanes,
+                    activity_name,
+                    group,
+                ));
+            }
+
             let access_size_bytes = min(self.max_access_size_bytes, bytes_remaining);
             let access = self.state.create_memory_access(
                 access_type,
@@ -346,13 +368,18 @@ impl LoadStoreUnit {
             {
                 // Spawn off a handler for the request
                 let state = self.state.clone();
+                let completed = Once::default();
+                completed_requests.push(completed.clone());
                 self.spawner.spawn(async move {
                     let response_ready_event =
                         state.make_request_to_port_driver(request_slot_idx, access)?;
 
                     // Wait for response to be received to slot
                     response_ready_event.listen().await;
-                    state.handle_response_in_slot(request_slot_idx)
+                    let result = state.handle_response_in_slot(request_slot_idx);
+
+                    completed.notify()?;
+                    result
                 });
             }
 
@@ -360,8 +387,12 @@ impl LoadStoreUnit {
             access_address += access_size_bytes as u64;
         }
 
-        // Allow another load/store Task to start
-        self.state.serialiser.release().await?;
+        // Allow other requests to start
+        drop(serialiser_guard);
+
+        for completed in completed_requests {
+            completed.listen().await;
+        }
 
         Ok(())
     }

--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -28,11 +28,11 @@ use async_trait::async_trait;
 use gwr_engine::engine::Engine;
 use gwr_engine::executor::Spawner;
 use gwr_engine::port::PortStateResult;
-use gwr_engine::time::clock::Clock;
+use gwr_engine::time::clock::{Clock, phase};
 use gwr_engine::traits::Runnable;
 use gwr_engine::types::{AccessType, SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
-use gwr_track::entity::Entity;
+use gwr_track::entity::{Entity, EntityGroup, EntityLane};
 use gwr_track::tracker::aka::Aka;
 use gwr_track::{debug, info};
 
@@ -116,6 +116,108 @@ struct ProcessingElementStats {
     total_flops: usize,
 }
 
+struct Lane {
+    lane: EntityLane,
+    active: bool,
+}
+
+pub(crate) struct ActivityLanes {
+    entity: Rc<Entity>,
+    track_name: String,
+    lanes: Vec<Lane>,
+}
+
+impl ActivityLanes {
+    fn new(entity: Rc<Entity>, track_name: &str) -> Self {
+        Self {
+            entity,
+            track_name: track_name.to_string(),
+            lanes: Vec::new(),
+        }
+    }
+
+    fn begin_in_group(
+        lanes: &Rc<RefCell<Self>>,
+        name: &str,
+        group: &Rc<EntityGroup>,
+    ) -> ActivityLaneGuard {
+        let mut lanes_ref = lanes.borrow_mut();
+        let lane_idx = match lanes_ref.lanes.iter().position(|lane| !lane.active) {
+            Some(lane_idx) => lane_idx,
+            None => lanes_ref.add_new_lane(),
+        };
+
+        let lane = &mut lanes_ref.lanes[lane_idx];
+        lane.lane.begin_in_group(name, group);
+        lane.active = true;
+
+        ActivityLaneGuard {
+            lanes: lanes.clone(),
+            lane_idx,
+            active: true,
+        }
+    }
+
+    fn add_new_lane(&mut self) -> usize {
+        let lane_idx = self.lanes.len();
+        let lane = EntityLane::new(&self.entity, &format!("{}::{lane_idx}", self.track_name));
+        self.lanes.push(Lane {
+            lane,
+            active: false,
+        });
+        lane_idx
+    }
+
+    fn end(&mut self, lane_idx: usize) {
+        let lane = &mut self.lanes[lane_idx];
+        lane.lane.end();
+        lane.active = false;
+    }
+}
+
+struct ActivityLaneGuard {
+    lanes: Rc<RefCell<ActivityLanes>>,
+    lane_idx: usize,
+    active: bool,
+}
+
+impl Drop for ActivityLaneGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.lanes.borrow_mut().end(self.lane_idx);
+            self.active = false;
+        }
+    }
+}
+
+struct ProcessingElementActivityLanes {
+    entity: Rc<Entity>,
+    compute: Rc<RefCell<ActivityLanes>>,
+    lsu_read: Rc<RefCell<ActivityLanes>>,
+    lsu_write: Rc<RefCell<ActivityLanes>>,
+}
+
+impl ProcessingElementActivityLanes {
+    fn new(entity: Rc<Entity>) -> Self {
+        Self {
+            entity: entity.clone(),
+            compute: Rc::new(RefCell::new(ActivityLanes::new(
+                entity.clone(),
+                "lane::compute",
+            ))),
+            lsu_read: Rc::new(RefCell::new(ActivityLanes::new(
+                entity.clone(),
+                "lane::lsu_read",
+            ))),
+            lsu_write: Rc::new(RefCell::new(ActivityLanes::new(entity, "lane::lsu_write"))),
+        }
+    }
+
+    fn create_group(&self, name: &str) -> Rc<EntityGroup> {
+        Rc::new(EntityGroup::new(&self.entity, name))
+    }
+}
+
 #[derive(EntityGet, EntityDisplay)]
 pub struct ProcessingElement {
     entity: Rc<Entity>,
@@ -125,6 +227,7 @@ pub struct ProcessingElement {
 
     compute_capabilities: Rc<ComputeCapabilities>,
     stats: Rc<RefCell<ProcessingElementStats>>,
+    activity_lanes: Rc<ProcessingElementActivityLanes>,
     dispatcher: RefCell<Option<Dispatcher>>,
     flop_monitor: Option<Rc<FlopMonitor>>,
 }
@@ -152,7 +255,7 @@ impl ProcessingElement {
         });
 
         let rc_self = Rc::new(Self {
-            entity,
+            entity: entity.clone(),
             lsu,
             clock: clock.clone(),
             spawner: engine.spawner(),
@@ -164,6 +267,7 @@ impl ProcessingElement {
                 sram_bytes: pe_config.sram_bytes,
             }),
             stats: Rc::new(RefCell::new(ProcessingElementStats::default())),
+            activity_lanes: Rc::new(ProcessingElementActivityLanes::new(entity.clone())),
 
             dispatcher: RefCell::new(None),
             flop_monitor,
@@ -255,6 +359,7 @@ impl Runnable for ProcessingElement {
                     let compute_capabilities = self.compute_capabilities.clone();
                     let stats = self.stats.clone();
                     let entity = self.entity.clone();
+                    let activity_lanes = self.activity_lanes.clone();
                     let flop_monitor = self.flop_monitor.clone();
                     self.spawner.spawn(async move {
                         handle_task(
@@ -264,6 +369,7 @@ impl Runnable for ProcessingElement {
                             lsu,
                             compute_capabilities,
                             stats,
+                            activity_lanes,
                             flop_monitor,
                             task_idx,
                         )
@@ -287,6 +393,7 @@ async fn handle_task(
     lsu: Rc<LoadStoreUnit>,
     compute_capabilities: Rc<ComputeCapabilities>,
     stats: Rc<RefCell<ProcessingElementStats>>,
+    activity_lanes: Rc<ProcessingElementActivityLanes>,
     flop_monitor: Option<Rc<FlopMonitor>>,
     task_idx: usize,
 ) -> SimResult {
@@ -299,14 +406,19 @@ async fn handle_task(
             task_idx,
             compute_capabilities,
             stats,
+            activity_lanes,
             flop_monitor,
             &config,
         )
         .await
         .map_err(|err| SimError(format!("{entity} had error on task {}:\n{err}", config.id))),
-        Task::MemoryTask { config } => handle_memory_task(dispatcher, lsu, task_idx, &config)
-            .await
-            .map_err(|err| SimError(format!("{entity} had error on task {}:\n{err}", config.id))),
+        Task::MemoryTask { config } => {
+            handle_memory_task(dispatcher, lsu, activity_lanes, task_idx, &config)
+                .await
+                .map_err(|err| {
+                    SimError(format!("{entity} had error on task {}:\n{err}", config.id))
+                })
+        }
         Task::SyncTask { .. } => {
             todo!();
         }
@@ -333,6 +445,7 @@ async fn handle_compute_task(
     task_idx: usize,
     compute_capabilities: Rc<ComputeCapabilities>,
     stats: Rc<RefCell<ProcessingElementStats>>,
+    activity_lanes: Rc<ProcessingElementActivityLanes>,
     flop_monitor: Option<Rc<FlopMonitor>>,
     config: &ComputeTaskConfig,
 ) -> SimResult {
@@ -352,13 +465,20 @@ async fn handle_compute_task(
         config
             .op
             .create_partitions(&config.inputs, &config.outputs, num_partitions)?;
+    let group = activity_lanes.create_group(&format!("{} operation", config.id));
 
     for partition in partitions {
-        for view in partition.inputs.iter().flatten() {
+        for (idx, view) in partition.inputs.iter().enumerate() {
+            let Some(view) = view else {
+                continue;
+            };
             lsu.do_access(
                 AccessType::ReadRequest,
                 tensor_view_num_bytes(view),
                 tensor_view_base_addr(view)?,
+                &activity_lanes.lsu_read,
+                &format!("{} tensor {idx} read", config.id),
+                &group,
             )
             .await?;
         }
@@ -374,38 +494,75 @@ async fn handle_compute_task(
         if let Some(flop_monitor) = &flop_monitor {
             flop_monitor.record_interval(compute_ticks as u64, compute_flops as f64);
         }
-        clock.wait_ticks(compute_ticks as u64).await;
+        {
+            // Lanes cannot support overlapping activity. If a lane will be released
+            // in the current clock cycle then we want to re-use it rather than allocate
+            // a new lane. Hence we wait here for the end of the current clock cycle
+            // to ensure all lanes that will be released in this cycle have been.
+            clock.wait_phase(phase::END).await;
+
+            let _activity = ActivityLanes::begin_in_group(
+                &activity_lanes.compute,
+                &format!("{} compute", config.id),
+                &group,
+            );
+            clock.wait_ticks(compute_ticks as u64).await;
+        }
         stats.borrow_mut().total_flops += compute_flops;
 
-        for view in partition.outputs.iter().flatten() {
+        for (idx, view) in partition.outputs.iter().enumerate() {
+            let Some(view) = view else {
+                continue;
+            };
             lsu.do_access(
                 AccessType::WriteNonPostedRequest,
                 tensor_view_num_bytes(view),
                 tensor_view_base_addr(view)?,
+                &activity_lanes.lsu_write,
+                &format!("{} tensor {idx} write", config.id),
+                &group,
             )
             .await?;
         }
     }
 
-    dispatcher.set_task_completed(task_idx)
+    dispatcher.set_task_completed(task_idx)?;
+    Ok(())
 }
 
 // Spawn the handling of memory nodes so that thye can run in parallel.
 async fn handle_memory_task(
     dispatcher: Dispatcher,
     lsu: Rc<LoadStoreUnit>,
+    activity_lanes: Rc<ProcessingElementActivityLanes>,
     task_idx: usize,
     config: &MemoryTaskConfig,
 ) -> SimResult {
     let dst_addr = config.addr;
-    let access_type = match config.op {
-        MemoryOp::Load => AccessType::ReadRequest,
-        MemoryOp::Store => AccessType::WriteNonPostedRequest,
+    let (access_type, lanes, activity_name) = match config.op {
+        MemoryOp::Load => (
+            AccessType::ReadRequest,
+            &activity_lanes.lsu_read,
+            format!("{} tensor read", config.id),
+        ),
+        MemoryOp::Store => (
+            AccessType::WriteNonPostedRequest,
+            &activity_lanes.lsu_write,
+            format!("{} tensor write", config.id),
+        ),
     };
 
     let access_size_bytes = config.num_bytes;
-    lsu.do_access(access_type, access_size_bytes, dst_addr)
-        .await?;
+    let group = activity_lanes.create_group(&format!("{} operation", config.id));
+    lsu.do_access(
+        access_type,
+        access_size_bytes,
+        dst_addr,
+        lanes,
+        &activity_name,
+        &group,
+    )
+    .await?;
     dispatcher.set_task_completed(task_idx)?;
     Ok(())
 }

--- a/gwr-models/src/processing_element/task.rs
+++ b/gwr-models/src/processing_element/task.rs
@@ -47,6 +47,15 @@ impl Serialize for ComputeOp {
 }
 
 impl ComputeOp {
+    #[must_use]
+    pub fn trace_name(&self) -> &'static str {
+        match self {
+            ComputeOp::Add => "add",
+            ComputeOp::Gemm => "gemm",
+            ComputeOp::MaxPool(_) => "maxpool",
+        }
+    }
+
     pub fn compute_delay_ticks(
         &self,
         compute_capabilities: &Rc<ComputeCapabilities>,

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -26,7 +26,7 @@ gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 log.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/gwr-protocols/Cargo.toml
+++ b/gwr-protocols/Cargo.toml
@@ -24,4 +24,4 @@ paste.workspace = true
 [dev-dependencies]
 gwr-components = { path = "../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }

--- a/gwr-resources/Cargo.toml
+++ b/gwr-resources/Cargo.toml
@@ -22,4 +22,4 @@ publish.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 
 [dev-dependencies]
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }

--- a/gwr-spotter/Cargo.toml
+++ b/gwr-spotter/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-spotter"
-version = "0.8.0"
+version = "0.9.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -27,7 +27,7 @@ publish.workspace = true
 capnp.workspace = true
 clap.workspace = true
 crossterm.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.11.0" }
+gwr-track = { path = "../gwr-track", version = "0.12.0" }
 itertools.workspace = true
 log.workspace = true
 ratatui.workspace = true

--- a/gwr-spotter/src/app/mod.rs
+++ b/gwr-spotter/src/app/mod.rs
@@ -63,6 +63,16 @@ pub enum EventLine {
         value: f64,
         time: f64,
     },
+    ActivityBegin {
+        id: u64,
+        name: String,
+        correlation_id: Option<u64>,
+        time: f64,
+    },
+    ActivityEnd {
+        id: u64,
+        time: f64,
+    },
 }
 
 impl ToTime for EventLine {
@@ -74,6 +84,8 @@ impl ToTime for EventLine {
             EventLine::Exit { time, .. } => *time,
             EventLine::Value { time, .. } => *time,
             EventLine::Log { time, .. } => *time,
+            EventLine::ActivityBegin { time, .. } => *time,
+            EventLine::ActivityEnd { time, .. } => *time,
         }
     }
 }
@@ -87,6 +99,8 @@ impl ToFullness for EventLine {
             EventLine::Exit { fullness, .. } => *fullness,
             EventLine::Value { .. } => 0,
             EventLine::Log { .. } => 0,
+            EventLine::ActivityBegin { .. } => 0,
+            EventLine::ActivityEnd { .. } => 0,
         }
     }
 }

--- a/gwr-spotter/src/bin_loader.rs
+++ b/gwr-spotter/src/bin_loader.rs
@@ -25,6 +25,8 @@ struct BinLoader {
     id_to_name: Option<HashMap<u64, String>>,
     id_to_details: Option<HashMap<u64, String>>,
     id_to_req_type: Option<HashMap<u64, u8>>,
+    group_memberships: HashMap<u64, u64>,
+    activity_lanes: HashMap<u64, u64>,
     current_time_ns: f64,
 }
 
@@ -39,6 +41,8 @@ impl BinLoader {
             id_to_name: Some(HashMap::new()),
             id_to_details: Some(HashMap::new()),
             id_to_req_type: Some(HashMap::new()),
+            group_memberships: HashMap::new(),
+            activity_lanes: HashMap::new(),
             current_time_ns: 0.0,
         }
     }
@@ -129,6 +133,24 @@ impl TraceVisitor for BinLoader {
             time: self.current_time_ns,
         });
     }
+
+    fn create_lane(&mut self, _created_by: Id, id: Id, name: &str) {
+        SHARED_STATE
+            .lock()
+            .unwrap()
+            .entity_names
+            .push(format!("{name}={id}"));
+        self.id_to_name
+            .as_mut()
+            .unwrap()
+            .insert(id.0, name.to_owned());
+        self.add_event(EventLine::Create {
+            id: id.0,
+            time: self.current_time_ns,
+        });
+    }
+
+    fn create_group(&mut self, _created_by: Id, _id: Id, _name: &str) {}
 
     fn create_object(
         &mut self,
@@ -237,6 +259,36 @@ impl TraceVisitor for BinLoader {
             value,
             time,
         });
+    }
+
+    fn add_to_group(&mut self, activity: Id, group_id: Id) {
+        self.group_memberships.insert(activity.0, group_id.0);
+    }
+
+    fn remove_from_group(&mut self, activity: Id, group_id: Id) {
+        if self.group_memberships.get(&activity.0) == Some(&group_id.0) {
+            self.group_memberships.remove(&activity.0);
+        }
+    }
+
+    fn begin_activity(&mut self, activity: Id, lane: Id, name: &str) {
+        self.activity_lanes.insert(activity.0, lane.0);
+        let correlation_id = self.group_memberships.get(&activity.0).copied();
+        self.add_event(EventLine::ActivityBegin {
+            id: lane.0,
+            name: name.to_owned(),
+            correlation_id,
+            time: self.current_time_ns,
+        });
+    }
+
+    fn end_activity(&mut self, activity: Id) {
+        if let Some(lane) = self.activity_lanes.remove(&activity.0) {
+            self.add_event(EventLine::ActivityEnd {
+                id: lane,
+                time: self.current_time_ns,
+            });
+        }
     }
 
     fn capacity(&mut self, id: Id, capacity: Capacity) {

--- a/gwr-spotter/src/filter.rs
+++ b/gwr-spotter/src/filter.rs
@@ -95,6 +95,17 @@ impl SearchState {
             EventLine::Exit { id, exited, .. } => self.id_matches(id) || self.id_matches(exited),
             EventLine::Value { id, .. } => self.id_matches(id),
             EventLine::Log { id, msg, .. } => self.id_matches(id) || self.text_matches(msg),
+            EventLine::ActivityBegin {
+                id,
+                name,
+                correlation_id,
+                ..
+            } => {
+                self.id_matches(id)
+                    || self.text_matches(name)
+                    || correlation_id.is_some_and(|id| self.id_text_matches(&id))
+            }
+            EventLine::ActivityEnd { id, .. } => self.id_matches(id),
         }
     }
 }

--- a/gwr-spotter/src/log_parser.rs
+++ b/gwr-spotter/src/log_parser.rs
@@ -20,14 +20,18 @@ use crate::rocket::SHARED_STATE;
 struct LogParser {
     log_line_re: Regex,
     connect_re: Regex,
-    create_entity_re: Regex,
-    create_monitor_re: Regex,
-    create_object_re: Regex,
+    create_re: Regex,
+    begin_activity_re: Regex,
+    end_activity_re: Regex,
+    add_to_group_re: Regex,
+    remove_from_group_re: Regex,
     enter_re: Regex,
     exit_re: Regex,
     value_re: Regex,
     time_re: Regex,
     text_re: Regex,
+    group_memberships: HashMap<u64, u64>,
+    activity_lanes: HashMap<u64, u64>,
 
     current_time: f64,
 }
@@ -38,23 +42,22 @@ impl LogParser {
             log_line_re: Regex::new(r"(?<id>\d+):(?<level>[^ :]+): (?<msg>.*)$").unwrap(),
 
             connect_re: Regex::new(r"(\d+): connect to (\d+)$").unwrap(),
-            create_entity_re: Regex::new(
-                r"(?<by>\d+): created entity (?<id>\d+), (?<name>.*)$",
+            create_re: Regex::new(r"(?<by>\d+): created (?<kind>\w+) (?<rest>.*)$").unwrap(),
+            add_to_group_re: Regex::new(r"(?<id>\d+): added to group (?<group_id>\d+)$").unwrap(),
+            remove_from_group_re: Regex::new(r"(?<id>\d+): removed from group (?<group_id>\d+)$")
+                .unwrap(),
+            begin_activity_re: Regex::new(
+                r"(?<id>\d+): activity begin (?<name>.*) on lane (?<lane>\d+)$",
             )
             .unwrap(),
-            create_monitor_re: Regex::new(
-                r"(?<by>\d+): created monitor (?<id>\d+), (?<name>.*)$",
-            )
-            .unwrap(),
-            create_object_re: Regex::new(
-                r"(?<by>\d+): created object (?<id>\d+), (?<type>\d+), (?<size>\d+), (?<units>.*), (?<details>.*)$",
-            )
-            .unwrap(),
+            end_activity_re: Regex::new(r"(?<id>\d+): activity end$").unwrap(),
             enter_re: Regex::new(r"(\d+): enter (\d+)$").unwrap(),
             exit_re: Regex::new(r"(\d+): exit (\d+)$").unwrap(),
             value_re: Regex::new(r"(\d+): value (.*)$").unwrap(),
             time_re: Regex::new(r"\d+: set time to ([^n]+)ns").unwrap(),
             text_re: Regex::new(r"(\d+): (\d+) entered$").unwrap(),
+            group_memberships: HashMap::new(),
+            activity_lanes: HashMap::new(),
 
             current_time: 0.0,
         }
@@ -119,13 +122,19 @@ impl LogParser {
         if let Some(event) = self.parse_text_log(msg) {
             return event;
         }
-        if let Some(event) = self.parse_create_entity(msg, id_to_name) {
+        if let Some(event) = self.parse_create(msg, id_to_name, id_to_details) {
             return event;
         }
-        if let Some(event) = self.parse_create_monitor(msg, id_to_name) {
+        if let Some(event) = self.parse_add_to_group(msg) {
             return event;
         }
-        if let Some(event) = self.parse_create_object(msg, id_to_name, id_to_details) {
+        if let Some(event) = self.parse_remove_from_group(msg) {
+            return event;
+        }
+        if let Some(event) = self.parse_begin_activity(msg) {
+            return event;
+        }
+        if let Some(event) = self.parse_end_activity(msg) {
             return event;
         }
         if let Some(event) = self.parse_connect(msg) {
@@ -236,65 +245,61 @@ impl LogParser {
         })
     }
 
-    fn parse_create_entity(
-        &self,
-        msg: &str,
-        id_to_name: &mut HashMap<u64, String>,
-    ) -> Option<EventLine> {
-        let e = self.create_entity_re.captures(msg)?;
-        let id_str = e.name("id").unwrap().as_str();
-        let id = id_str.parse().unwrap();
-        let name = e.name("name").unwrap().as_str().to_owned();
-
-        SHARED_STATE
-            .lock()
-            .unwrap()
-            .entity_names
-            .push(format!("{name}={id_str}"));
-
-        id_to_name.insert(id, name);
-
-        Some(EventLine::Create {
-            id,
-            time: self.current_time,
-        })
-    }
-
-    fn parse_create_monitor(
-        &self,
-        msg: &str,
-        id_to_name: &mut HashMap<u64, String>,
-    ) -> Option<EventLine> {
-        let e = self.create_monitor_re.captures(msg)?;
-        let id_str = e.name("id").unwrap().as_str();
-        let id = id_str.parse().unwrap();
-        let name = e.name("name").unwrap().as_str().to_owned();
-
-        SHARED_STATE
-            .lock()
-            .unwrap()
-            .entity_names
-            .push(format!("{name}={id_str}"));
-
-        id_to_name.insert(id, name);
-
-        Some(EventLine::Create {
-            id,
-            time: self.current_time,
-        })
-    }
-
-    fn parse_create_object(
+    fn parse_create(
         &self,
         msg: &str,
         id_to_name: &mut HashMap<u64, String>,
         id_to_details: &mut HashMap<u64, String>,
     ) -> Option<EventLine> {
-        let e = self.create_object_re.captures(msg)?;
-        let id_str = e.name("id").unwrap().as_str();
+        let e = self.create_re.captures(msg)?;
+        let kind = e.name("kind").unwrap().as_str();
+        let rest = e.name("rest").unwrap().as_str();
+
+        match kind {
+            "entity" | "monitor" | "lane" | "group" | "activity" => {
+                self.parse_named_create(rest, id_to_name)
+            }
+            "object" => self.parse_object_create(rest, id_to_name, id_to_details),
+            _ => None,
+        }
+    }
+
+    fn parse_named_create(
+        &self,
+        rest: &str,
+        id_to_name: &mut HashMap<u64, String>,
+    ) -> Option<EventLine> {
+        let (id_str, name) = rest.split_once(", ")?;
         let id = id_str.parse().unwrap();
-        let units = e.name("units").unwrap().as_str().to_owned();
-        let details = e.name("details").unwrap().as_str().to_owned();
+        let name = name.to_owned();
+
+        SHARED_STATE
+            .lock()
+            .unwrap()
+            .entity_names
+            .push(format!("{name}={id_str}"));
+
+        id_to_name.insert(id, name);
+
+        Some(EventLine::Create {
+            id,
+            time: self.current_time,
+        })
+    }
+
+    fn parse_object_create(
+        &self,
+        rest: &str,
+        id_to_name: &mut HashMap<u64, String>,
+        id_to_details: &mut HashMap<u64, String>,
+    ) -> Option<EventLine> {
+        let mut fields = rest.splitn(5, ", ");
+        let id_str = fields.next()?;
+        let _req_type = fields.next()?;
+        let _size = fields.next()?;
+        let units = fields.next()?;
+        let details = fields.next()?.to_owned();
+        let id = id_str.parse().unwrap();
 
         SHARED_STATE
             .lock()
@@ -334,6 +339,59 @@ impl LogParser {
         Some(EventLine::Connect {
             from_id,
             to_id,
+            time: self.current_time,
+        })
+    }
+
+    fn parse_add_to_group(&mut self, msg: &str) -> Option<EventLine> {
+        let e = self.add_to_group_re.captures(msg)?;
+        let id = e.name("id").unwrap().as_str().parse().unwrap();
+        let group_id = e.name("group_id").unwrap().as_str().parse().unwrap();
+        self.group_memberships.insert(id, group_id);
+        Some(EventLine::Log {
+            level: log::Level::Trace,
+            id,
+            msg: msg.to_owned(),
+            time: self.current_time,
+        })
+    }
+
+    fn parse_remove_from_group(&mut self, msg: &str) -> Option<EventLine> {
+        let e = self.remove_from_group_re.captures(msg)?;
+        let id = e.name("id").unwrap().as_str().parse().unwrap();
+        let group_id = e.name("group_id").unwrap().as_str().parse().unwrap();
+        if self.group_memberships.get(&id) == Some(&group_id) {
+            self.group_memberships.remove(&id);
+        }
+        Some(EventLine::Log {
+            level: log::Level::Trace,
+            id,
+            msg: msg.to_owned(),
+            time: self.current_time,
+        })
+    }
+
+    fn parse_begin_activity(&mut self, msg: &str) -> Option<EventLine> {
+        let e = self.begin_activity_re.captures(msg)?;
+        let id = e.name("id").unwrap().as_str().parse().unwrap();
+        let lane = e.name("lane").unwrap().as_str().parse().unwrap();
+        let name = e.name("name").unwrap().as_str().to_owned();
+        self.activity_lanes.insert(id, lane);
+        let correlation_id = self.group_memberships.get(&id).copied();
+        Some(EventLine::ActivityBegin {
+            id: lane,
+            name,
+            correlation_id,
+            time: self.current_time,
+        })
+    }
+
+    fn parse_end_activity(&mut self, msg: &str) -> Option<EventLine> {
+        let e = self.end_activity_re.captures(msg)?;
+        let id = e.name("id").unwrap().as_str().parse().unwrap();
+        let id = self.activity_lanes.remove(&id).unwrap_or(id);
+        Some(EventLine::ActivityEnd {
+            id,
             time: self.current_time,
         })
     }
@@ -405,4 +463,43 @@ pub fn start_background_load(
             filter.lock().unwrap().extend_id_to_details(id_to_details);
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_created_events_from_shared_prefix() {
+        let parser = LogParser::new();
+        let mut id_to_name = HashMap::new();
+        let mut id_to_details = HashMap::new();
+
+        let event = parser
+            .parse_create(
+                "12: created lane 34, top::pe0::lane::compute::0",
+                &mut id_to_name,
+                &mut id_to_details,
+            )
+            .unwrap();
+        assert!(matches!(event, EventLine::Create { id: 34, .. }));
+        assert_eq!(
+            id_to_name.get(&34).map(String::as_str),
+            Some("top::pe0::lane::compute::0")
+        );
+
+        let event = parser
+            .parse_create(
+                "12: created object 35, 255, 128, bytes, tensor chunk",
+                &mut id_to_name,
+                &mut id_to_details,
+            )
+            .unwrap();
+        assert!(matches!(event, EventLine::Create { id: 35, .. }));
+        assert_eq!(id_to_name.get(&35).map(String::as_str), Some("object"));
+        assert_eq!(
+            id_to_details.get(&35).map(String::as_str),
+            Some("tensor chunk [bytes]")
+        );
+    }
 }

--- a/gwr-spotter/src/perfetto.rs
+++ b/gwr-spotter/src/perfetto.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Write};
 use std::path::Path;
@@ -12,6 +13,8 @@ struct PerfettoGenerator {
     output: File,
     current_time_ns: u64,
     trace_builder: PerfettoTraceBuilder,
+    group_memberships: HashMap<Id, Id>,
+    activity_lanes: HashMap<Id, Id>,
 }
 
 impl PerfettoGenerator {
@@ -21,6 +24,8 @@ impl PerfettoGenerator {
                 .expect("`output` should be a file path that can be written to"),
             current_time_ns: 0,
             trace_builder: PerfettoTraceBuilder::new(),
+            group_memberships: HashMap::new(),
+            activity_lanes: HashMap::new(),
         }
     }
 
@@ -62,6 +67,23 @@ impl TraceVisitor for PerfettoGenerator {
             .write_all(&buf)
             .expect("`output` should be writable file");
     }
+
+    fn create_lane(&mut self, created_by: Id, id: Id, name: &str) {
+        let trace_packet = self
+            .trace_builder
+            .build_activity_track_descriptor_trace_packet(
+                self.current_time_ns,
+                id,
+                created_by,
+                name,
+            );
+        let buf = self.trace_builder.build_trace_to_bytes(vec![trace_packet]);
+        self.output
+            .write_all(&buf)
+            .expect("`output` should be writable file");
+    }
+
+    fn create_group(&mut self, _created_by: Id, _id: Id, _name: &str) {}
 
     fn create_object(
         &mut self,
@@ -128,6 +150,46 @@ impl TraceVisitor for PerfettoGenerator {
         self.output
             .write_all(&buf)
             .expect("`output` should be writable file");
+    }
+
+    fn add_to_group(&mut self, activity: Id, group_id: Id) {
+        self.group_memberships.insert(activity, group_id);
+    }
+
+    fn remove_from_group(&mut self, activity: Id, group_id: Id) {
+        if self.group_memberships.get(&activity) == Some(&group_id) {
+            self.group_memberships.remove(&activity);
+        }
+    }
+
+    fn begin_activity(&mut self, activity: Id, lane: Id, name: &str) {
+        self.activity_lanes.insert(activity, lane);
+        let correlation_id = self
+            .group_memberships
+            .get(&activity)
+            .map(|group_id| group_id.0);
+        let trace_packet = self.trace_builder.build_activity_begin_trace_packet(
+            self.current_time_ns,
+            lane,
+            name,
+            correlation_id,
+        );
+        let buf = self.trace_builder.build_trace_to_bytes(vec![trace_packet]);
+        self.output
+            .write_all(&buf)
+            .expect("`output` should be writable file");
+    }
+
+    fn end_activity(&mut self, activity: Id) {
+        if let Some(lane) = self.activity_lanes.remove(&activity) {
+            let trace_packet = self
+                .trace_builder
+                .build_activity_end_trace_packet(self.current_time_ns, lane);
+            let buf = self.trace_builder.build_trace_to_bytes(vec![trace_packet]);
+            self.output
+                .write_all(&buf)
+                .expect("`output` should be writable file");
+        }
     }
 
     fn time(&mut self, _id: Id, time_ns: f64) {

--- a/gwr-spotter/src/renderer.rs
+++ b/gwr-spotter/src/renderer.rs
@@ -190,7 +190,9 @@ impl Renderer {
             | EventLine::Enter { id, .. }
             | EventLine::Exit { id, .. }
             | EventLine::Value { id, .. }
-            | EventLine::Log { id, .. } => *id,
+            | EventLine::Log { id, .. }
+            | EventLine::ActivityBegin { id, .. }
+            | EventLine::ActivityEnd { id, .. } => *id,
             EventLine::Connect { .. } => {
                 return Some(0);
             }
@@ -257,6 +259,27 @@ impl Renderer {
             EventLine::Log { id, msg, time, .. } => {
                 let name = self.name_id(id, &mut tmp0);
                 (format!("{name}: {msg}").to_owned(), time)
+            }
+
+            EventLine::ActivityBegin {
+                id,
+                name,
+                correlation_id,
+                time,
+            } => {
+                let track = self.name_id(id, &mut tmp0);
+                let suffix = correlation_id
+                    .map(|correlation_id| format!(" correlation {correlation_id}"))
+                    .unwrap_or_default();
+                (
+                    format!("{track}: activity begin {name}{suffix}").to_owned(),
+                    time,
+                )
+            }
+
+            EventLine::ActivityEnd { id, time } => {
+                let name = self.name_id(id, &mut tmp0);
+                (format!("{name}: activity end").to_owned(), time)
             }
 
             EventLine::Create { id, time } => {
@@ -447,5 +470,34 @@ impl Iterator for LineIterator<'_> {
             }
             None => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_activity_events() {
+        let mut renderer = Renderer::new();
+        renderer.extend_id_to_name(HashMap::from([(7, "pe0::lane::compute::0".to_string())]));
+        renderer.add_chunk(vec![
+            EventLine::ActivityBegin {
+                id: 7,
+                name: "add compute".to_string(),
+                correlation_id: Some(42),
+                time: 10.0,
+            },
+            EventLine::ActivityEnd { id: 7, time: 15.0 },
+        ]);
+
+        assert_eq!(
+            renderer.render_line(0),
+            "7: pe0::lane::compute::0: activity begin add compute correlation 42 @10.0ns"
+        );
+        assert_eq!(
+            renderer.render_line(1),
+            "7: pe0::lane::compute::0: activity end @15.0ns"
+        );
     }
 }

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -31,7 +31,7 @@ gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.19.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.4.0" }
-gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.11.0" }
+gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.12.0" }
 indicatif.workspace = true
 log.workspace = true
 rand.workspace = true

--- a/gwr-timetable/tests/operator_activity.rs
+++ b/gwr-timetable/tests/operator_activity.rs
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use gwr_engine::engine::Engine;
+use gwr_models::processing_element::dispatch::Dispatch;
+use gwr_platform::Platform;
+use gwr_timetable::Timetable;
+use gwr_timetable::timetable_file::TimetableFile;
+
+const PLATFORM_YAML: &str = "
+memory_maps:
+  - name: pe_memory_map
+    devices:
+      - name: mem0
+
+processing_elements:
+  - name: pe0
+    memory_map: pe_memory_map
+    config:
+      lsu_access_bytes: 32
+      sram_bytes: 64KiB
+
+caches:
+  - name: l1_0
+    config:
+      bw_bytes_per_cycle: 32
+      line_size_bytes: 32
+      delay_ticks: 4
+
+memories:
+  - name: mem0
+    kind: ddr
+    base_address: 0x1_0000_0000
+    capacity_bytes: 1GiB
+    delay_ticks: 40
+
+connections:
+  - connect:
+      - pe.pe0
+      - cache.l1_0.dev
+  - connect:
+      - cache.l1_0.mem
+      - mem.mem0
+";
+
+const TIMETABLE_YAML: &str = "
+nodes:
+  - id: input_a
+    kind: tensor
+    config:
+      addr: 0x1_0000_0000
+      dtype: fp32
+      shape: [4]
+
+  - id: input_b
+    kind: tensor
+    config:
+      addr: 0x1_0000_0400
+      dtype: fp32
+      shape: [4]
+
+  - id: add
+    kind: compute
+    op: add
+    pe: pe0
+    input_views:
+      -
+      -
+    output_views:
+      -
+
+  - id: output
+    kind: tensor
+    config:
+      addr: 0x1_0000_0800
+      dtype: fp32
+      shape: [4]
+
+edges:
+  - from: input_a
+    to: add.0
+    kind: data
+
+  - from: input_b
+    to: add.1
+    kind: data
+
+  - from: add
+    to: output
+    kind: data
+";
+
+#[test]
+fn compute_task_emits_operator_activity_on_pe() {
+    let (test_tracker, tracker) = gwr_track::test_init!(1000);
+    let mut engine = Engine::new(&tracker);
+    let clock = engine.default_clock();
+    let platform = Rc::new(Platform::from_string(&engine, &clock, PLATFORM_YAML).unwrap());
+    let timetable_file = TimetableFile::from_string(TIMETABLE_YAML).unwrap();
+    let timetable = Rc::new(Timetable::new(engine.top(), timetable_file, &platform).unwrap());
+    let dispatcher: Rc<dyn Dispatch> = timetable.clone();
+    platform.attach_dispatcher(&dispatcher);
+
+    engine.run().unwrap();
+    timetable.check_tasks_complete().unwrap();
+
+    let events = test_tracker.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("created lane") && event.contains("pe0::lane::lsu_read::0")),
+        "missing PE LSU read lane create event in {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("created lane") && event.contains("pe0::lane::compute::0")),
+        "missing PE compute lane create event in {events:#?}"
+    );
+    assert!(
+        events.iter().any(
+            |event| event.contains("created lane") && event.contains("pe0::lane::lsu_write::0")
+        ),
+        "missing PE LSU write lane create event in {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("created group") && event.contains("pe0::add operation")),
+        "missing PE operation group create event in {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("activity begin add tensor 0 read")),
+        "missing operator tensor 0 read activity begin event in {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("activity begin add tensor 1 read")),
+        "missing operator tensor 1 read activity begin event in {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("activity begin add compute")),
+        "missing operator compute activity begin event in {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("activity begin add tensor 0 write")),
+        "missing operator tensor 0 write activity begin event in {events:#?}"
+    );
+    let read_group =
+        activity_group(&events, "activity begin add tensor 0 read").expect("missing read group");
+    let compute_group =
+        activity_group(&events, "activity begin add compute").expect("missing compute group");
+    let write_group =
+        activity_group(&events, "activity begin add tensor 0 write").expect("missing write group");
+    assert_eq!(read_group, compute_group);
+    assert_eq!(compute_group, write_group);
+    assert!(
+        events.iter().any(|event| event.contains("activity end")),
+        "missing operator activity end event in {events:#?}"
+    );
+}
+
+fn activity_group(events: &[String], activity_name: &str) -> Option<String> {
+    let mut lane_groups = HashMap::new();
+    for event in events {
+        let Some((lane, rest)) = event.split_once(": ") else {
+            continue;
+        };
+        if let Some(group) = rest.strip_prefix("added to group ") {
+            lane_groups.insert(lane.to_string(), group.to_string());
+        } else if let Some(group) = rest.strip_prefix("removed from group ") {
+            if lane_groups
+                .get(lane)
+                .is_some_and(|active_group| active_group == group)
+            {
+                lane_groups.remove(lane);
+            }
+        } else if rest.contains(activity_name) {
+            return lane_groups.get(lane).cloned();
+        }
+    }
+    None
+}

--- a/gwr-track/Cargo.toml
+++ b/gwr-track/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-track"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-track/schemas/gwr_track.capnp
+++ b/gwr-track/schemas/gwr_track.capnp
@@ -10,36 +10,51 @@ struct Log @0x835154066f85a612 {
 
   # Logging levels to match those of the Rust log::Level
   enum LogLevel {
-    error @0;
-    warn  @1;
-    info  @2;
-    debug @3;
-    trace @4;
+    trace   @4;
+    debug   @3;
+    info    @2;
+    warn    @1;
+    error   @0;
   }
 }
 
 struct Capacity @0xac486acbf54c747d {
-  units    @1  :Text;
-  value    @0  :UInt64;
+  units     @1  :Text;
+  value     @0  :UInt64;
 }
 
 struct Object @0xa7fb0080384f0095 {
-  details  @3 :Text;
-  type     @2 :UInt8;
-  units    @1 :Text;
-  size     @0 :UInt64;
+  details   @3 :Text;
+  type      @2 :UInt8;
+  units     @1 :Text;
+  size      @0 :UInt64;
 }
 
 struct Monitor @0xa021bdb26d110114 {
-  name     @0 :Text;
+  name      @0 :Text;
 }
 
 struct Entity @0xbc946b85a6484339 {
-  name     @0 :Text;
+  name      @0 :Text;
+}
+
+struct Lane @0xadd90ea73cb2a0d0 {
+  name      @0 :Text;
+}
+
+struct Group @0xbff44d59fb8e94de {
+  name      @0 :Text;
+}
+
+struct BeginActivity @0xaed8c4666e3db85e {
+  name      @1 :Text;
+  lane      @0 :UInt64;
 }
 
 struct Create @0xc95443fd58b475bb {
   union {
+    group   @5 :Group;
+    lane    @4 :Lane;
     object  @3 :Object;
     monitor @2 :Monitor;
     entity  @1 :Entity;
@@ -49,15 +64,19 @@ struct Create @0xc95443fd58b475bb {
 
 struct Event @0xc13b4d9cc5ead95b {
   union {
-    capacity @9 :Capacity;
-    value   @8  :Float64;
-    connect @7  :UInt64;
-    time    @6  :Float64;
-    enter   @5  :UInt64;
-    exit    @4  :UInt64;
-    destroy @3  :UInt64;
-    create  @2  :Create;
-    log     @1  :Log;
+    removeFromGroup @13 :UInt64;
+    addToGroup      @12 :UInt64;
+    endActivity     @11 :Void;
+    beginActivity   @10 :BeginActivity;
+    capacity        @9  :Capacity;
+    value           @8  :Float64;
+    connect         @7  :UInt64;
+    time            @6  :Float64;
+    enter           @5  :UInt64;
+    exit            @4  :UInt64;
+    destroy         @3  :UInt64;
+    create          @2  :Create;
+    log             @1  :Log;
   }
   id        @0 :UInt64;
 }

--- a/gwr-track/src/entity.rs
+++ b/gwr-track/src/entity.rs
@@ -228,6 +228,138 @@ impl EntityMonitor {
     }
 }
 
+/// A child trace lane used to represent named activity intervals.
+pub struct EntityLane {
+    /// Parent entity that owns this lane.
+    pub entity: Rc<Entity>,
+
+    /// Unique simulation identifier used for trace events.
+    pub id: Id,
+
+    /// Name of this lane.
+    pub name: String,
+
+    active: bool,
+    active_activity: Option<Id>,
+    active_group: Option<Id>,
+}
+
+impl EntityLane {
+    /// Create a new lane under `parent`.
+    #[must_use]
+    pub fn new(parent: &Rc<Entity>, name: &str) -> Self {
+        let mut full_name = parent.full_name();
+        full_name.push_str(JOIN);
+        full_name.push_str(name);
+
+        let id = create_id!(parent);
+        let lane = Self {
+            entity: parent.clone(),
+            id,
+            name: String::from(name),
+            active: false,
+            active_activity: None,
+            active_group: None,
+        };
+
+        lane.track_create(parent.id, &full_name);
+
+        lane
+    }
+
+    fn track_create(&self, created_by: Id, full_name: &str) {
+        self.entity
+            .tracker
+            .create_lane(created_by, self.id, full_name);
+    }
+
+    /// Begin the named activity on this lane.
+    pub fn begin(&mut self, name: &str) {
+        let activity_id = create_id!(self.entity);
+        self.entity
+            .tracker
+            .begin_activity(activity_id, self.id, name);
+        self.active_activity = Some(activity_id);
+        self.active = true;
+    }
+
+    /// Begin the named activity as part of a group.
+    pub fn begin_in_group(&mut self, name: &str, group: &EntityGroup) {
+        let activity_id = create_id!(self.entity);
+        self.entity.tracker.add_to_group(activity_id, group.id);
+        self.active_activity = Some(activity_id);
+        self.active_group = Some(group.id);
+        self.entity
+            .tracker
+            .begin_activity(activity_id, self.id, name);
+        self.active = true;
+    }
+
+    /// End the current activity on this lane.
+    pub fn end(&mut self) {
+        if self.active {
+            let activity_id = self
+                .active_activity
+                .take()
+                .expect("active lane should have an activity ID");
+            self.entity.tracker.end_activity(activity_id);
+            if let Some(group_id) = self.active_group.take() {
+                self.entity.tracker.remove_from_group(activity_id, group_id);
+            }
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for EntityLane {
+    fn drop(&mut self) {
+        self.end();
+        self.entity.tracker.destroy(self.entity.id, self.id);
+    }
+}
+
+/// A trace group used to associate related activities.
+pub struct EntityGroup {
+    /// Parent entity that owns this group.
+    pub entity: Rc<Entity>,
+
+    /// Unique simulation identifier used for trace events.
+    pub id: Id,
+
+    /// Name of this group.
+    pub name: String,
+}
+
+impl EntityGroup {
+    /// Create a new group under `parent`.
+    #[must_use]
+    pub fn new(parent: &Rc<Entity>, name: &str) -> Self {
+        let mut full_name = parent.full_name();
+        full_name.push_str(JOIN);
+        full_name.push_str(name);
+
+        let id = create_id!(parent);
+        let group = Self {
+            entity: parent.clone(),
+            id,
+            name: String::from(name),
+        };
+
+        group
+            .entity
+            .tracker
+            .create_group(parent.id, group.id, &full_name);
+
+        group
+    }
+}
+
+impl Drop for EntityGroup {
+    fn drop(&mut self) {
+        self.entity.tracker.destroy(self.entity.id, self.id);
+    }
+}
+
 /// The `GetEntity` trait is used to provide access to an objects [Entity]
 pub trait GetEntity {
     /// Return the [Entity]

--- a/gwr-track/src/perfetto_trace_builder.rs
+++ b/gwr-track/src/perfetto_trace_builder.rs
@@ -179,6 +179,22 @@ impl PerfettoTraceBuilder {
         self.build_track_descriptor_trace_packet(current_time_ns, track_descriptor)
     }
 
+    /// Build a TracePacket containing the TrackDescriptor for activity slices
+    /// denoted by [crate::tracker::Track::begin_activity] and
+    /// [crate::tracker::Track::end_activity] events.
+    #[must_use]
+    pub fn build_activity_track_descriptor_trace_packet(
+        &mut self,
+        current_time_ns: u64,
+        id: Id,
+        parent: Id,
+        name: &str,
+    ) -> TracePacket {
+        let track_descriptor = self.build_track_descriptor(id, parent, name);
+
+        self.build_track_descriptor_trace_packet(current_time_ns, track_descriptor)
+    }
+
     fn build_track_descriptor_trace_packet(
         &self,
         current_time_ns: u64,
@@ -234,6 +250,35 @@ impl PerfettoTraceBuilder {
         self.build_track_event_trace_packet(current_time_ns, track_event)
     }
 
+    /// Build a TracePacket containing the TrackEvent for a
+    /// [crate::tracker::Track::begin_activity] SliceBegin event.
+    #[must_use]
+    pub fn build_activity_begin_trace_packet(
+        &self,
+        current_time_ns: u64,
+        id: Id,
+        name: &str,
+        correlation_id: Option<u64>,
+    ) -> TracePacket {
+        let track_event = build_slice_track_event(
+            id,
+            Some(name),
+            track_event::Type::SliceBegin,
+            correlation_id,
+        );
+
+        self.build_track_event_trace_packet(current_time_ns, track_event)
+    }
+
+    /// Build a TracePacket containing the TrackEvent for a
+    /// [crate::tracker::Track::end_activity] SliceEnd event.
+    #[must_use]
+    pub fn build_activity_end_trace_packet(&self, current_time_ns: u64, id: Id) -> TracePacket {
+        let track_event = build_slice_track_event(id, None, track_event::Type::SliceEnd, None);
+
+        self.build_track_event_trace_packet(current_time_ns, track_event)
+    }
+
     fn build_track_event_trace_packet(
         &self,
         current_time_ns: u64,
@@ -268,5 +313,85 @@ impl PerfettoTraceBuilder {
         Trace {
             packet: trace_packets,
         }
+    }
+}
+
+fn build_slice_track_event(
+    id: Id,
+    name: Option<&str>,
+    event_type: track_event::Type,
+    correlation_id: Option<u64>,
+) -> TrackEvent {
+    let mut track_event = match name {
+        Some(name) => build_named_track_event(id, name),
+        None => TrackEvent {
+            track_uuid: Some(id.0),
+            ..Default::default()
+        },
+    };
+    track_event.set_type(event_type);
+    if let Some(correlation_id) = correlation_id {
+        track_event.correlation_id_field = Some(track_event::CorrelationIdField::CorrelationId(
+            correlation_id,
+        ));
+    }
+    track_event
+}
+
+fn build_named_track_event(id: Id, name: &str) -> TrackEvent {
+    TrackEvent {
+        track_uuid: Some(id.0),
+        name_field: Some(track_event::NameField::Name(name.to_string())),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gwr_perfetto::protos::trace_packet::Data;
+
+    use super::*;
+
+    #[test]
+    fn activity_packets_are_perfetto_slices() {
+        let mut builder = PerfettoTraceBuilder::new();
+        let descriptor =
+            builder.build_activity_track_descriptor_trace_packet(0, Id(11), Id(10), "pe::op");
+        let begin = builder.build_activity_begin_trace_packet(42, Id(11), "add_task (add)", None);
+        let correlated_begin =
+            builder.build_activity_begin_trace_packet(43, Id(11), "add compute", Some(99));
+        let end = builder.build_activity_end_trace_packet(84, Id(11));
+
+        let Some(Data::TrackDescriptor(descriptor)) = descriptor.data else {
+            panic!("expected activity track descriptor");
+        };
+        assert_eq!(descriptor.uuid, Some(11));
+        assert_eq!(descriptor.parent_uuid, Some(10));
+        assert!(descriptor.counter.is_none());
+
+        let Some(Data::TrackEvent(begin)) = begin.data else {
+            panic!("expected activity begin track event");
+        };
+        assert_eq!(begin.track_uuid, Some(11));
+        assert_eq!(begin.r#type, Some(track_event::Type::SliceBegin as i32));
+        assert_eq!(
+            begin.name_field,
+            Some(track_event::NameField::Name("add_task (add)".to_string()))
+        );
+
+        let Some(Data::TrackEvent(correlated_begin)) = correlated_begin.data else {
+            panic!("expected correlated activity begin track event");
+        };
+        assert_eq!(correlated_begin.track_uuid, Some(11));
+        assert_eq!(
+            correlated_begin.correlation_id_field,
+            Some(track_event::CorrelationIdField::CorrelationId(99))
+        );
+
+        let Some(Data::TrackEvent(end)) = end.data else {
+            panic!("expected activity end track event");
+        };
+        assert_eq!(end.track_uuid, Some(11));
+        assert_eq!(end.r#type, Some(track_event::Type::SliceEnd as i32));
     }
 }

--- a/gwr-track/src/test_helpers.rs
+++ b/gwr-track/src/test_helpers.rs
@@ -48,6 +48,12 @@ impl TestTracker {
         let mut events = self.events.borrow_mut();
         events.push(event);
     }
+
+    /// Return a snapshot of the events recorded so far.
+    #[must_use]
+    pub fn events(&self) -> Vec<String> {
+        self.events.borrow().clone()
+    }
 }
 
 impl Track for TestTracker {
@@ -82,12 +88,36 @@ impl Track for TestTracker {
         self.add_event(format!("{id}: {value}"));
     }
 
+    fn begin_activity(&self, activity: Id, lane: Id, name: &str) {
+        self.add_event(format!("{activity}: activity begin {name} on lane {lane}"));
+    }
+
+    fn end_activity(&self, activity: Id) {
+        self.add_event(format!("{activity}: activity end"));
+    }
+
+    fn add_to_group(&self, activity: Id, group_id: Id) {
+        self.add_event(format!("{activity}: added to group {group_id}"));
+    }
+
+    fn remove_from_group(&self, activity: Id, group_id: Id) {
+        self.add_event(format!("{activity}: removed from group {group_id}"));
+    }
+
     fn create_entity(&self, created_by: Id, id: Id, name: &str) {
         self.add_event(format!("{created_by}: created entity {id}, {name}"));
     }
 
     fn create_monitor(&self, created_by: Id, id: Id, name: &str) {
         self.add_event(format!("{created_by}: created monitor {id}, {name}"));
+    }
+
+    fn create_lane(&self, created_by: Id, id: Id, name: &str) {
+        self.add_event(format!("{created_by}: created lane {id}, {name}"));
+    }
+
+    fn create_group(&self, created_by: Id, id: Id, name: &str) {
+        self.add_event(format!("{created_by}: created group {id}, {name}"));
     }
 
     fn create_object(

--- a/gwr-track/src/trace_visitor.rs
+++ b/gwr-track/src/trace_visitor.rs
@@ -57,6 +57,32 @@ pub trait TraceVisitor {
         let _ = name;
     }
 
+    /// The creation of a lane.
+    ///
+    /// # Arguments
+    ///
+    /// * `created_by` - ID of the entity causing the creation.
+    /// * `id` - The originator of this event.
+    /// * `name` - Name of the lane being created.
+    fn create_lane(&mut self, created_by: Id, id: Id, name: &str) {
+        let _ = created_by;
+        let _ = id;
+        let _ = name;
+    }
+
+    /// The creation of a group.
+    ///
+    /// # Arguments
+    ///
+    /// * `created_by` - ID of the entity causing the creation.
+    /// * `id` - The originator of this event.
+    /// * `name` - Name of the group being created.
+    fn create_group(&mut self, created_by: Id, id: Id, name: &str) {
+        let _ = created_by;
+        let _ = id;
+        let _ = name;
+    }
+
     /// The creation of an object.
     ///
     /// # Arguments
@@ -142,6 +168,50 @@ pub trait TraceVisitor {
         // Remove the unused variable warnings
         let _ = id;
         let _ = value;
+    }
+
+    /// The specified ID has been added to a group.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID added to the group.
+    /// * `group_id` - The group ID.
+    fn add_to_group(&mut self, id: Id, group_id: Id) {
+        let _ = id;
+        let _ = group_id;
+    }
+
+    /// The specified ID has been removed from a group.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID removed from the group.
+    /// * `group_id` - The group ID.
+    fn remove_from_group(&mut self, id: Id, group_id: Id) {
+        let _ = id;
+        let _ = group_id;
+    }
+
+    /// A named activity has begun on the specified lane.
+    ///
+    /// # Arguments
+    ///
+    /// * `activity` - The activity identity.
+    /// * `lane` - The lane on which the activity is starting.
+    /// * `name` - The activity name.
+    fn begin_activity(&mut self, activity: Id, lane: Id, name: &str) {
+        let _ = activity;
+        let _ = lane;
+        let _ = name;
+    }
+
+    /// The specivied activity has ended.
+    ///
+    /// # Arguments
+    ///
+    /// * `activity` - The activity identity.
+    fn end_activity(&mut self, activity: Id) {
+        let _ = activity;
     }
 
     /// A capacity has been set for the specified ID.
@@ -234,6 +304,18 @@ where
             Ok(gwr_track_capnp::event::Which::Enter(entered)) => handle_enter(visitor, id, entered),
             Ok(gwr_track_capnp::event::Which::Exit(exited)) => handle_exit(visitor, id, exited),
             Ok(gwr_track_capnp::event::Which::Value(value)) => handle_value(visitor, id, value),
+            Ok(gwr_track_capnp::event::Which::AddToGroup(group_id)) => {
+                handle_add_to_group(visitor, id, group_id);
+            }
+            Ok(gwr_track_capnp::event::Which::RemoveFromGroup(group_id)) => {
+                handle_remove_from_group(visitor, id, group_id);
+            }
+            Ok(gwr_track_capnp::event::Which::BeginActivity(begin_activity)) => {
+                handle_begin_activity(visitor, id, begin_activity);
+            }
+            Ok(gwr_track_capnp::event::Which::EndActivity(())) => {
+                handle_end_activity(visitor, id);
+            }
             Ok(gwr_track_capnp::event::Which::Capacity(capacity)) => {
                 handle_capacity(visitor, id, capacity);
             }
@@ -298,6 +380,29 @@ fn handle_create(
                     .expect("Create Monitor name should be valid UTF-8 string"),
             );
         }
+        Ok(gwr_track_capnp::create::Which::Lane(lane)) => {
+            let lane = lane.expect("should be able to parse Create Lane");
+            visitor.create_lane(
+                id,
+                created_id,
+                lane.get_name()
+                    .expect("should be able to parse Lane name")
+                    .to_str()
+                    .expect("Create Lane name should be valid UTF-8 string"),
+            );
+        }
+        Ok(gwr_track_capnp::create::Which::Group(group)) => {
+            let group = group.expect("should be able to parse Create Group");
+            visitor.create_group(
+                id,
+                created_id,
+                group
+                    .get_name()
+                    .expect("should be able to parse Group name")
+                    .to_str()
+                    .expect("Create Group name should be valid UTF-8 string"),
+            );
+        }
         Ok(gwr_track_capnp::create::Which::Object(object)) => {
             let object = object.expect("should be able to parse Create Object");
             visitor.create_object(
@@ -339,6 +444,35 @@ fn handle_exit(visitor: &mut dyn TraceVisitor, id: Id, exited: u64) {
 
 fn handle_value(visitor: &mut dyn TraceVisitor, id: Id, value: f64) {
     visitor.value(id, value);
+}
+
+fn handle_add_to_group(visitor: &mut dyn TraceVisitor, id: Id, group_id: u64) {
+    visitor.add_to_group(id, Id(group_id));
+}
+
+fn handle_remove_from_group(visitor: &mut dyn TraceVisitor, id: Id, group_id: u64) {
+    visitor.remove_from_group(id, Id(group_id));
+}
+
+fn handle_begin_activity(
+    visitor: &mut dyn TraceVisitor,
+    id: Id,
+    begin_activity: capnp::Result<gwr_track_capnp::begin_activity::Reader<'_>>,
+) {
+    let begin_activity = begin_activity.expect("should be able to parse BeginActivity event");
+    visitor.begin_activity(
+        id,
+        Id(begin_activity.get_lane()),
+        begin_activity
+            .get_name()
+            .expect("should be able to parse activity name")
+            .to_str()
+            .expect("Activity name should be valid UTF-8 string"),
+    );
+}
+
+fn handle_end_activity(visitor: &mut dyn TraceVisitor, id: Id) {
+    visitor.end_activity(id);
 }
 
 fn handle_capacity(

--- a/gwr-track/src/tracker/capnp.rs
+++ b/gwr-track/src/tracker/capnp.rs
@@ -102,6 +102,34 @@ impl Track for CapnProtoTracker {
         }
     }
 
+    fn begin_activity(&self, activity: Id, lane: Id, name: &str) {
+        if self.is_entity_enabled(lane, log::Level::Trace) {
+            self.write_event(activity, |event| {
+                let mut begin_activity = event.init_begin_activity();
+                begin_activity.set_lane(lane.0);
+                begin_activity.set_name(name);
+            });
+        }
+    }
+
+    fn add_to_group(&self, activity: Id, group_id: Id) {
+        self.write_event(activity, |mut event| {
+            event.set_add_to_group(group_id.0);
+        });
+    }
+
+    fn remove_from_group(&self, activity: Id, group_id: Id) {
+        self.write_event(activity, |mut event| {
+            event.set_remove_from_group(group_id.0);
+        });
+    }
+
+    fn end_activity(&self, activity: Id) {
+        self.write_event(activity, |mut event| {
+            event.set_end_activity(());
+        });
+    }
+
     fn create_entity(&self, created_by: Id, id: Id, name: &str) {
         // Don't filter this event as it could be required by a GUI
         self.write_event(created_by, |event| {
@@ -117,6 +145,24 @@ impl Track for CapnProtoTracker {
             let mut create = event.init_create();
             create.set_id(id.0);
             create.init_monitor().set_name(name);
+        });
+    }
+
+    fn create_lane(&self, created_by: Id, id: Id, name: &str) {
+        // Don't filter this event as it could be required by a GUI
+        self.write_event(created_by, |event| {
+            let mut create = event.init_create();
+            create.set_id(id.0);
+            create.init_lane().set_name(name);
+        });
+    }
+
+    fn create_group(&self, created_by: Id, id: Id, name: &str) {
+        // Don't filter this event as it could be required by a GUI
+        self.write_event(created_by, |event| {
+            let mut create = event.init_create();
+            create.set_id(id.0);
+            create.init_group().set_name(name);
         });
     }
 

--- a/gwr-track/src/tracker/dev_null.rs
+++ b/gwr-track/src/tracker/dev_null.rs
@@ -26,9 +26,15 @@ impl Track for DevNullTracker {
     fn enter(&self, _id: Id, _obj: Id) {}
     fn exit(&self, _id: Id, _obj: Id) {}
     fn value(&self, _id: Id, _value: f64) {}
+    fn begin_activity(&self, _activity: Id, _lane: Id, _name: &str) {}
+    fn end_activity(&self, _activity: Id) {}
+    fn add_to_group(&self, _activity: Id, _group_id: Id) {}
+    fn remove_from_group(&self, _activity: Id, _group_id: Id) {}
     fn capacity(&self, _id: Id, _capacity: Capacity) {}
     fn create_entity(&self, _created_by: Id, _id: Id, _name: &str) {}
     fn create_monitor(&self, _created_by: Id, _id: Id, _name: &str) {}
+    fn create_lane(&self, _created_by: Id, _id: Id, _name: &str) {}
+    fn create_group(&self, _created_by: Id, _id: Id, _name: &str) {}
     fn create_object(
         &self,
         _created_by: Id,

--- a/gwr-track/src/tracker/mod.rs
+++ b/gwr-track/src/tracker/mod.rs
@@ -68,6 +68,24 @@ pub trait Track {
     /// Track when a monitor with the given ID is created.
     fn create_monitor(&self, created_by: Id, id: Id, name: &str);
 
+    /// Track when a lane with the given ID is created.
+    fn create_lane(&self, created_by: Id, id: Id, name: &str);
+
+    /// Track when a group with the given ID is created.
+    fn create_group(&self, created_by: Id, id: Id, name: &str);
+
+    /// Track when an activity becomes a member of a group.
+    fn add_to_group(&self, activity: Id, group_id: Id);
+
+    /// Track when an activity is no longer a member of a group.
+    fn remove_from_group(&self, activity: Id, group_id: Id);
+
+    /// Track the beginning of a named activity on a lane.
+    fn begin_activity(&self, activity: Id, lane: Id, name: &str);
+
+    /// Track the end of the current activity on a lane.
+    fn end_activity(&self, activity: Id);
+
     /// Track when an object with the given ID is created.
     fn create_object(
         &self,

--- a/gwr-track/src/tracker/multi_tracker.rs
+++ b/gwr-track/src/tracker/multi_tracker.rs
@@ -76,6 +76,30 @@ impl Track for MultiTracker {
         }
     }
 
+    fn begin_activity(&self, activity: Id, lane: Id, name: &str) {
+        for tracker in &self.trackers {
+            tracker.begin_activity(activity, lane, name);
+        }
+    }
+
+    fn add_to_group(&self, activity: Id, group_id: Id) {
+        for tracker in &self.trackers {
+            tracker.add_to_group(activity, group_id);
+        }
+    }
+
+    fn remove_from_group(&self, activity: Id, group_id: Id) {
+        for tracker in &self.trackers {
+            tracker.remove_from_group(activity, group_id);
+        }
+    }
+
+    fn end_activity(&self, activity: Id) {
+        for tracker in &self.trackers {
+            tracker.end_activity(activity);
+        }
+    }
+
     fn create_entity(&self, created_by: Id, id: Id, name: &str) {
         for tracker in &self.trackers {
             tracker.create_entity(created_by, id, name);
@@ -85,6 +109,18 @@ impl Track for MultiTracker {
     fn create_monitor(&self, created_by: Id, id: Id, name: &str) {
         for tracker in &self.trackers {
             tracker.create_monitor(created_by, id, name);
+        }
+    }
+
+    fn create_lane(&self, created_by: Id, id: Id, name: &str) {
+        for tracker in &self.trackers {
+            tracker.create_lane(created_by, id, name);
+        }
+    }
+
+    fn create_group(&self, created_by: Id, id: Id, name: &str) {
+        for tracker in &self.trackers {
+            tracker.create_group(created_by, id, name);
         }
     }
 

--- a/gwr-track/src/tracker/perfetto.rs
+++ b/gwr-track/src/tracker/perfetto.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::entity::Capacity;
@@ -15,6 +16,8 @@ pub struct PerfettoTracker {
     writer: SharedWriter,
     current_time_ns: RefCell<u64>,
     trace_builder: RefCell<PerfettoTraceBuilder>,
+    group_memberships: RefCell<HashMap<Id, Id>>,
+    activity_lanes: RefCell<HashMap<Id, Id>>,
 }
 
 impl PerfettoTracker {
@@ -25,6 +28,8 @@ impl PerfettoTracker {
             writer: Rc::new(RefCell::new(writer)),
             current_time_ns: RefCell::new(0),
             trace_builder: RefCell::new(PerfettoTraceBuilder::new()),
+            group_memberships: RefCell::new(HashMap::new()),
+            activity_lanes: RefCell::new(HashMap::new()),
         }
     }
 }
@@ -86,6 +91,51 @@ impl Track for PerfettoTracker {
         }
     }
 
+    fn begin_activity(&self, activity: Id, lane: Id, name: &str) {
+        if self.is_entity_enabled(lane, log::Level::Trace) {
+            self.activity_lanes.borrow_mut().insert(activity, lane);
+            let guard = self.trace_builder.borrow_mut();
+            let correlation_id = self
+                .group_memberships
+                .borrow()
+                .get(&activity)
+                .map(|group_id| group_id.0);
+            let trace_packet = guard.build_activity_begin_trace_packet(
+                *self.current_time_ns.borrow(),
+                lane,
+                name,
+                correlation_id,
+            );
+            let buf = guard.build_trace_to_bytes(vec![trace_packet]);
+            self.writer.borrow_mut().write_all(&buf).unwrap();
+        }
+    }
+
+    fn add_to_group(&self, activity: Id, group_id: Id) {
+        self.group_memberships
+            .borrow_mut()
+            .insert(activity, group_id);
+    }
+
+    fn remove_from_group(&self, activity: Id, group_id: Id) {
+        let is_member = self.group_memberships.borrow().get(&activity) == Some(&group_id);
+        if is_member {
+            self.group_memberships.borrow_mut().remove(&activity);
+        }
+    }
+
+    fn end_activity(&self, activity: Id) {
+        if let Some(lane) = self.activity_lanes.borrow_mut().remove(&activity)
+            && self.is_entity_enabled(lane, log::Level::Trace)
+        {
+            let guard = self.trace_builder.borrow_mut();
+            let trace_packet =
+                guard.build_activity_end_trace_packet(*self.current_time_ns.borrow(), lane);
+            let buf = guard.build_trace_to_bytes(vec![trace_packet]);
+            self.writer.borrow_mut().write_all(&buf).unwrap();
+        }
+    }
+
     fn create_entity(&self, created_by: Id, id: Id, name: &str) {
         if self.is_entity_enabled(id, log::Level::Trace) {
             let mut guard = self.trace_builder.borrow_mut();
@@ -113,6 +163,22 @@ impl Track for PerfettoTracker {
             self.writer.borrow_mut().write_all(&buf).unwrap();
         }
     }
+
+    fn create_lane(&self, created_by: Id, id: Id, name: &str) {
+        if self.is_entity_enabled(id, log::Level::Trace) {
+            let mut guard = self.trace_builder.borrow_mut();
+            let trace_packet = guard.build_activity_track_descriptor_trace_packet(
+                *self.current_time_ns.borrow(),
+                id,
+                created_by,
+                name,
+            );
+            let buf = guard.build_trace_to_bytes(vec![trace_packet]);
+            self.writer.borrow_mut().write_all(&buf).unwrap();
+        }
+    }
+
+    fn create_group(&self, _created_by: Id, _id: Id, _name: &str) {}
 
     fn create_object(
         &self,

--- a/gwr-track/src/tracker/text.rs
+++ b/gwr-track/src/tracker/text.rs
@@ -75,6 +75,42 @@ impl Track for TextTracker {
         }
     }
 
+    fn add_to_group(&self, activity: Id, group_id: Id) {
+        if self.is_entity_enabled(activity, log::Level::Trace) {
+            self.writer
+                .borrow_mut()
+                .write_all(format!("{activity}: added to group {group_id}\n").as_bytes())
+                .unwrap();
+        }
+    }
+
+    fn remove_from_group(&self, activity: Id, group_id: Id) {
+        if self.is_entity_enabled(activity, log::Level::Trace) {
+            self.writer
+                .borrow_mut()
+                .write_all(format!("{activity}: removed from group {group_id}\n").as_bytes())
+                .unwrap();
+        }
+    }
+
+    fn begin_activity(&self, activity: Id, lane: Id, name: &str) {
+        if self.is_entity_enabled(lane, log::Level::Trace) {
+            self.writer
+                .borrow_mut()
+                .write_all(format!("{activity}: activity begin {name} on lane {lane}\n").as_bytes())
+                .unwrap();
+        }
+    }
+
+    fn end_activity(&self, activity: Id) {
+        if self.is_entity_enabled(activity, log::Level::Trace) {
+            self.writer
+                .borrow_mut()
+                .write_all(format!("{activity}: activity end\n").as_bytes())
+                .unwrap();
+        }
+    }
+
     fn create_entity(&self, created_by: Id, id: Id, name: &str) {
         if self.is_entity_enabled(created_by, log::Level::Trace) {
             self.writer
@@ -89,6 +125,24 @@ impl Track for TextTracker {
             self.writer
                 .borrow_mut()
                 .write_all(format!("{created_by}: created monitor {id}, {name}\n").as_bytes())
+                .unwrap();
+        }
+    }
+
+    fn create_lane(&self, created_by: Id, id: Id, name: &str) {
+        if self.is_entity_enabled(created_by, log::Level::Trace) {
+            self.writer
+                .borrow_mut()
+                .write_all(format!("{created_by}: created lane {id}, {name}\n").as_bytes())
+                .unwrap();
+        }
+    }
+
+    fn create_group(&self, created_by: Id, id: Id, name: &str) {
+        if self.is_entity_enabled(created_by, log::Level::Trace) {
+            self.writer
+                .borrow_mut()
+                .write_all(format!("{created_by}: created group {id}, {name}\n").as_bytes())
                 .unwrap();
         }
     }

--- a/gwr-track/tests/activity.rs
+++ b/gwr-track/tests/activity.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::fs;
+use std::io::{BufReader, BufWriter};
+use std::rc::Rc;
+
+use gwr_track::entity::{EntityGroup, EntityLane, toplevel};
+use gwr_track::trace_visitor::{TraceVisitor, process_capnp};
+use gwr_track::tracker::{CapnProtoTracker, EntityManager};
+use gwr_track::{Id, Tracker};
+
+#[derive(Default)]
+struct ActivityVisitor {
+    events: Vec<String>,
+}
+
+impl TraceVisitor for ActivityVisitor {
+    fn create_lane(&mut self, created_by: Id, id: Id, name: &str) {
+        self.events
+            .push(format!("{created_by}: created lane {id}, {name}"));
+    }
+
+    fn create_group(&mut self, created_by: Id, id: Id, name: &str) {
+        self.events
+            .push(format!("{created_by}: created group {id}, {name}"));
+    }
+
+    fn begin_activity(&mut self, activity: Id, lane: Id, name: &str) {
+        self.events
+            .push(format!("{activity}: activity begin {name} on lane {lane}"));
+    }
+
+    fn add_to_group(&mut self, id: Id, group_id: Id) {
+        self.events.push(format!("{id}: added to group {group_id}"));
+    }
+
+    fn remove_from_group(&mut self, id: Id, group_id: Id) {
+        self.events
+            .push(format!("{id}: removed from group {group_id}"));
+    }
+
+    fn end_activity(&mut self, id: Id) {
+        self.events.push(format!("{id}: activity end"));
+    }
+}
+
+#[test]
+fn activity_events_round_trip_through_capnp_trace() {
+    let path = std::env::temp_dir().join(format!("gwr-track-activity-{}.bin", std::process::id()));
+    let writer: gwr_track::Writer = Box::new(BufWriter::new(fs::File::create(&path).unwrap()));
+    let tracker: Tracker = Rc::new(CapnProtoTracker::new(
+        EntityManager::new(log::Level::Trace),
+        writer,
+    ));
+
+    {
+        let top = toplevel(&tracker, "top");
+        let mut lane = EntityLane::new(&top, "lane::add");
+        let group = EntityGroup::new(&top, "group::add_task");
+        lane.begin("add_task (add)");
+        lane.end();
+        lane.begin_in_group("add_task compute", &group);
+        lane.end();
+    }
+    tracker.shutdown();
+
+    let mut visitor = ActivityVisitor::default();
+    let reader = BufReader::new(fs::File::open(&path).unwrap());
+    process_capnp(reader, &mut visitor);
+    fs::remove_file(path).unwrap();
+
+    assert_eq!(
+        visitor.events,
+        [
+            "2: created lane 3, top::lane::add",
+            "2: created group 4, top::group::add_task",
+            "5: activity begin add_task (add) on lane 3",
+            "5: activity end",
+            "6: added to group 4",
+            "6: activity begin add_task compute on lane 3",
+            "6: activity end",
+            "6: removed from group 4",
+        ]
+    );
+}

--- a/gwr-track/tests/smoke_macros.rs
+++ b/gwr-track/tests/smoke_macros.rs
@@ -5,7 +5,7 @@
 use std::fmt::Display;
 use std::rc::Rc;
 
-use gwr_track::entity::{Entity, toplevel};
+use gwr_track::entity::{Entity, EntityLane, toplevel};
 use gwr_track::id::Unique;
 use gwr_track::{
     Id, create_id, debug, destroy_id, error, info, set_time, test_helpers, test_init, trace, warn,
@@ -112,6 +112,32 @@ fn enter_exit_basics() {
 
     drop(top);
     test_helpers::check_and_clear(&test_tracker, &["40: destroyed"]);
+}
+
+#[test]
+fn activity_basics() {
+    let (test_tracker, tracker) = test_init!(70);
+
+    let top = toplevel(&tracker, "top");
+    test_helpers::check_and_clear(&test_tracker, &["0: created entity 70, top"]);
+
+    {
+        let mut lane = EntityLane::new(&top, "lane::add");
+        test_helpers::check_and_clear(&test_tracker, &["70: created lane 71, top::lane::add"]);
+
+        lane.begin("add_task (add)");
+        test_helpers::check_and_clear(
+            &test_tracker,
+            &["72: activity begin add_task \\(add\\) on lane 71"],
+        );
+
+        lane.end();
+        test_helpers::check_and_clear(&test_tracker, &["72: activity end"]);
+    }
+    test_helpers::check_and_clear(&test_tracker, &["70: destroyed 71"]);
+
+    drop(top);
+    test_helpers::check_and_clear(&test_tracker, &["70: destroyed"]);
 }
 
 #[test]

--- a/licenses.html
+++ b/licenses.html
@@ -8107,10 +8107,10 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.4.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.8.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.9.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-terminus 0.4.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-timetable 0.3.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.11.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.12.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 


### PR DESCRIPTION
This change allows us to better visualise the PE activity. It adds lanes for the
tensor read/write and compute and shows the activity within those lanes. A lane cannot
support overlapping activity (a Perfetto restriction) and so we automatically
create new lanes when required.

We add the concept of groups as well in order to ensure that Perfetto (and other
UI tools) can associate related activity. In this case, the tensor read/write
and compute are all grouped together and that maps to the Perfetto correlation_id
so that they can be coloured appropriately.

The other change that was required in order to make this plotting work effectively
was to ensure that the clock Phases are always available and that the BEGIN
phase will always come after the END phase. That guarantees that events that
complete in the same clock tick will be completed before new ones that start
in that clock tick. Without that change, it could look like there were overlapping
read/write events when they did not actually overlap.
