### PR TITLE
refactor(gwr-models,gwr-platform): Add cache stats to dump-stats report and cleanup stats printing

### DIFF
--- a/gwr-models/src/lib.rs
+++ b/gwr-models/src/lib.rs
@@ -2,6 +2,12 @@
 
 #![doc = include_str!(gwr_build::generated_crate_docs_path!())]
 
+use std::fmt::Display;
+use std::rc::Rc;
+
+use gwr_track::entity::Entity;
+use gwr_track::info;
+
 pub mod ethernet_frame;
 pub mod ethernet_link;
 pub mod fabric;
@@ -11,3 +17,9 @@ pub mod processing_element;
 pub mod registers;
 pub mod ring_node;
 pub mod test_helpers;
+
+pub fn log_stats(entity: &Rc<Entity>, stats: impl Display) {
+    for line in stats.to_string().lines() {
+        info!(entity ; "{line}");
+    }
+}

--- a/gwr-models/src/memory/cache.rs
+++ b/gwr-models/src/memory/cache.rs
@@ -34,6 +34,7 @@
 //!  ----------------------------
 //! ```
 use std::cell::RefCell;
+use std::fmt::{self, Display};
 use std::rc::Rc;
 
 use async_trait::async_trait;
@@ -46,6 +47,7 @@ use gwr_engine::executor::Spawner;
 use gwr_engine::port::{InPort, OutPort, PortStateResult};
 use gwr_engine::sim_error;
 use gwr_engine::time::clock::Clock;
+use gwr_engine::time::compute_adjusted_value_and_rate;
 use gwr_engine::traits::{Runnable, SimObject};
 use gwr_engine::types::{AccessType, SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
@@ -53,6 +55,7 @@ use gwr_track::entity::Entity;
 use gwr_track::tracker::aka::Aka;
 use gwr_track::{build_aka, trace};
 
+use crate::log_stats;
 #[cfg(test)]
 use crate::memory::memory_access::MemoryAccess;
 use crate::memory::traits::{AccessMemory, ReadMemory};
@@ -94,6 +97,68 @@ struct CacheMetrics {
     payload_bytes_written: usize,
     num_hits: usize,
     num_misses: usize,
+}
+
+pub struct CacheStatsDisplay {
+    prefix: String,
+    time_now_ns: f64,
+    payload_bytes_read: usize,
+    payload_bytes_written: usize,
+    num_hits: usize,
+    num_misses: usize,
+}
+
+impl CacheStatsDisplay {
+    #[must_use]
+    pub fn new(
+        prefix: impl Into<String>,
+        time_now_ns: f64,
+        payload_bytes_read: usize,
+        payload_bytes_written: usize,
+        num_hits: usize,
+        num_misses: usize,
+    ) -> Self {
+        Self {
+            prefix: prefix.into(),
+            time_now_ns,
+            payload_bytes_read,
+            payload_bytes_written,
+            num_hits,
+            num_misses,
+        }
+    }
+}
+
+impl Display for CacheStatsDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (read_value, read_per_second) =
+            compute_adjusted_value_and_rate(self.time_now_ns, self.payload_bytes_read);
+        let (write_value, write_per_second) =
+            compute_adjusted_value_and_rate(self.time_now_ns, self.payload_bytes_written);
+        let num_accesses = self.num_hits + self.num_misses;
+        let hit_rate = if num_accesses == 0 {
+            0.0
+        } else {
+            self.num_hits as f64 / num_accesses as f64 * 100.0
+        };
+
+        writeln!(f, "{}:", self.prefix)?;
+        writeln!(
+            f,
+            "  Payload read: {} bytes, {read_value:.2}, {read_per_second:.2}/s",
+            self.payload_bytes_read
+        )?;
+        writeln!(
+            f,
+            "  Payload written: {} bytes, {write_value:.2}, {write_per_second:.2}/s",
+            self.payload_bytes_written
+        )?;
+        write!(
+            f,
+            "  Hits: {}, misses: {}, hit rate: {hit_rate:.2}%",
+            self.num_hits, self.num_misses
+        )
+    }
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -405,6 +470,21 @@ where
     #[must_use]
     pub fn num_misses(&self) -> usize {
         self.metrics.borrow().num_misses
+    }
+
+    pub fn dump_stats(&self, time_now_ns: f64) {
+        let metrics = self.metrics.borrow();
+        log_stats(
+            &self.entity,
+            CacheStatsDisplay::new(
+                format!("Cache {}", self.entity.full_name()),
+                time_now_ns,
+                metrics.payload_bytes_read,
+                metrics.payload_bytes_written,
+                metrics.num_hits,
+                metrics.num_misses,
+            ),
+        );
     }
 }
 

--- a/gwr-models/src/memory/mod.rs
+++ b/gwr-models/src/memory/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
 use std::cell::RefCell;
+use std::fmt::{self, Display};
 use std::rc::Rc;
 
 use async_trait::async_trait;
@@ -16,8 +17,9 @@ use gwr_engine::types::{AccessType, SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
 use gwr_track::entity::Entity;
 use gwr_track::tracker::aka::Aka;
-use gwr_track::{build_aka, debug, info};
+use gwr_track::{build_aka, debug};
 
+use crate::log_stats;
 use crate::memory::traits::{AccessMemory, ReadMemory};
 
 pub mod cache;
@@ -61,6 +63,51 @@ impl MemoryConfig {
 pub struct MemoryStats {
     bytes_read: usize,
     bytes_written: usize,
+}
+
+pub struct MemoryStatsDisplay {
+    prefix: String,
+    time_now_ns: f64,
+    bytes_read: usize,
+    bytes_written: usize,
+}
+
+impl MemoryStatsDisplay {
+    #[must_use]
+    pub fn new(
+        prefix: impl Into<String>,
+        time_now_ns: f64,
+        bytes_read: usize,
+        bytes_written: usize,
+    ) -> Self {
+        Self {
+            prefix: prefix.into(),
+            time_now_ns,
+            bytes_read,
+            bytes_written,
+        }
+    }
+}
+
+impl Display for MemoryStatsDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (read_value, read_per_second) =
+            compute_adjusted_value_and_rate(self.time_now_ns, self.bytes_read);
+        let (write_value, write_per_second) =
+            compute_adjusted_value_and_rate(self.time_now_ns, self.bytes_written);
+
+        writeln!(f, "{}:", self.prefix)?;
+        writeln!(
+            f,
+            "  Read: {} bytes, {read_value:.2}, {read_per_second:.2}/s",
+            self.bytes_read
+        )?;
+        write!(
+            f,
+            "  Written: {} bytes, {write_value:.2}, {write_per_second:.2}/s",
+            self.bytes_written
+        )
+    }
 }
 
 #[derive(EntityGet, EntityDisplay)]
@@ -163,20 +210,14 @@ where
 
     pub fn dump_stats(&self, time_now_ns: f64) {
         let stats = self.stats.borrow();
-
-        let (read_value, read_per_second) =
-            compute_adjusted_value_and_rate(time_now_ns, stats.bytes_read);
-        let (write_value, write_per_second) =
-            compute_adjusted_value_and_rate(time_now_ns, stats.bytes_written);
-
-        info!(self.entity ; "Memory {}:", self.entity.full_name());
-        info!(self.entity ;
-            "  Read: {} bytes, {read_value:.2}, {read_per_second:.2}/s",
-            stats.bytes_read
-        );
-        info!(self.entity ;
-            "  Written: {} bytes, {write_value:.2}, {write_per_second:.2}/s",
-            stats.bytes_written
+        log_stats(
+            &self.entity,
+            MemoryStatsDisplay::new(
+                format!("Memory {}", self.entity.full_name()),
+                time_now_ns,
+                stats.bytes_read,
+                stats.bytes_written,
+            ),
         );
     }
 }

--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -22,6 +22,7 @@
 //! that are managed by the `LoadStoreUnit`
 
 use std::cell::RefCell;
+use std::fmt::{self, Display};
 use std::rc::Rc;
 
 use async_trait::async_trait;
@@ -32,10 +33,11 @@ use gwr_engine::time::clock::{Clock, phase};
 use gwr_engine::traits::Runnable;
 use gwr_engine::types::{AccessType, SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
+use gwr_track::debug;
 use gwr_track::entity::{Entity, EntityGroup, EntityLane};
 use gwr_track::tracker::aka::Aka;
-use gwr_track::{debug, info};
 
+use crate::log_stats;
 use crate::memory::memory_access::MemoryAccess;
 use crate::memory::memory_map::{DeviceId, MemoryMap};
 use crate::processing_element::dispatch::Dispatch;
@@ -74,6 +76,50 @@ impl MachineOpCounts {
         self.adds += other.adds;
         self.compares += other.compares;
         self.muls += other.muls;
+    }
+}
+
+pub struct ProcessingElementStatsDisplay {
+    prefix: String,
+    time_now_ns: f64,
+    machine_ops: MachineOpCounts,
+}
+
+impl ProcessingElementStatsDisplay {
+    #[must_use]
+    pub fn new(prefix: impl Into<String>, time_now_ns: f64, machine_ops: MachineOpCounts) -> Self {
+        Self {
+            prefix: prefix.into(),
+            time_now_ns,
+            machine_ops,
+        }
+    }
+}
+
+impl Display for ProcessingElementStatsDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let total_flops = self.machine_ops.total();
+        let time_now_s = self.time_now_ns / 1e9;
+        let total_gflops = total_flops as f64 / 1e9;
+        let average_gflops_per_second = if time_now_s == 0.0 {
+            0.0
+        } else {
+            total_gflops / time_now_s
+        };
+
+        writeln!(f, "{}:", self.prefix)?;
+        writeln!(
+            f,
+            "  FLOPs: {total_flops}, {total_gflops:.2} GFLOPs, {average_gflops_per_second:.2} GFLOP/s"
+        )?;
+        write!(
+            f,
+            "  Machine ops: {} total, {} add, {} mul, {} compare",
+            self.machine_ops.total(),
+            self.machine_ops.adds,
+            self.machine_ops.muls,
+            self.machine_ops.compares
+        )
     }
 }
 
@@ -342,26 +388,13 @@ impl ProcessingElement {
 
     pub fn dump_stats(&self, time_now_ns: f64) {
         let stats = self.stats.borrow();
-        let time_now_s = time_now_ns / 1e9;
-        let total_flops = stats.machine_ops.total();
-        let total_gflops = total_flops as f64 / 1e9;
-        let average_gflops_per_second = if time_now_s == 0.0 {
-            0.0
-        } else {
-            total_gflops / time_now_s
-        };
-
-        info!(self.entity ; "ProcessingElement {}:", self.entity.full_name());
-        info!(self.entity ;
-            "  FLOPs: {}, {total_gflops:.2} GFLOPs, {average_gflops_per_second:.2} GFLOP/s",
-            total_flops
-        );
-        info!(self.entity ;
-            "  Machine ops: {} total, {} add, {} mul, {} compare",
-            stats.machine_ops.total(),
-            stats.machine_ops.adds,
-            stats.machine_ops.muls,
-            stats.machine_ops.compares
+        log_stats(
+            &self.entity,
+            ProcessingElementStatsDisplay::new(
+                format!("ProcessingElement {}", self.entity.full_name()),
+                time_now_ns,
+                stats.machine_ops,
+            ),
         );
     }
 }

--- a/gwr-platform/src/lib.rs
+++ b/gwr-platform/src/lib.rs
@@ -10,18 +10,19 @@ use std::rc::Rc;
 use gwr_engine::engine::Engine;
 use gwr_engine::sim_error;
 use gwr_engine::time::clock::Clock;
-use gwr_engine::time::compute_adjusted_value_and_rate;
 use gwr_engine::types::SimError;
 use gwr_model_builder::EntityGet;
 use gwr_models::fabric::Fabric;
-use gwr_models::memory::Memory;
-use gwr_models::memory::cache::Cache;
+use gwr_models::log_stats;
+use gwr_models::memory::cache::{Cache, CacheStatsDisplay};
 use gwr_models::memory::memory_access::MemoryAccess;
 use gwr_models::memory::memory_map::DeviceId;
+use gwr_models::memory::{Memory, MemoryStatsDisplay};
 use gwr_models::processing_element::dispatch::Dispatch;
-use gwr_models::processing_element::{MachineOpCounts, ProcessingElement};
+use gwr_models::processing_element::{
+    MachineOpCounts, ProcessingElement, ProcessingElementStatsDisplay,
+};
 use gwr_track::entity::{Entity, GetEntity};
-use gwr_track::info;
 
 use crate::builder::{build_caches, build_fabrics, build_memories, build_memory_maps, build_pes};
 use crate::connect::connect_ports;
@@ -193,9 +194,13 @@ impl Platform {
 
     pub fn dump_stats(&self, time_now_ns: f64) {
         self.dump_memory_totals(time_now_ns);
+        self.dump_cache_totals(time_now_ns);
         self.dump_pe_totals(time_now_ns);
         for mem in &self.memories {
             mem.dump_stats(time_now_ns);
+        }
+        for cache in &self.caches {
+            cache.dump_stats(time_now_ns);
         }
         for pe in &self.processing_elements {
             pe.dump_stats(time_now_ns);
@@ -206,17 +211,39 @@ impl Platform {
         let total_bytes_read: usize = self.memories.iter().map(|mem| mem.bytes_read()).sum();
         let total_bytes_written: usize = self.memories.iter().map(|mem| mem.bytes_written()).sum();
 
-        let (read_value, read_per_second) =
-            compute_adjusted_value_and_rate(time_now_ns, total_bytes_read);
-        let (write_value, write_per_second) =
-            compute_adjusted_value_and_rate(time_now_ns, total_bytes_written);
-
-        info!(self.entity ; "Memory totals:");
-        info!(self.entity ;
-            "  Read: {total_bytes_read} bytes, {read_value:.2}, {read_per_second:.2}/s"
+        log_stats(
+            &self.entity,
+            MemoryStatsDisplay::new(
+                "Memory totals",
+                time_now_ns,
+                total_bytes_read,
+                total_bytes_written,
+            ),
         );
-        info!(self.entity ;
-            "  Written: {total_bytes_written} bytes, {write_value:.2}, {write_per_second:.2}/s"
+    }
+
+    fn total_cache_stat<F>(&self, stat_fn: F) -> usize
+    where
+        F: Fn(&Cache<MemoryAccess>) -> usize,
+    {
+        self.caches.iter().map(|cache| stat_fn(cache)).sum()
+    }
+
+    fn dump_cache_totals(&self, time_now_ns: f64) {
+        let total_payload_bytes_read = self.total_cache_stat(Cache::payload_bytes_read);
+        let total_payload_bytes_written = self.total_cache_stat(Cache::payload_bytes_written);
+        let total_hits = self.total_cache_stat(Cache::num_hits);
+        let total_misses = self.total_cache_stat(Cache::num_misses);
+        log_stats(
+            &self.entity,
+            CacheStatsDisplay::new(
+                "Cache totals",
+                time_now_ns,
+                total_payload_bytes_read,
+                total_payload_bytes_written,
+                total_hits,
+                total_misses,
+            ),
         );
     }
 
@@ -228,25 +255,13 @@ impl Platform {
                     total.add_assign(pe.machine_ops());
                     total
                 });
-        let total_flops = machine_ops.total();
-        let time_now_s = time_now_ns / 1e9;
-        let total_gflops = total_flops as f64 / 1e9;
-        let average_gflops_per_second = if time_now_s == 0.0 {
-            0.0
-        } else {
-            total_gflops / time_now_s
-        };
-
-        info!(self.entity ; "ProcessingElement totals:");
-        info!(self.entity ;
-            "  FLOPs: {total_flops}, {total_gflops:.2} GFLOPs, {average_gflops_per_second:.2} GFLOP/s"
-        );
-        info!(self.entity ;
-            "  Machine ops: {} total, {} add, {} mul, {} compare",
-            machine_ops.total(),
-            machine_ops.adds,
-            machine_ops.muls,
-            machine_ops.compares
+        log_stats(
+            &self.entity,
+            ProcessingElementStatsDisplay::new(
+                "ProcessingElement totals",
+                time_now_ns,
+                machine_ops,
+            ),
         );
     }
 }

--- a/gwr-timetable/examples/cache.yaml
+++ b/gwr-timetable/examples/cache.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+nodes:
+  - id: tensor_A
+    kind: tensor
+    config:
+      addr: 0x1_0000_0000
+      dtype: fp32
+      shape: [8]
+
+  - id: load0
+    kind: memory
+    op: load
+    pe: pe0
+    config: {}
+
+  - id: load1
+    kind: memory
+    op: load
+    pe: pe0
+    config: {}
+
+edges:
+  - from: tensor_A
+    to: load0
+    kind: data
+
+  - from: tensor_A
+    to: load1
+    kind: data

--- a/gwr-timetable/tests/dump_stats.rs
+++ b/gwr-timetable/tests/dump_stats.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::process::Command;
+
+#[test]
+fn dump_stats_includes_cache_stats() {
+    let output = Command::new(env!("CARGO_BIN_EXE_gwr-timetable"))
+        .arg("--platform")
+        .arg("../gwr-platform/examples/simple_pe_cache_mem.yaml")
+        .arg("--timetable")
+        .arg("examples/cache.yaml")
+        .arg("--stdout")
+        .arg("--dump-stats")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "gwr-timetable failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Cache totals:"), "stdout:\n{stdout}");
+    assert!(
+        stdout.contains("Cache top::l1_0:"),
+        "stdout did not contain per-cache stats:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Payload read: 64 bytes"),
+        "stdout did not contain cache payload read stats:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("INFO:   Payload read: 64 bytes"),
+        "stdout did not contain a prefixed cache payload read stat line:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Hits: 1, misses: 1, hit rate: 50.00%"),
+        "stdout did not contain cache hit/miss stats:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Include cache totals and per-cache metrics in --dump-stats.
Add shared display helpers for cache, memory, and PE stats so aggregate
and per-entity reports stay consistent. Add a cache-backed timetable
example and regression test covering cache stats output.
