### PR TITLE
perf(gwr-track): Avoid formatting disabled trace events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-track"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/examples/flaky-component/Cargo.toml
+++ b/examples/flaky-component/Cargo.toml
@@ -24,5 +24,5 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", version = "0.13.0" }
 rand.workspace = true

--- a/examples/flaky-with-delay/Cargo.toml
+++ b/examples/flaky-with-delay/Cargo.toml
@@ -24,5 +24,5 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", version = "0.13.0" }
 rand.workspace = true

--- a/examples/scrambler/Cargo.toml
+++ b/examples/scrambler/Cargo.toml
@@ -24,4 +24,4 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-track = { path = "../../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", version = "0.13.0" }

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -25,7 +25,7 @@ gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true
 rand_xoshiro = "0.7.0"

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -25,7 +25,7 @@ gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true
 serde.workspace = true

--- a/examples/sim-restaurant/Cargo.toml
+++ b/examples/sim-restaurant/Cargo.toml
@@ -22,7 +22,7 @@ crossterm.workspace = true
 futures.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 log.workspace = true
 rand.workspace = true
 ratatui.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -24,6 +24,6 @@ gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.12.0" }
+gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/gwr-components/Cargo.toml
+++ b/gwr-components/Cargo.toml
@@ -34,7 +34,7 @@ gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 paste.workspace = true
 

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 futures.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 mimalloc = { version = "0.1.48", features = ["v3"], optional = true }
 rand.workspace = true

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -35,7 +35,7 @@ gwr-components = { path = "../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
-gwr-track = { path = "../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 paste.workspace = true
 rand.workspace = true

--- a/gwr-models/src/ethernet_frame.rs
+++ b/gwr-models/src/ethernet_frame.rs
@@ -9,7 +9,7 @@ use gwr_engine::traits::{Routable, SimObject, TotalBytes};
 use gwr_engine::types::AccessType;
 use gwr_track::entity::Entity;
 use gwr_track::id::Unique;
-use gwr_track::{Id, create_id};
+use gwr_track::{Id, create_id, track_create_object};
 
 pub const PREAMBLE_BYTES: usize = 7;
 pub const SFD_BYTES: usize = 1;
@@ -61,12 +61,13 @@ impl EthernetFrame {
             payload_size_bytes,
         };
         // Having just created the frame the req_type must be valid
-        created_by.track_create_object(
+        track_create_object!(
+            created_by;
             frame.id,
             frame.total_bytes(),
             "bytes",
             frame.access_type() as u8,
-            &format!("EthernetFrame: {frame}"),
+            "EthernetFrame: {frame}"
         );
         frame
     }

--- a/gwr-models/src/memory/memory_access.rs
+++ b/gwr-models/src/memory/memory_access.rs
@@ -8,7 +8,7 @@ use gwr_engine::traits::{Routable, SimObject, TotalBytes};
 use gwr_engine::types::{AccessType, SimError};
 use gwr_track::entity::Entity;
 use gwr_track::id::Unique;
-use gwr_track::{Id, create_id};
+use gwr_track::{Id, create_id, track_create_object};
 
 use crate::memory::CacheHintType;
 use crate::memory::memory_map::DeviceId;
@@ -145,12 +145,13 @@ impl MemoryAccess {
             cache_hint: CacheHintType::Allocate,
             overhead_size_bytes,
         };
-        created_by.track_create_object(
+        track_create_object!(
+            created_by;
             access.id,
             access.total_bytes(),
             "bytes",
             access.access_type() as u8,
-            &format!("MemoryAccess: {access}"),
+            "MemoryAccess: {access}"
         );
         access
     }

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -26,7 +26,7 @@ gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.19.0" }
-gwr-track = { path = "../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/gwr-protocols/Cargo.toml
+++ b/gwr-protocols/Cargo.toml
@@ -24,4 +24,4 @@ paste.workspace = true
 [dev-dependencies]
 gwr-components = { path = "../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
-gwr-track = { path = "../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.13.0" }

--- a/gwr-protocols/src/packet.rs
+++ b/gwr-protocols/src/packet.rs
@@ -52,13 +52,14 @@ macro_rules! build_packet_type {
                         $field: (cfg.$field >> $scale) & ((1 << $bits) - 1),
                     )+
                 };
-                let details = format!("{pkt:?}");
-                created_by.create_object(
+                gwr_track::track_create_object!(
+                    created_by;
                     pkt.id(),
                     pkt.total_bytes(),
                     "bytes",
                     pkt.req_type() as u8,
-                    &format!("{}: {details}", stringify!($packet_type)),
+                    "{}: {pkt:?}",
+                    stringify!($packet_type)
                 );
                 pkt
             }

--- a/gwr-resources/Cargo.toml
+++ b/gwr-resources/Cargo.toml
@@ -22,4 +22,4 @@ publish.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 
 [dev-dependencies]
-gwr-track = { path = "../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.13.0" }

--- a/gwr-spotter/Cargo.toml
+++ b/gwr-spotter/Cargo.toml
@@ -27,7 +27,7 @@ publish.workspace = true
 capnp.workspace = true
 clap.workspace = true
 crossterm.workspace = true
-gwr-track = { path = "../gwr-track", version = "0.12.0" }
+gwr-track = { path = "../gwr-track", version = "0.13.0" }
 itertools.workspace = true
 log.workspace = true
 ratatui.workspace = true

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -31,7 +31,7 @@ gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.19.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.5.0" }
-gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.12.0" }
+gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true
 rand.workspace = true

--- a/gwr-track/Cargo.toml
+++ b/gwr-track/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-track"
-version = "0.12.0"
+version = "0.13.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-track/src/entity.rs
+++ b/gwr-track/src/entity.rs
@@ -53,6 +53,9 @@ pub struct Entity {
 
     /// [`Tracker`] used to handle trace/log events.
     pub tracker: Tracker,
+
+    /// Most verbose log level enabled for this entity by any tracker.
+    enabled_level: log::Level,
 }
 
 static JOIN: &str = "::";
@@ -74,13 +77,14 @@ impl Entity {
 
         let tracker = parent.tracker.clone();
         let id = create_id!(parent);
-        tracker.add_entity(id, &full_name, alternative_names);
+        let enabled_level = tracker.add_entity(id, &full_name, alternative_names);
 
         let entity = Self {
             name: String::from(name),
             parent: Some(parent.clone()),
             id,
             tracker,
+            enabled_level,
         };
         entity.track_create(parent.id, &full_name);
 
@@ -107,6 +111,19 @@ impl Entity {
         }
     }
 
+    /// Return whether trace-level events for this entity will be emitted.
+    #[must_use]
+    pub fn trace_enabled(&self) -> bool {
+        self.enabled_for(log::Level::Trace)
+    }
+
+    /// Return whether events at the given level will be emitted for this
+    /// entity.
+    #[must_use]
+    pub fn enabled_for(&self, level: log::Level) -> bool {
+        level <= self.enabled_level
+    }
+
     /// Emit the capacity represented by this simulation entity.
     pub fn track_capacity(&self, value: usize, units: impl Into<String>) {
         self.tracker.capacity(self.id, Capacity::new(value, units));
@@ -120,19 +137,6 @@ impl Entity {
     /// Emit an exit event for an object.
     pub fn track_exit(&self, exited: Id) {
         self.tracker.exit(self.id, exited);
-    }
-
-    /// Emit an object creation event.
-    pub fn track_create_object(
-        &self,
-        created: Id,
-        size: usize,
-        units: &str,
-        req_type: u8,
-        details: &str,
-    ) {
-        self.tracker
-            .create_object(self.id, created, size, units, req_type, details);
     }
 
     fn track_create(&self, created_by: Id, full_name: &str) {
@@ -171,12 +175,13 @@ impl fmt::Display for Entity {
 /// parent.
 pub fn toplevel(tracker: &Tracker, name: &str) -> Rc<Entity> {
     let id = tracker.unique_id();
-    tracker.add_entity(id, name, None);
+    let enabled_level = tracker.add_entity(id, name, None);
     let top = Rc::new(Entity {
         parent: None,
         name: String::from(name),
         id,
         tracker: tracker.clone(),
+        enabled_level,
     });
     top.track_create(crate::NO_ID, name);
     top

--- a/gwr-track/src/lib.rs
+++ b/gwr-track/src/lib.rs
@@ -73,10 +73,32 @@ pub const ROOT: Id = id::Id(1);
 ///
 /// **Note:** this macro should be used when the object being assigned the
 ///           [`Id`] will have its creation tracked with the
-///           [crate::entity::Entity::track_create_object] function.
+///           [`track_create_object`] macro.
 #[macro_export]
 macro_rules! create_id {
     ($entity:expr) => {{ $entity.tracker.unique_id() }};
+}
+
+/// Add an object creation event.
+///
+/// The details string is only formatted when trace-level events are enabled for
+/// the entity.
+#[macro_export]
+macro_rules! track_create_object {
+    ($entity:expr ; $created:expr, $size:expr, $units:expr, $req_type:expr, $($details:tt)+) => {{
+        let entity = &$entity;
+        if entity.trace_enabled() {
+            let details = format!($($details)+);
+            entity.tracker.create_object(
+                entity.id,
+                $created,
+                $size,
+                $units,
+                $req_type,
+                &details,
+            );
+        }
+    }};
 }
 
 /// Destroy an ID
@@ -127,9 +149,13 @@ macro_rules! set_time {
 /// stream.
 #[macro_export]
 macro_rules! log_base {
-    ($entity:expr ; $lvl:expr, $($arg:tt)+) => (
-        $entity.tracker.log($entity.id, $lvl, format_args!($($arg)+));
-    );
+    ($entity:expr ; $lvl:expr, $($arg:tt)+) => {{
+        let entity = &$entity;
+        let level = $lvl;
+        if entity.enabled_for(level) {
+            entity.tracker.log(entity.id, level, format_args!($($arg)+));
+        }
+    }};
 }
 
 /// The `trace` macro provides a wrapper for the [`log`](macro.log.html) macro

--- a/gwr-track/src/test_helpers.rs
+++ b/gwr-track/src/test_helpers.rs
@@ -64,16 +64,21 @@ impl Track for TestTracker {
         Id(id)
     }
 
-    fn is_entity_enabled(&self, _id: Id, level: log::Level) -> bool {
-        level <= self.level
+    fn enabled_level(&self, _id: Id) -> log::Level {
+        self.level
     }
 
     fn monitoring_window_size_for(&self, _id: Id) -> Option<u64> {
         None
     }
 
-    fn add_entity(&self, _id: Id, _entity_name: &str, _alternative_names: AlternativeNames) {
-        // Do nothing
+    fn add_entity(
+        &self,
+        _id: Id,
+        _entity_name: &str,
+        _alternative_names: AlternativeNames,
+    ) -> log::Level {
+        self.level
     }
 
     fn enter(&self, id: Id, item: Id) {

--- a/gwr-track/src/tracker/capnp.rs
+++ b/gwr-track/src/tracker/capnp.rs
@@ -65,17 +65,22 @@ impl Track for CapnProtoTracker {
         self.entity_manager.unique_id()
     }
 
-    fn is_entity_enabled(&self, id: Id, level: log::Level) -> bool {
-        self.entity_manager.is_log_enabled_at_level(id, level)
+    fn enabled_level(&self, id: Id) -> log::Level {
+        self.entity_manager.enabled_level(id)
     }
 
     fn monitoring_window_size_for(&self, id: Id) -> Option<u64> {
         self.entity_manager.monitoring_window_size_for(id)
     }
 
-    fn add_entity(&self, id: Id, entity_name: &str, alternative_names: AlternativeNames) {
+    fn add_entity(
+        &self,
+        id: Id,
+        entity_name: &str,
+        alternative_names: AlternativeNames,
+    ) -> log::Level {
         self.entity_manager
-            .add_entity(id, entity_name, alternative_names);
+            .add_entity(id, entity_name, alternative_names)
     }
 
     fn enter(&self, id: Id, object: Id) {

--- a/gwr-track/src/tracker/dev_null.rs
+++ b/gwr-track/src/tracker/dev_null.rs
@@ -16,13 +16,20 @@ impl Track for DevNullTracker {
     fn unique_id(&self) -> Id {
         Id(0)
     }
-    fn is_entity_enabled(&self, _id: Id, _level: log::Level) -> bool {
-        false
+    fn enabled_level(&self, _id: Id) -> log::Level {
+        log::Level::Error
     }
     fn monitoring_window_size_for(&self, _id: Id) -> Option<u64> {
         None
     }
-    fn add_entity(&self, _id: Id, _entity_name: &str, _alternative_names: AlternativeNames) {}
+    fn add_entity(
+        &self,
+        _id: Id,
+        _entity_name: &str,
+        _alternative_names: AlternativeNames,
+    ) -> log::Level {
+        log::Level::Error
+    }
     fn enter(&self, _id: Id, _obj: Id) {}
     fn exit(&self, _id: Id, _obj: Id) {}
     fn value(&self, _id: Id, _value: f64) {}

--- a/gwr-track/src/tracker/mod.rs
+++ b/gwr-track/src/tracker/mod.rs
@@ -42,16 +42,25 @@ pub trait Track {
     /// Allocate a new global ID
     fn unique_id(&self) -> Id;
 
-    /// Determine whether tracking is enabled, and at what level for an
-    /// entity looked up by its ID.
-    fn is_entity_enabled(&self, id: Id, level: log::Level) -> bool;
+    /// Determine the most verbose tracking level enabled for an entity.
+    fn enabled_level(&self, id: Id) -> log::Level;
+
+    /// Determine whether tracking is enabled at a given level for an entity.
+    fn is_entity_enabled(&self, id: Id, level: log::Level) -> bool {
+        level <= self.enabled_level(id)
+    }
 
     /// Return the monitoring window size if it is to be enabled.
     /// Entity looked up by its ID.
     fn monitoring_window_size_for(&self, id: Id) -> Option<u64>;
 
     /// Record an entity being created.
-    fn add_entity(&self, id: Id, entity_name: &str, alternative_names: AlternativeNames);
+    fn add_entity(
+        &self,
+        id: Id,
+        entity_name: &str,
+        alternative_names: AlternativeNames,
+    ) -> log::Level;
 
     /// Track when an entity with the given ID arrives.
     fn enter(&self, enter_into: Id, enter_obj: Id);
@@ -185,10 +194,10 @@ impl EntityManager {
         Id(id)
     }
 
-    fn is_log_enabled_at_level(&self, id: Id, level: log::Level) -> bool {
+    fn enabled_level(&self, id: Id) -> log::Level {
         match self.log_entity_lookup.borrow().get(&id) {
-            None => level <= self.default_entity_level,
-            Some(entity_level) => level <= *entity_level,
+            None => self.default_entity_level,
+            Some(entity_level) => *entity_level,
         }
     }
 
@@ -196,7 +205,12 @@ impl EntityManager {
         self.monitor_window_size_lookup.borrow().get(&id).copied()
     }
 
-    fn add_entity(&self, id: Id, entity_name: &str, alternative_names: AlternativeNames) {
+    fn add_entity(
+        &self,
+        id: Id,
+        entity_name: &str,
+        alternative_names: AlternativeNames,
+    ) -> log::Level {
         let entity_level = self.log_level_for(entity_name, alternative_names);
         if entity_level != self.default_entity_level
             && self
@@ -215,6 +229,8 @@ impl EntityManager {
                 .borrow_mut()
                 .insert(id, window_size_ticks);
         }
+
+        entity_level
     }
 
     fn log_level_for(&self, entity_name: &str, alternative_names: AlternativeNames) -> log::Level {

--- a/gwr-track/src/tracker/multi_tracker.rs
+++ b/gwr-track/src/tracker/multi_tracker.rs
@@ -34,13 +34,12 @@ impl Track for MultiTracker {
         self.entity_manager.unique_id()
     }
 
-    fn is_entity_enabled(&self, id: Id, level: log::Level) -> bool {
-        for tracker in &self.trackers {
-            if tracker.is_entity_enabled(id, level) {
-                return true;
-            }
-        }
-        false
+    fn enabled_level(&self, id: Id) -> log::Level {
+        self.trackers
+            .iter()
+            .map(|tracker| tracker.enabled_level(id))
+            .max()
+            .unwrap_or(log::Level::Error)
     }
 
     fn monitoring_window_size_for(&self, id: Id) -> Option<u64> {
@@ -52,10 +51,17 @@ impl Track for MultiTracker {
         None
     }
 
-    fn add_entity(&self, id: Id, entity_name: &str, alternative_names: AlternativeNames) {
-        for tracker in &self.trackers {
-            tracker.add_entity(id, entity_name, alternative_names);
-        }
+    fn add_entity(
+        &self,
+        id: Id,
+        entity_name: &str,
+        alternative_names: AlternativeNames,
+    ) -> log::Level {
+        self.trackers
+            .iter()
+            .map(|tracker| tracker.add_entity(id, entity_name, alternative_names))
+            .max()
+            .unwrap_or(log::Level::Error)
     }
 
     fn enter(&self, id: Id, object: Id) {

--- a/gwr-track/src/tracker/perfetto.rs
+++ b/gwr-track/src/tracker/perfetto.rs
@@ -39,17 +39,22 @@ impl Track for PerfettoTracker {
         self.entity_manager.unique_id()
     }
 
-    fn is_entity_enabled(&self, id: Id, level: log::Level) -> bool {
-        self.entity_manager.is_log_enabled_at_level(id, level)
+    fn enabled_level(&self, id: Id) -> log::Level {
+        self.entity_manager.enabled_level(id)
     }
 
     fn monitoring_window_size_for(&self, id: Id) -> Option<u64> {
         self.entity_manager.monitoring_window_size_for(id)
     }
 
-    fn add_entity(&self, id: Id, entity_name: &str, alternative_names: AlternativeNames) {
+    fn add_entity(
+        &self,
+        id: Id,
+        entity_name: &str,
+        alternative_names: AlternativeNames,
+    ) -> log::Level {
         self.entity_manager
-            .add_entity(id, entity_name, alternative_names);
+            .add_entity(id, entity_name, alternative_names)
     }
 
     fn enter(&self, id: Id, entered: Id) {

--- a/gwr-track/src/tracker/text.rs
+++ b/gwr-track/src/tracker/text.rs
@@ -35,17 +35,22 @@ impl Track for TextTracker {
         self.entity_manager.unique_id()
     }
 
-    fn is_entity_enabled(&self, id: Id, level: log::Level) -> bool {
-        self.entity_manager.is_log_enabled_at_level(id, level)
+    fn enabled_level(&self, id: Id) -> log::Level {
+        self.entity_manager.enabled_level(id)
     }
 
     fn monitoring_window_size_for(&self, id: Id) -> Option<u64> {
         self.entity_manager.monitoring_window_size_for(id)
     }
 
-    fn add_entity(&self, id: Id, entity_name: &str, alternative_names: AlternativeNames) {
+    fn add_entity(
+        &self,
+        id: Id,
+        entity_name: &str,
+        alternative_names: AlternativeNames,
+    ) -> log::Level {
         self.entity_manager
-            .add_entity(id, entity_name, alternative_names);
+            .add_entity(id, entity_name, alternative_names)
     }
 
     fn enter(&self, id: Id, object: Id) {

--- a/gwr-track/tests/smoke_macros.rs
+++ b/gwr-track/tests/smoke_macros.rs
@@ -2,13 +2,17 @@
 
 //! Ensure that all version of each macro can be used
 
+use std::cell::Cell;
 use std::fmt::Display;
 use std::rc::Rc;
 
 use gwr_track::entity::{Entity, EntityLane, toplevel};
 use gwr_track::id::Unique;
+use gwr_track::tracker::Tracker;
+use gwr_track::tracker::multi_tracker::MultiTracker;
 use gwr_track::{
-    Id, create_id, debug, destroy_id, error, info, set_time, test_helpers, test_init, trace, warn,
+    Id, create_id, debug, destroy_id, error, info, set_time, test_helpers, test_init, trace,
+    track_create_object, warn,
 };
 
 #[derive(Debug)]
@@ -20,7 +24,7 @@ impl TestObject {
     fn new(entity: &Rc<Entity>, size: usize) -> Self {
         let id = create_id!(entity);
         let object = Self { id };
-        entity.track_create_object(id, size, "bytes", u8::MAX, &format!("{object}"));
+        track_create_object!(entity ; id, size, "bytes", u8::MAX, "{object}");
         object
     }
 }
@@ -67,6 +71,75 @@ build_with_entity!(info_with_entity, info, "INFO");
 build_with_entity!(debug_with_entity, debug, "DEBUG");
 build_with_entity!(warn_with_entity, warn, "WARN");
 build_with_entity!(error_with_entity, error, "ERROR");
+
+fn count_format_evaluation(evaluations: &Cell<usize>) -> &'static str {
+    evaluations.set(evaluations.get() + 1);
+    "evaluated"
+}
+
+#[test]
+fn disabled_log_macro_does_not_evaluate_format_arguments() {
+    let test_tracker = Rc::new(test_helpers::TestTracker::new(500, log::Level::Error));
+    let tracker: Tracker = test_tracker.clone();
+
+    let top = toplevel(&tracker, "top");
+    let evaluations = Cell::new(0);
+
+    trace!(top ; "{}", count_format_evaluation(&evaluations));
+
+    assert_eq!(evaluations.get(), 0);
+    test_helpers::check_and_clear(&test_tracker, &["0: created entity 500, top"]);
+}
+
+#[test]
+fn disabled_create_object_macro_does_not_evaluate_format_arguments() {
+    let test_tracker = Rc::new(test_helpers::TestTracker::new(550, log::Level::Error));
+    let tracker: Tracker = test_tracker.clone();
+
+    let top = toplevel(&tracker, "top");
+    let evaluations = Cell::new(0);
+
+    track_create_object!(
+        top;
+        Id(551),
+        1,
+        "bytes",
+        0,
+        "{}",
+        count_format_evaluation(&evaluations)
+    );
+
+    assert_eq!(evaluations.get(), 0);
+    test_helpers::check_and_clear(&test_tracker, &["0: created entity 550, top"]);
+}
+
+#[test]
+fn log_macro_evaluates_format_arguments_when_any_tracker_enables_level() {
+    let trace_tracker = Rc::new(test_helpers::TestTracker::new(600, log::Level::Trace));
+    let error_tracker = Rc::new(test_helpers::TestTracker::new(700, log::Level::Error));
+
+    let mut multi_tracker = MultiTracker::default();
+    let trace_tracker_dyn: Tracker = trace_tracker.clone();
+    let error_tracker_dyn: Tracker = error_tracker.clone();
+    multi_tracker.add_tracker(trace_tracker_dyn);
+    multi_tracker.add_tracker(error_tracker_dyn);
+    let tracker: Tracker = Rc::new(multi_tracker);
+
+    let top = toplevel(&tracker, "top");
+    let evaluations = Cell::new(0);
+
+    trace!(top ; "{}", count_format_evaluation(&evaluations));
+
+    assert_eq!(evaluations.get(), 1);
+    test_helpers::check_and_clear(
+        &trace_tracker,
+        &["0: created entity 2, top", "2:TRACE: evaluated"],
+    );
+    test_helpers::check_and_clear(
+        &error_tracker,
+        &["0: created entity 2, top", "2:TRACE: evaluated"],
+    );
+}
 
 #[test]
 fn create_destroy() {

--- a/licenses.html
+++ b/licenses.html
@@ -8110,7 +8110,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.9.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-terminus 0.4.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-timetable 0.3.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.12.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.13.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 


### PR DESCRIPTION
Cache each entity's enabled log level when it is registered, and use that
cached level to gate log/object-creation macros before evaluating format
arguments.

- Add `Entity::enabled_for` and `Entity::trace_enabled`
- Replace `Entity::track_create_object` with a `track_create_object!` macro
  that lazily formats details only when trace logging is enabled
- Update tracker APIs so `add_entity` returns the enabled level and trackers
  expose `enabled_level`
- Make `MultiTracker` use the most verbose level enabled by any child tracker
- Update packet, Ethernet frame, and memory access creation tracing to use the
  new lazy macro
- Add smoke tests proving disabled log/create-object macros do not evaluate
  format arguments, while multi-tracker trace logging still does
