### PR TITLE
refactor(gwr-platform,gwr-timetable): Reject unknown platform and timetable fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,7 @@ version = "2.0.0"
 
 [[package]]
 name = "gwr-platform"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "byte-unit",

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-platform"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-platform/examples/platform.yaml
+++ b/gwr-platform/examples/platform.yaml
@@ -14,12 +14,13 @@ fabrics:
     routing: column-first
 
 # A default PE config so that it doesn't have to be repeated
-default_pe_config: &default_pe_config
-  num_active_requests: 8
-  lsu_access_bytes: 32
-  sram_bytes: 0x20_0000 # 2MB of SRAM
-  adds_per_tick: 128.0
-  muls_per_tick: 16.0
+defaults:
+  pe_config: &default_pe_config
+    num_active_requests: 8
+    lsu_access_bytes: 32
+    sram_bytes: 0x20_0000 # 2MB of SRAM
+    adds_per_tick: 128.0
+    muls_per_tick: 16.0
 
 processing_elements:
   - name: pe_0_0

--- a/gwr-platform/examples/platform_4x4.yaml
+++ b/gwr-platform/examples/platform_4x4.yaml
@@ -14,9 +14,10 @@ fabrics:
     routing: column-first
 
 # A default PE config so that it doesn't have to be repeated
-default_pe_config: &default_pe_config
-  num_active_requests: 8
-  lsu_access_bytes: 32
+defaults:
+  pe_config: &default_pe_config
+    num_active_requests: 8
+    lsu_access_bytes: 32
 
 processing_elements:
   - name: pe_0_0

--- a/gwr-platform/examples/platform_4x4_4xhbm.yaml
+++ b/gwr-platform/examples/platform_4x4_4xhbm.yaml
@@ -17,9 +17,10 @@ fabrics:
     routing: column-first
 
 # A default PE config so that it doesn't have to be repeated
-default_pe_config: &default_pe_config
-  num_active_requests: 8
-  lsu_access_bytes: 32
+defaults:
+  pe_config: &default_pe_config
+    num_active_requests: 8
+    lsu_access_bytes: 32
 
 processing_elements:
   - name: pe_0_0

--- a/gwr-platform/src/bin/gen-fabric.rs
+++ b/gwr-platform/src/bin/gen-fabric.rs
@@ -345,6 +345,7 @@ fn build_platform(args: &Args) -> Result<PlatformConfig, String> {
 
     Ok(PlatformConfig {
         memory_maps: vec![memory_map],
+        defaults: None,
         processing_elements: Some(build_processing_elements(args, &pe_config)?),
         caches: build_caches(args)?,
         fabrics: Some(build_fabrics(args)),

--- a/gwr-platform/src/builder.rs
+++ b/gwr-platform/src/builder.rs
@@ -347,6 +347,7 @@ mod tests {
                     name: "hbm0".to_string(),
                 }],
             }],
+            defaults: None,
             processing_elements: None,
             caches: None,
             fabrics: None,

--- a/gwr-platform/src/types.rs
+++ b/gwr-platform/src/types.rs
@@ -77,8 +77,10 @@ where
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlatformConfig {
     pub memory_maps: Vec<MemoryMapSection>,
+    pub defaults: Option<DefaultsSection>,
     pub processing_elements: Option<Vec<ProcessingElementSection>>,
     pub caches: Option<Vec<CacheSection>>,
     pub fabrics: Option<Vec<FabricSection>>,
@@ -86,18 +88,27 @@ pub struct PlatformConfig {
     pub connections: Option<Vec<ConnectSection>>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct DefaultsSection {
+    pub pe_config: Option<ProcessingElementConfigSection>,
+    pub cache_config: Option<CacheConfigSection>,
+}
+
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct MemoryMapSection {
     pub name: String,
     pub devices: Vec<MemoryDeviceSection>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct MemoryDeviceSection {
     pub name: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct ProcessingElementSection {
     pub name: String,
     pub memory_map: String,
@@ -105,6 +116,7 @@ pub struct ProcessingElementSection {
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct ProcessingElementConfigSection {
     pub num_active_requests: Option<usize>,
     pub lsu_access_bytes: Option<usize>,
@@ -117,12 +129,14 @@ pub struct ProcessingElementConfigSection {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct CacheSection {
     pub name: String,
     pub config: CacheConfigSection,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct CacheConfigSection {
     pub bw_bytes_per_cycle: Option<usize>,
     pub line_size_bytes: Option<usize>,
@@ -132,6 +146,7 @@ pub struct CacheConfigSection {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct FabricSection {
     pub name: String,
     pub kind: FabricKind,
@@ -147,6 +162,7 @@ pub struct FabricSection {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct MemorySection {
     pub name: String,
     pub kind: MemoryKind,
@@ -173,6 +189,7 @@ pub enum MemoryKind {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct ConnectSection {
     pub connect: Vec<String>,
 }

--- a/gwr-platform/src/yaml.rs
+++ b/gwr-platform/src/yaml.rs
@@ -366,6 +366,7 @@ mod tests {
         };
         let platform = PlatformConfig {
             memory_maps: vec![test_memory_map()],
+            defaults: None,
             processing_elements: Some(vec![
                 ProcessingElementSection {
                     name: "pe0".to_string(),
@@ -433,6 +434,7 @@ mod tests {
         };
         let platform = PlatformConfig {
             memory_maps: vec![test_memory_map()],
+            defaults: None,
             processing_elements: Some(vec![ProcessingElementSection {
                 name: "pe0".to_string(),
                 memory_map: "memory_map".to_string(),

--- a/gwr-platform/tests/errors.rs
+++ b/gwr-platform/tests/errors.rs
@@ -4,6 +4,94 @@ use gwr_engine::test_helpers::start_test;
 use gwr_platform::Platform;
 
 #[test]
+fn unknown_top_level_field_is_rejected() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let err = Platform::from_string(
+        &engine,
+        &clock,
+        "
+memory_maps: []
+processing_elementz: []
+",
+    )
+    .unwrap_err();
+
+    assert!(format!("{err}").contains("unknown field `processing_elementz`"));
+}
+
+#[test]
+fn unknown_pe_config_field_is_rejected() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let err = Platform::from_string(
+        &engine,
+        &clock,
+        "
+memory_maps:
+  - name: mm0
+    devices: []
+
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config:
+      lsu_acess_bytes: 32
+",
+    )
+    .unwrap_err();
+
+    assert!(format!("{err}").contains("unknown field `lsu_acess_bytes`"));
+}
+
+#[test]
+fn defaults_pe_config_anchor_is_allowed() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let platform = Platform::from_string(
+        &engine,
+        &clock,
+        "
+memory_maps:
+  - name: mm0
+    devices: []
+
+defaults:
+  pe_config: &default_pe_config
+    lsu_access_bytes: 32
+
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config: *default_pe_config
+",
+    )
+    .unwrap();
+
+    assert_eq!(platform.num_pes(), 1);
+}
+
+#[test]
+fn defaults_pe_config_anchor_is_type_checked() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let err = Platform::from_string(
+        &engine,
+        &clock,
+        "
+memory_maps: []
+
+defaults:
+  pe_config:
+    lsu_acess_bytes: 32
+",
+    )
+    .unwrap_err();
+
+    assert!(format!("{err}").contains("unknown field `lsu_acess_bytes`"));
+}
+
+#[test]
 #[should_panic(expected = "Duplicate device")]
 fn duplicate_pe_name() {
     let mut engine = start_test(file!());

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -30,7 +30,7 @@ clap.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-models = { path = "../gwr-models", version = "0.20.0" }
-gwr-platform = { path = "../gwr-platform", version = "0.5.0" }
+gwr-platform = { path = "../gwr-platform", version = "0.6.0" }
 gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/gwr-timetable/src/timetable_file.rs
+++ b/gwr-timetable/src/timetable_file.rs
@@ -14,6 +14,7 @@ use gwr_platform::Platform;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TimetableFile {
     pub nodes: Vec<NodeSection>,
     pub edges: Vec<EdgeSection>,
@@ -79,6 +80,7 @@ impl TimetableFile {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 #[serde(tag = "kind")]
 pub enum NodeSection {
     #[serde(rename = "compute")]
@@ -104,6 +106,7 @@ pub enum NodeSection {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TensorViewSection {
     pub offsets: Vec<usize>,
     pub shape: Vec<usize>,
@@ -117,6 +120,7 @@ impl TensorViewSection {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MemoryConfigSection {
     pub view: Option<TensorViewSection>,
 }
@@ -129,6 +133,7 @@ pub fn dtype_num_bytes(dtype: &DataType, num_elements: usize) -> usize {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TensorConfigSection {
     #[serde(deserialize_with = "gwr_platform::types::parse_u64_byte_str")]
     pub addr: u64,
@@ -193,6 +198,7 @@ pub enum EdgeKind {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EdgeSection {
     pub from: String,
     pub to: String,

--- a/gwr-timetable/tests/errors.rs
+++ b/gwr-timetable/tests/errors.rs
@@ -92,6 +92,57 @@ fn timetable_file() {
     Timetable::new(&top, timetable_file, &platform).unwrap();
 }
 
+#[test]
+fn timetable_rejects_unknown_top_level_field() {
+    let err = TimetableFile::from_string(
+        "
+nodes: []
+edges: []
+edegs: []
+",
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("unknown field `edegs`"));
+}
+
+#[test]
+fn memory_node_rejects_unknown_view_field() {
+    let err = TimetableFile::from_string(
+        "
+nodes:
+  - id: load0
+    kind: memory
+    op: load
+    pe: pe0
+    config:
+      view:
+        shape: [4]
+        offsets: [0]
+        stride: [1]
+
+edges:
+",
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("unknown field `stride`"));
+}
+
+#[test]
+fn edge_rejects_unknown_field() {
+    let err = TimetableFile::from_string(
+        "
+nodes: []
+edges:
+  - from: a
+    to: b
+    kind: data
+    label: typo
+",
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("unknown field `label`"));
+}
+
 // Node errors
 
 #[test]

--- a/licenses.html
+++ b/licenses.html
@@ -8104,7 +8104,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx-sys 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-perfetto 0.3.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-perfetto-sys 2.0.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.5.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.6.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.9.0</a></li>


### PR DESCRIPTION
Add serde deny_unknown_fields coverage across platform and timetable YAML
configuration types so misspelled or unsupported fields fail during parsing
instead of being silently ignored.

Move platform example PE defaults under a typed defaults section, preserving
YAML anchor reuse while ensuring default configs are validated too. Add tests
for unknown top-level, nested platform, timetable node view, and edge fields.
