### PR TITLE
feat(gwr-models): Add totals to the stats dumping and operations to timetable summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-models"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -24,7 +24,7 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.19.0" }
+gwr-models = { path = "../../gwr-models", version = "0.20.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -24,7 +24,7 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.19.0" }
+gwr-models = { path = "../../gwr-models", version = "0.20.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -23,7 +23,7 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.19.0" }
+gwr-models = { path = "../../gwr-models", version = "0.20.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-models"
-version = "0.19.0"
+version = "0.20.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -57,6 +57,26 @@ pub enum MachineOp {
     Mul,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct MachineOpCounts {
+    pub adds: usize,
+    pub compares: usize,
+    pub muls: usize,
+}
+
+impl MachineOpCounts {
+    #[must_use]
+    pub fn total(&self) -> usize {
+        self.adds + self.compares + self.muls
+    }
+
+    pub fn add_assign(&mut self, other: Self) {
+        self.adds += other.adds;
+        self.compares += other.compares;
+        self.muls += other.muls;
+    }
+}
+
 type Dispatcher = Rc<dyn Dispatch>;
 
 pub struct ProcessingElementConfig {
@@ -113,7 +133,7 @@ impl ComputeCapabilities {
 
 #[derive(Default)]
 struct ProcessingElementStats {
-    total_flops: usize,
+    machine_ops: MachineOpCounts,
 }
 
 struct Lane {
@@ -310,10 +330,21 @@ impl ProcessingElement {
         }
     }
 
+    #[must_use]
+    pub fn total_flops(&self) -> usize {
+        self.stats.borrow().machine_ops.total()
+    }
+
+    #[must_use]
+    pub fn machine_ops(&self) -> MachineOpCounts {
+        self.stats.borrow().machine_ops
+    }
+
     pub fn dump_stats(&self, time_now_ns: f64) {
         let stats = self.stats.borrow();
         let time_now_s = time_now_ns / 1e9;
-        let total_gflops = stats.total_flops as f64 / 1e9;
+        let total_flops = stats.machine_ops.total();
+        let total_gflops = total_flops as f64 / 1e9;
         let average_gflops_per_second = if time_now_s == 0.0 {
             0.0
         } else {
@@ -323,7 +354,14 @@ impl ProcessingElement {
         info!(self.entity ; "ProcessingElement {}:", self.entity.full_name());
         info!(self.entity ;
             "  FLOPs: {}, {total_gflops:.2} GFLOPs, {average_gflops_per_second:.2} GFLOP/s",
-            stats.total_flops
+            total_flops
+        );
+        info!(self.entity ;
+            "  Machine ops: {} total, {} add, {} mul, {} compare",
+            stats.machine_ops.total(),
+            stats.machine_ops.adds,
+            stats.machine_ops.muls,
+            stats.machine_ops.compares
         );
     }
 }
@@ -488,9 +526,10 @@ async fn handle_compute_task(
             &partition.inputs,
             &partition.outputs,
         )?;
-        let compute_flops = config
+        let machine_ops = config
             .op
-            .compute_flops(&partition.inputs, &partition.outputs)?;
+            .compute_machine_ops(&partition.inputs, &partition.outputs)?;
+        let compute_flops = machine_ops.total();
         if let Some(flop_monitor) = &flop_monitor {
             flop_monitor.record_interval(compute_ticks as u64, compute_flops as f64);
         }
@@ -508,7 +547,7 @@ async fn handle_compute_task(
             );
             clock.wait_ticks(compute_ticks as u64).await;
         }
-        stats.borrow_mut().total_flops += compute_flops;
+        stats.borrow_mut().machine_ops.add_assign(machine_ops);
 
         for (idx, view) in partition.outputs.iter().enumerate() {
             let Some(view) = view else {

--- a/gwr-models/src/processing_element/operators/add.rs
+++ b/gwr-models/src/processing_element/operators/add.rs
@@ -14,7 +14,7 @@ use super::{Operator, Shape, Tensor, TensorPartition};
 use crate::processing_element::operators::{
     HasShape, TensorView, apply_dim_partitions, partition_across_dimensions,
 };
-use crate::processing_element::{ComputeCapabilities, MachineOp};
+use crate::processing_element::{ComputeCapabilities, MachineOp, MachineOpCounts};
 
 const NAME: &str = "Add";
 
@@ -204,12 +204,15 @@ impl Operator for OperatorAdd {
         compute_capabilities.cycles_for_ops(num_adds, MachineOp::Add)
     }
 
-    fn compute_flops(
+    fn compute_machine_ops(
         &self,
         inputs: &[Option<TensorView>],
         outputs: &[Option<TensorView>],
-    ) -> Result<usize, SimError> {
-        num_add_flops(inputs, outputs)
+    ) -> Result<MachineOpCounts, SimError> {
+        Ok(MachineOpCounts {
+            adds: num_add_flops(inputs, outputs)?,
+            ..MachineOpCounts::default()
+        })
     }
 
     fn partition_views(

--- a/gwr-models/src/processing_element/operators/gemm.rs
+++ b/gwr-models/src/processing_element/operators/gemm.rs
@@ -14,7 +14,7 @@ use super::{Operator, Tensor, TensorPartition};
 use crate::processing_element::operators::{
     HasShape, Shape, TensorView, apply_dim_partitions, partition_across_dimensions,
 };
-use crate::processing_element::{ComputeCapabilities, MachineOp};
+use crate::processing_element::{ComputeCapabilities, MachineOp, MachineOpCounts};
 
 const NAME: &str = "Gemm";
 
@@ -362,13 +362,17 @@ impl Operator for OperatorGemm {
         )
     }
 
-    fn compute_flops(
+    fn compute_machine_ops(
         &self,
         inputs: &[Option<TensorView>],
         outputs: &[Option<TensorView>],
-    ) -> Result<usize, SimError> {
+    ) -> Result<MachineOpCounts, SimError> {
         let (num_muls, num_adds) = gemm_op_counts(inputs, outputs)?;
-        Ok(num_muls + num_adds)
+        Ok(MachineOpCounts {
+            adds: num_adds,
+            muls: num_muls,
+            ..MachineOpCounts::default()
+        })
     }
 
     fn partition_views(

--- a/gwr-models/src/processing_element/operators/maxpool.rs
+++ b/gwr-models/src/processing_element/operators/maxpool.rs
@@ -17,7 +17,7 @@ use crate::processing_element::operators::{
     DimPartition, ExpansionDirection, HasShape, TensorView, apply_dim_partitions,
     partition_across_dimensions,
 };
-use crate::processing_element::{ComputeCapabilities, MachineOp};
+use crate::processing_element::{ComputeCapabilities, MachineOp, MachineOpCounts};
 
 const NAME: &str = "MaxPool";
 const BATCH_DIM: usize = 0;
@@ -725,12 +725,15 @@ impl Operator for OperatorMaxPool {
         compute_capabilities.cycles_for_ops(comparisons, MachineOp::Compare)
     }
 
-    fn compute_flops(
+    fn compute_machine_ops(
         &self,
         inputs: &[Option<TensorView>],
         outputs: &[Option<TensorView>],
-    ) -> Result<usize, SimError> {
-        maxpool_comparisons(self, inputs, outputs)
+    ) -> Result<MachineOpCounts, SimError> {
+        Ok(MachineOpCounts {
+            compares: maxpool_comparisons(self, inputs, outputs)?,
+            ..MachineOpCounts::default()
+        })
     }
 
     fn partition_views(

--- a/gwr-models/src/processing_element/operators/mod.rs
+++ b/gwr-models/src/processing_element/operators/mod.rs
@@ -8,8 +8,8 @@ use std::rc::Rc;
 use gwr_engine::sim_error;
 use gwr_engine::types::{SimError, SimResult};
 
-use crate::processing_element::ComputeCapabilities;
 use crate::processing_element::operators::dtype::DataType;
+use crate::processing_element::{ComputeCapabilities, MachineOpCounts};
 
 pub mod dtype;
 
@@ -387,7 +387,17 @@ pub trait Operator {
         &self,
         inputs: &[Option<TensorView>],
         outputs: &[Option<TensorView>],
-    ) -> Result<usize, SimError>;
+    ) -> Result<usize, SimError> {
+        Ok(self.compute_machine_ops(inputs, outputs)?.total())
+    }
+
+    /// Returns the number of machine operations performed by the specified
+    /// computation, broken down by operation type.
+    fn compute_machine_ops(
+        &self,
+        inputs: &[Option<TensorView>],
+        outputs: &[Option<TensorView>],
+    ) -> Result<MachineOpCounts, SimError>;
 
     /// Partition the operation into one or more views that can be executed in
     /// parallel. Implementations may return fewer than `num_partitions` if the

--- a/gwr-models/src/processing_element/task.rs
+++ b/gwr-models/src/processing_element/task.rs
@@ -6,11 +6,11 @@ use gwr_engine::types::SimError;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
 
-use crate::processing_element::ComputeCapabilities;
 use crate::processing_element::operators::add::OperatorAdd;
 use crate::processing_element::operators::gemm::OperatorGemm;
 use crate::processing_element::operators::maxpool::OperatorMaxPool;
 use crate::processing_element::operators::{Operator, TensorPartition, TensorView};
+use crate::processing_element::{ComputeCapabilities, MachineOpCounts};
 
 #[derive(Debug, Clone)]
 pub struct ComputeTaskConfig {
@@ -84,6 +84,18 @@ impl ComputeOp {
             ComputeOp::Add => OperatorAdd {}.compute_flops(input_views, output_views),
             ComputeOp::Gemm => OperatorGemm {}.compute_flops(input_views, output_views),
             ComputeOp::MaxPool(operator) => operator.compute_flops(input_views, output_views),
+        }
+    }
+
+    pub fn compute_machine_ops(
+        &self,
+        input_views: &[Option<TensorView>],
+        output_views: &[Option<TensorView>],
+    ) -> Result<MachineOpCounts, SimError> {
+        match self {
+            ComputeOp::Add => OperatorAdd {}.compute_machine_ops(input_views, output_views),
+            ComputeOp::Gemm => OperatorGemm {}.compute_machine_ops(input_views, output_views),
+            ComputeOp::MaxPool(operator) => operator.compute_machine_ops(input_views, output_views),
         }
     }
 

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -25,7 +25,7 @@ clap.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.19.0" }
+gwr-models = { path = "../gwr-models", version = "0.20.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 regex.workspace = true

--- a/gwr-platform/src/lib.rs
+++ b/gwr-platform/src/lib.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use gwr_engine::engine::Engine;
 use gwr_engine::sim_error;
 use gwr_engine::time::clock::Clock;
+use gwr_engine::time::compute_adjusted_value_and_rate;
 use gwr_engine::types::SimError;
 use gwr_model_builder::EntityGet;
 use gwr_models::fabric::Fabric;
@@ -17,9 +18,10 @@ use gwr_models::memory::Memory;
 use gwr_models::memory::cache::Cache;
 use gwr_models::memory::memory_access::MemoryAccess;
 use gwr_models::memory::memory_map::DeviceId;
-use gwr_models::processing_element::ProcessingElement;
 use gwr_models::processing_element::dispatch::Dispatch;
+use gwr_models::processing_element::{MachineOpCounts, ProcessingElement};
 use gwr_track::entity::{Entity, GetEntity};
+use gwr_track::info;
 
 use crate::builder::{build_caches, build_fabrics, build_memories, build_memory_maps, build_pes};
 use crate::connect::connect_ports;
@@ -190,12 +192,62 @@ impl Platform {
     }
 
     pub fn dump_stats(&self, time_now_ns: f64) {
+        self.dump_memory_totals(time_now_ns);
+        self.dump_pe_totals(time_now_ns);
         for mem in &self.memories {
             mem.dump_stats(time_now_ns);
         }
         for pe in &self.processing_elements {
             pe.dump_stats(time_now_ns);
         }
+    }
+
+    fn dump_memory_totals(&self, time_now_ns: f64) {
+        let total_bytes_read: usize = self.memories.iter().map(|mem| mem.bytes_read()).sum();
+        let total_bytes_written: usize = self.memories.iter().map(|mem| mem.bytes_written()).sum();
+
+        let (read_value, read_per_second) =
+            compute_adjusted_value_and_rate(time_now_ns, total_bytes_read);
+        let (write_value, write_per_second) =
+            compute_adjusted_value_and_rate(time_now_ns, total_bytes_written);
+
+        info!(self.entity ; "Memory totals:");
+        info!(self.entity ;
+            "  Read: {total_bytes_read} bytes, {read_value:.2}, {read_per_second:.2}/s"
+        );
+        info!(self.entity ;
+            "  Written: {total_bytes_written} bytes, {write_value:.2}, {write_per_second:.2}/s"
+        );
+    }
+
+    fn dump_pe_totals(&self, time_now_ns: f64) {
+        let machine_ops: MachineOpCounts =
+            self.processing_elements
+                .iter()
+                .fold(MachineOpCounts::default(), |mut total, pe| {
+                    total.add_assign(pe.machine_ops());
+                    total
+                });
+        let total_flops = machine_ops.total();
+        let time_now_s = time_now_ns / 1e9;
+        let total_gflops = total_flops as f64 / 1e9;
+        let average_gflops_per_second = if time_now_s == 0.0 {
+            0.0
+        } else {
+            total_gflops / time_now_s
+        };
+
+        info!(self.entity ; "ProcessingElement totals:");
+        info!(self.entity ;
+            "  FLOPs: {total_flops}, {total_gflops:.2} GFLOPs, {average_gflops_per_second:.2} GFLOP/s"
+        );
+        info!(self.entity ;
+            "  Machine ops: {} total, {} add, {} mul, {} compare",
+            machine_ops.total(),
+            machine_ops.adds,
+            machine_ops.muls,
+            machine_ops.compares
+        );
     }
 }
 

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -29,7 +29,7 @@ byte-unit.workspace = true
 clap.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.19.0" }
+gwr-models = { path = "../gwr-models", version = "0.20.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.5.0" }
 gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true

--- a/gwr-timetable/src/lib.rs
+++ b/gwr-timetable/src/lib.rs
@@ -19,6 +19,7 @@ use gwr_engine::sim_error;
 use gwr_engine::traits::Event;
 use gwr_engine::types::{SimError, SimResult};
 use gwr_model_builder::EntityGet;
+use gwr_models::processing_element::MachineOpCounts;
 use gwr_models::processing_element::dispatch::Dispatch;
 use gwr_models::processing_element::operators::{Tensor, TensorView};
 use gwr_models::processing_element::task::{
@@ -632,6 +633,7 @@ impl Timetable {
     pub fn dump_stats(&self) -> SimResult {
         let mut total_load_bytes = 0;
         let mut total_store_bytes = 0;
+        let mut machine_ops = MachineOpCounts::default();
         let mut num_compute_nodes = 0;
         let mut num_tensor_nodes = 0;
         let mut num_memory_nodes = 0;
@@ -645,8 +647,9 @@ impl Timetable {
                     }
                     num_memory_nodes += 1;
                 }
-                NodeSection::Compute { .. } => {
+                NodeSection::Compute { op, .. } => {
                     let (inputs, outputs) = self.get_input_output_tensors(idx)?;
+                    machine_ops.add_assign(op.compute_machine_ops(&inputs, &outputs)?);
                     for input_view in inputs.iter().flatten() {
                         total_load_bytes += input_view.num_bytes();
                     }
@@ -664,6 +667,13 @@ impl Timetable {
             "  {num_compute_nodes} compute nodes, {num_tensor_nodes} tensor nodes, {num_memory_nodes} memory nodes"
         );
         info!(self.entity ; "  loads {total_load_bytes} bytes, stores {total_store_bytes} bytes");
+        info!(self.entity ;
+            "  machine ops {} total, {} add, {} mul, {} compare",
+            machine_ops.total(),
+            machine_ops.adds,
+            machine_ops.muls,
+            machine_ops.compares
+        );
 
         Ok(())
     }

--- a/licenses.html
+++ b/licenses.html
@@ -8099,7 +8099,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-docpp 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.13.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-model-builder 0.2.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.19.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.20.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx-sys 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-perfetto 0.3.0</a></li>


### PR DESCRIPTION
Add aggregate memory and PE stats reporting:
 - Print memory totals before per-memory stats, including read/write bytes and rates
 - Print PE totals before per-PE stats, including total FLOPs and machine-op breakdown
 - Add shared MachineOpCounts for add/mul/compare accounting
 - Extend operator/task APIs to report machine-op counts from the same formulas used for execution
 - Include static timetable machine-op totals with per-op breakdown for comparison against runtime PE stats
 - Preserve existing detailed per-memory and per-PE stat output after the summaries
