### PR TITLE
test(gwr-components,gwr-models): adopt test harnesses

### DIFF
--- a/gwr-components/tests/arbiter.rs
+++ b/gwr-components/tests/arbiter.rs
@@ -52,27 +52,15 @@ mod arbiter_harness {
             Arbiter::new_and_register(&engine, &clock, top, "arb", 3, Box::new(RoundRobin::new()));
         let mut harness = ArbiterHarness::new(engine, arbiter, 3);
 
-        let mut sends_a = Vec::new();
-        let mut sends_b = Vec::new();
-        let mut sends_c = Vec::new();
-        let mut expects = Vec::new();
-
-        for _ in 0..NUM_PUTS {
-            sends_a.push(send_rx!(0, VALUE));
-            sends_b.push(send_rx!(1, VALUE));
-            sends_c.push(send_rx!(2, VALUE));
-        }
-
-        for _ in 0..NUM_PUTS * 3 {
-            expects.push(expect_tx!(VALUE));
-        }
-
-        harness.run_steps([par!([
-            seq!(sends_a),
-            seq!(sends_b),
-            seq!(sends_c),
-            seq!(expects),
-        ])]);
+        harness.run_steps([
+            par!([
+                seq!(vec![send_rx!(0, VALUE); NUM_PUTS]),
+                seq!(vec![send_rx!(1, VALUE); NUM_PUTS]),
+                seq!(vec![send_rx!(2, VALUE); NUM_PUTS]),
+                seq!(vec![expect_tx!(VALUE); NUM_PUTS * 3]),
+            ]),
+            expect_no_traffic!(&[Port::Tx], 1),
+        ]);
     }
 
     #[test]
@@ -89,23 +77,14 @@ mod arbiter_harness {
 
         let mut harness = ArbiterHarness::new(engine, arbiter, 3);
 
-        let mut sends_a = Vec::new();
-        let mut sends_c = Vec::new();
-        let mut expects = Vec::new();
-
-        for _ in 0..NUM_A_PUTS {
-            sends_a.push(send_rx!(0, VALUE));
-        }
-
-        for _ in 0..NUM_C_PUTS {
-            sends_c.push(send_rx!(2, VALUE));
-        }
-
-        for _ in 0..(NUM_A_PUTS + NUM_C_PUTS) {
-            expects.push(expect_tx!(VALUE));
-        }
-
-        harness.run_steps([par!([seq!(sends_a), seq!(sends_c), seq!(expects),])]);
+        harness.run_steps([
+            par!([
+                seq!(vec![send_rx!(0, VALUE); NUM_A_PUTS]),
+                seq!(vec![send_rx!(2, VALUE); NUM_C_PUTS]),
+                seq!(vec![expect_tx!(VALUE); NUM_A_PUTS + NUM_C_PUTS]),
+            ]),
+            expect_no_traffic!(&[Port::Tx], 1),
+        ]);
     }
 
     #[test]

--- a/gwr-components/tests/arbiter.rs
+++ b/gwr-components/tests/arbiter.rs
@@ -8,7 +8,6 @@ use gwr_components::arbiter::policy::{
     Priority, PriorityRoundRobin, RoundRobin, WeightedRoundRobin,
 };
 use gwr_components::flow_controls::limiter::Limiter;
-use gwr_components::sink::Sink;
 use gwr_components::source::Source;
 use gwr_components::store::{ObjectStore, Store};
 use gwr_components::test_helpers::{
@@ -20,61 +19,115 @@ use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 use gwr_track::entity::Entity;
 
-#[test]
-fn source_sink() {
-    const NUM_PUTS: usize = 25;
+mod arbiter_harness {
+    use gwr_components::build_component_harness;
 
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
+    use super::*;
 
-    let top = engine.top();
-    let arbiter =
-        Arbiter::new_and_register(&engine, &clock, top, "arb", 3, Box::new(RoundRobin::new()));
-    let source_a =
-        Source::new_and_register(&engine, top, "source_a", option_box_repeat!(1; NUM_PUTS));
-    let source_b =
-        Source::new_and_register(&engine, top, "source_b", option_box_repeat!(2; NUM_PUTS));
-    let source_c =
-        Source::new_and_register(&engine, top, "source_c", option_box_repeat!(3; NUM_PUTS));
-    let sink = Sink::new_and_register(&engine, &clock, top, "sink");
+    build_component_harness! {
+        harness ArbiterHarness<T> {
+            component: arbiter: Rc<Arbiter<T>>,
+            rx port arrays: {
+                Rx<T> => rx {
+                    count: num_rx
+                }
+            },
+            tx ports: {
+                Tx<T> => tx,
+            },
+        }
+    }
 
-    connect_port!(source_a, tx => arbiter, rx, 0).unwrap();
-    connect_port!(source_b, tx => arbiter, rx, 1).unwrap();
-    connect_port!(source_c, tx => arbiter, rx, 2).unwrap();
-    connect_port!(arbiter, tx => sink, rx).unwrap();
+    #[test]
+    fn source_sink() {
+        const NUM_PUTS: usize = 25;
+        const VALUE: i32 = 1;
 
-    run_simulation!(engine);
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
 
-    let num_sunk = sink.num_sunk();
-    assert_eq!(num_sunk, NUM_PUTS * 3);
-}
+        let top = engine.top();
 
-#[test]
-fn two_active_inputs() {
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
+        let arbiter =
+            Arbiter::new_and_register(&engine, &clock, top, "arb", 3, Box::new(RoundRobin::new()));
+        let mut harness = ArbiterHarness::new(engine, arbiter, 3);
 
-    let na = 10;
-    let nb = 0;
-    let nc = 20;
+        let mut sends_a = Vec::new();
+        let mut sends_b = Vec::new();
+        let mut sends_c = Vec::new();
+        let mut expects = Vec::new();
 
-    let top = engine.top();
-    let arbiter =
-        Arbiter::new_and_register(&engine, &clock, top, "arb", 3, Box::new(RoundRobin::new()));
-    let source_a = Source::new_and_register(&engine, top, "source_a", option_box_repeat!(1; na));
-    let source_b = Source::new_and_register(&engine, top, "source_b", option_box_repeat!(2; nb));
-    let source_c = Source::new_and_register(&engine, top, "source_c", option_box_repeat!(3; nc));
-    let sink = Sink::new_and_register(&engine, &clock, top, "sink");
+        for _ in 0..NUM_PUTS {
+            sends_a.push(send_rx!(0, VALUE));
+            sends_b.push(send_rx!(1, VALUE));
+            sends_c.push(send_rx!(2, VALUE));
+        }
 
-    connect_port!(source_a, tx => arbiter, rx, 0).unwrap();
-    connect_port!(source_b, tx => arbiter, rx, 1).unwrap();
-    connect_port!(source_c, tx => arbiter, rx, 2).unwrap();
-    connect_port!(arbiter, tx => sink, rx).unwrap();
+        for _ in 0..NUM_PUTS * 3 {
+            expects.push(expect_tx!(VALUE));
+        }
 
-    run_simulation!(engine);
+        harness.run_steps([par!([
+            seq!(sends_a),
+            seq!(sends_b),
+            seq!(sends_c),
+            seq!(expects),
+        ])]);
+    }
 
-    let num_sunk = sink.num_sunk();
-    assert_eq!(num_sunk, 30);
+    #[test]
+    fn two_active_inputs() {
+        const NUM_A_PUTS: usize = 10;
+        const NUM_C_PUTS: usize = 20;
+        const VALUE: i32 = 1;
+
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
+        let top = engine.top();
+        let arbiter =
+            Arbiter::new_and_register(&engine, &clock, top, "arb", 3, Box::new(RoundRobin::new()));
+
+        let mut harness = ArbiterHarness::new(engine, arbiter, 3);
+
+        let mut sends_a = Vec::new();
+        let mut sends_c = Vec::new();
+        let mut expects = Vec::new();
+
+        for _ in 0..NUM_A_PUTS {
+            sends_a.push(send_rx!(0, VALUE));
+        }
+
+        for _ in 0..NUM_C_PUTS {
+            sends_c.push(send_rx!(2, VALUE));
+        }
+
+        for _ in 0..(NUM_A_PUTS + NUM_C_PUTS) {
+            expects.push(expect_tx!(VALUE));
+        }
+
+        harness.run_steps([par!([seq!(sends_a), seq!(sends_c), seq!(expects),])]);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is 2 but the index is 2")]
+    fn more_inputs() {
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
+
+        let top = engine.top();
+        let arbiter = Arbiter::<i32>::new_and_register(
+            &engine,
+            &clock,
+            top,
+            "arb",
+            2,
+            Box::new(RoundRobin::new()),
+        );
+
+        // Try and connect three sources to an arbiter that only has two inputs. This
+        // should panic.
+        let _harness = ArbiterHarness::new(engine, arbiter, 3);
+    }
 }
 
 #[test]
@@ -152,32 +205,6 @@ fn input_order() {
         check_round_robin(&inputs, &store_get);
         Ok(())
     });
-
-    run_simulation!(engine);
-}
-
-#[test]
-#[should_panic(expected = "index out of bounds: the len is 2 but the index is 2")]
-fn more_inputs() {
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
-
-    let na = 10;
-    let nb = 5;
-    let nc = 15;
-
-    let top = engine.top();
-    let arbiter =
-        Arbiter::new_and_register(&engine, &clock, top, "arb", 2, Box::new(RoundRobin::new()));
-    let source_a = Source::new_and_register(&engine, top, "source_a", option_box_repeat!(1; na));
-    let source_b = Source::new_and_register(&engine, top, "source_b", option_box_repeat!(2; nb));
-    let source_c = Source::new_and_register(&engine, top, "source_c", option_box_repeat!(3; nc));
-    let store = ObjectStore::new_and_register(&engine, &clock, top, "store", na + nb + nc).unwrap();
-
-    connect_port!(source_a, tx => arbiter, rx, 0).unwrap();
-    connect_port!(source_b, tx => arbiter, rx, 1).unwrap();
-    connect_port!(source_c, tx => arbiter, rx, 2).unwrap();
-    connect_port!(arbiter, tx => store, rx).unwrap();
 
     run_simulation!(engine);
 }

--- a/gwr-components/tests/delay.rs
+++ b/gwr-components/tests/delay.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use gwr_components::delay::Delay;
-use gwr_components::sink::Sink;
 use gwr_components::source::Source;
 use gwr_components::store::{ObjectStore, Store};
 use gwr_components::{connect_port, option_box_repeat};
@@ -65,27 +64,46 @@ fn put_get() {
     assert_eq!(total, NUM_PUTS);
 }
 
-#[test]
-fn source_sink() {
-    const DELAY: usize = 3;
-    const NUM_PUTS: usize = DELAY * 10;
+mod delay_harness {
+    use gwr_components::build_component_harness;
 
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
+    use super::*;
 
-    let top = engine.top();
-    let source =
-        Source::new_and_register(&engine, top, "source", option_box_repeat!(500 ; NUM_PUTS));
-    let delay = Delay::new_and_register(&engine, &clock, top, "delay", DELAY);
-    let sink = Sink::new_and_register(&engine, &clock, top, "sink");
+    build_component_harness! {
+        harness DelayHarness<T> {
+            component: delay: Rc<Delay<T>>,
+            rx ports: {
+                Rx<T> => rx,
+            },
+            tx ports: {
+                Tx<T> => tx,
+            },
+        }
+    }
 
-    connect_port!(source, tx => delay, rx).unwrap();
-    connect_port!(delay, tx => sink, rx).unwrap();
+    #[test]
+    fn source_sink() {
+        const DELAY_TICKS: usize = 3;
+        const NUM_PUTS: usize = 30;
+        const VALUE: i32 = 500;
 
-    run_simulation!(engine);
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
+        let top = engine.top();
 
-    let num_sunk = sink.num_sunk();
-    assert_eq!(num_sunk, NUM_PUTS);
+        let delay = Delay::new_and_register(&engine, &clock, top, "delay", DELAY_TICKS);
+        let mut harness = DelayHarness::new(engine, delay);
+
+        let mut sends = Vec::new();
+        let mut expects = Vec::new();
+
+        for _ in 0..NUM_PUTS {
+            sends.push(send_rx!(VALUE));
+            expects.push(expect_tx!(VALUE));
+        }
+
+        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+    }
 }
 
 #[test]

--- a/gwr-components/tests/delay.rs
+++ b/gwr-components/tests/delay.rs
@@ -94,15 +94,13 @@ mod delay_harness {
         let delay = Delay::new_and_register(&engine, &clock, top, "delay", DELAY_TICKS);
         let mut harness = DelayHarness::new(engine, delay);
 
-        let mut sends = Vec::new();
-        let mut expects = Vec::new();
-
-        for _ in 0..NUM_PUTS {
-            sends.push(send_rx!(VALUE));
-            expects.push(expect_tx!(VALUE));
-        }
-
-        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+        harness.run_steps([
+            par!([
+                seq!(vec![send_rx!(VALUE); NUM_PUTS]),
+                seq!(vec![expect_tx!(VALUE); NUM_PUTS]),
+            ]),
+            expect_no_traffic!(&[Port::Tx], (DELAY_TICKS + 1) as u64),
+        ]);
     }
 }
 

--- a/gwr-components/tests/object_store.rs
+++ b/gwr-components/tests/object_store.rs
@@ -1,47 +1,97 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
-use gwr_components::sink::Sink;
-use gwr_components::source::Source;
 use gwr_components::store::ObjectStore;
-use gwr_components::{connect_port, option_box_repeat};
-use gwr_engine::port::InPort;
-use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 
-/// Basic end-to-end test: Source -> ObjectStore -> Sink.
-///
-/// Verifies:
-///  * all values make it through the store
-///  * the store is empty at the end (capacity_used == 0)
-#[test]
-fn object_store_basic_flow() {
-    const NUM_PUTS: usize = 50;
-    const CAPACITY: usize = 8;
+mod object_store_harness {
+    use std::rc::Rc;
 
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
+    use gwr_components::build_component_harness;
+    use gwr_components::store::Store;
 
-    let top = engine.top();
+    use super::*;
 
-    // Simple source that repeatedly produces the same value.
-    let source = Source::new_and_register(&engine, top, "source", option_box_repeat!(1 ; NUM_PUTS));
+    build_component_harness! {
+        harness ObjectStoreHarness<T> {
+            component: store: Rc<Store<T>>,
+            rx ports: {
+                Rx<T> => rx
+            },
+            tx ports: {
+                Tx<T> => tx
+            },
+        }
+    }
 
-    let store = ObjectStore::new_and_register(&engine, &clock, top, "store", CAPACITY).unwrap();
+    /// Basic end-to-end test of the ObjectStore's input and output ports.
+    ///
+    /// Verifies:
+    ///  * all values make it through the store
+    ///  * the store is empty at the end (capacity_used == 0)
+    #[test]
+    fn object_store_basic_flow() {
+        const NUM_PUTS: usize = 50;
+        const CAPACITY: usize = 8;
+        const VALUE: i32 = 1;
 
-    let sink = Sink::new_and_register(&engine, &clock, top, "sink");
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
 
-    // Wire up the simple pipeline: source → store → sink
-    connect_port!(source, tx => store, rx).unwrap();
-    connect_port!(store, tx => sink, rx).unwrap();
+        let top = engine.top();
 
-    run_simulation!(engine);
+        let store = ObjectStore::new_and_register(&engine, &clock, top, "store", CAPACITY).unwrap();
+        let mut harness = ObjectStoreHarness::new(engine, store.clone());
 
-    // All items should have been sunk.
-    assert_eq!(sink.num_sunk(), NUM_PUTS);
-    // ObjectStore must be empty at the end of simulation.
-    assert_eq!(store.capacity_used(), 0);
+        let mut sends = Vec::new();
+        let mut expects = Vec::new();
+
+        for _ in 0..NUM_PUTS {
+            sends.push(send_rx!(VALUE));
+            expects.push(expect_tx!(VALUE));
+        }
+
+        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+
+        assert_eq!(store.capacity_used(), 0);
+    }
+
+    /// When `set_error_on_overflow` is enabled, overflowing the object store
+    /// should cause the simulation to fail with an overflow error.
+    ///
+    /// The harness driver keeps pushing data into the store while the
+    /// store's `tx` receiver is left unread, causing the store to overflow.
+    /// Expect the overflow path in `State::push_value` to be hit.
+    ///
+    /// NOTE: we only match a substring of the message to avoid depending
+    /// on the exact formatting of the entity name.
+    #[test]
+    #[should_panic(expected = "Overflow in")]
+    fn object_store_overflow_panics_when_error_on_overflow_set() {
+        const CAPACITY: usize = 2;
+        const NUM_PUTS: usize = 10;
+
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
+
+        let top = engine.top();
+
+        let store = ObjectStore::new_and_register(&engine, &clock, top, "store_overflow", CAPACITY)
+            .unwrap();
+
+        // Switch to "error on overflow" mode so `run_rx` no longer blocks once full
+        // and instead allows `State::push_value` to return a SimError.
+        store.set_error_on_overflow();
+
+        let mut harness = ObjectStoreHarness::new(engine, store.clone());
+
+        let mut sends = Vec::new();
+        for _ in 0..NUM_PUTS {
+            sends.push(send_rx!(1));
+        }
+
+        harness.run_steps(sends);
+    }
 }
-
 /// Creating an object store with zero capacity should fail with a SimError.
 ///
 /// This directly exercises the constructor error path.
@@ -64,45 +114,4 @@ fn object_store_zero_capacity_fails() {
         msg.contains("Unsupported Store with capacity of 0"),
         "Unexpected error message: {msg}"
     );
-}
-
-/// When `set_error_on_overflow` is enabled, overflowing the object store should
-/// cause the simulation to fail with an overflow error.
-///
-/// We connect a source that keeps pushing data into the store and
-/// connect the store's `tx` port to a port that never takes out data.
-/// Expect the overflow path in `State::push_value` to be hit.
-///
-/// NOTE: we only match a substring of the message to avoid depending
-/// on the exact formatting of the entity name.
-#[test]
-#[should_panic(expected = "Overflow in")]
-fn object_store_overflow_panics_when_error_on_overflow_set() {
-    const CAPACITY: usize = 2;
-    const NUM_PUTS: usize = 10;
-
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
-
-    let top = engine.top();
-
-    let source = Source::new_and_register(&engine, top, "source", option_box_repeat!(1 ; NUM_PUTS));
-
-    let store =
-        ObjectStore::new_and_register(&engine, &clock, top, "store_overflow", CAPACITY).unwrap();
-
-    // Switch to "error on overflow" mode so `run_rx` no longer blocks once full
-    // and instead allows `State::push_value` to return a SimError.
-    store.set_error_on_overflow();
-
-    // Only connect source → store. No consumer on `store.tx`, so the internal
-    // queue keeps growing until it overflows.
-    connect_port!(source, tx => store, rx).unwrap();
-
-    // Connect the output of the store to prevent `tx not connected` error.
-    let rx = InPort::new(&engine, &clock, engine.top(), "test_rx");
-    store.connect_port_tx(rx.state()).unwrap();
-
-    // This should panic due to the SimError bubbling up from the store.
-    run_simulation!(engine);
 }

--- a/gwr-components/tests/object_store.rs
+++ b/gwr-components/tests/object_store.rs
@@ -42,15 +42,10 @@ mod object_store_harness {
         let store = ObjectStore::new_and_register(&engine, &clock, top, "store", CAPACITY).unwrap();
         let mut harness = ObjectStoreHarness::new(engine, store.clone());
 
-        let mut sends = Vec::new();
-        let mut expects = Vec::new();
-
-        for _ in 0..NUM_PUTS {
-            sends.push(send_rx!(VALUE));
-            expects.push(expect_tx!(VALUE));
-        }
-
-        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+        harness.run_steps([par!([
+            seq!(vec![send_rx!(VALUE); NUM_PUTS]),
+            seq!(vec![expect_tx!(VALUE); NUM_PUTS]),
+        ])]);
 
         assert_eq!(store.capacity_used(), 0);
     }
@@ -84,12 +79,7 @@ mod object_store_harness {
 
         let mut harness = ObjectStoreHarness::new(engine, store.clone());
 
-        let mut sends = Vec::new();
-        for _ in 0..NUM_PUTS {
-            sends.push(send_rx!(1));
-        }
-
-        harness.run_steps(sends);
+        harness.run_steps(vec![send_rx!(1); NUM_PUTS]);
     }
 }
 /// Creating an object store with zero capacity should fail with a SimError.

--- a/gwr-components/tests/queue.rs
+++ b/gwr-components/tests/queue.rs
@@ -203,15 +203,10 @@ mod queue_harness {
         let queue = Queue::new_and_register(&engine, &clock, top, "queue", Some(2)).unwrap();
         let mut harness = QueueHarness::new(engine, queue.clone());
 
-        let mut sends = Vec::new();
-        let mut expects = Vec::new();
-
-        for _ in 0..NUM_VALUES {
-            sends.push(send_rx!(VALUE));
-            expects.push(expect_tx!(VALUE));
-        }
-
-        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+        harness.run_steps([par!([
+            seq!(vec![send_rx!(VALUE); NUM_VALUES]),
+            seq!(vec![expect_tx!(VALUE); NUM_VALUES]),
+        ])]);
 
         assert!(queue.is_empty());
     }

--- a/gwr-components/tests/queue.rs
+++ b/gwr-components/tests/queue.rs
@@ -5,9 +5,6 @@ use std::rc::Rc;
 
 use futures::executor::block_on;
 use gwr_components::queue::{Queue, QueueCore};
-use gwr_components::sink::Sink;
-use gwr_components::source::Source;
-use gwr_components::{connect_port, option_box_repeat};
 use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 use gwr_engine::traits::Event;
@@ -177,24 +174,45 @@ fn queue_changed_event_fires_for_mutations() {
     assert_eq!(clock.time_now_ns(), 4.0);
 }
 
-#[test]
-fn queue_component_connects_rx_to_tx_ports() {
-    const NUM_VALUES: usize = 10;
+mod queue_harness {
+    use gwr_components::build_component_harness;
 
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
-    let top = engine.top();
+    use super::*;
 
-    let source =
-        Source::new_and_register(&engine, top, "source", option_box_repeat!(5 ; NUM_VALUES));
-    let queue = Queue::new_and_register(&engine, &clock, top, "queue", Some(2)).unwrap();
-    let sink = Sink::new_and_register(&engine, &clock, top, "sink");
+    build_component_harness! {
+        harness QueueHarness<T> {
+            component: queue: Rc<Queue<T>>,
+            rx ports: {
+                Rx<T> => rx
+            },
+            tx ports: {
+                Tx<T> => tx
+            },
+        }
+    }
 
-    connect_port!(source, tx => queue, rx).unwrap();
-    connect_port!(queue, tx => sink, rx).unwrap();
+    #[test]
+    fn queue_component_connects_rx_to_tx_ports() {
+        const NUM_VALUES: usize = 10;
+        const VALUE: i32 = 5;
 
-    run_simulation!(engine);
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
+        let top = engine.top();
 
-    assert_eq!(sink.num_sunk(), NUM_VALUES);
-    assert!(queue.is_empty());
+        let queue = Queue::new_and_register(&engine, &clock, top, "queue", Some(2)).unwrap();
+        let mut harness = QueueHarness::new(engine, queue.clone());
+
+        let mut sends = Vec::new();
+        let mut expects = Vec::new();
+
+        for _ in 0..NUM_VALUES {
+            sends.push(send_rx!(VALUE));
+            expects.push(expect_tx!(VALUE));
+        }
+
+        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+
+        assert!(queue.is_empty());
+    }
 }

--- a/gwr-models/README.md
+++ b/gwr-models/README.md
@@ -99,25 +99,28 @@ API as `build_component_harness!`, but uses `MemoryTxn` to check objects coming
 out of the model.
 
 `MemoryTxn` lets tests match only the memory access fields that matter for a
-scenario. For example, this test harness only checks the destination address
-when the `expect_tx()` is called:
+scenario. For example, this test harness checks that a `Memory` model produces a
+read response for the expected destination address, while ignoring fields that
+are not specified:
 
 ```rust,no_run
-mod delay_harness {
+mod memory_harness {
     use std::rc::Rc;
 
-    use gwr_components::delay::Delay;
     use gwr_engine::test_helpers::start_test;
     use gwr_models::build_model_harness;
     use gwr_models::memory::memory_access::MemoryAccess;
+    use gwr_models::memory::{Memory, MemoryConfig};
     use gwr_models::test_helpers::{MemoryTxn, create_default_memory_map, create_read};
 
     const DST_ADDR: u64 = 0x80000;
     const SRC_ADDR: u64 = 0x90000;
+    const ACCESS_SIZE_BYTES: usize = 64;
+    const OVERHEAD_SIZE_BYTES: usize = 8;
 
     build_model_harness! {
-        harness DelayHarness<T> {
-            component: delay: Rc<Delay<T>>,
+        harness MemoryHarness<T> {
+            component: memory: Rc<Memory<T>>,
             rx ports: {
                 Rx<T> => rx,
             },
@@ -131,14 +134,29 @@ mod delay_harness {
     fn model_harness_matches_selected_memory_fields() {
         let mut engine = start_test(file!());
         let clock = engine.default_clock();
-        let delay = Delay::new_and_register(&engine, &clock, engine.top(), "delay", 1).unwrap();
+        let config = MemoryConfig::new(DST_ADDR, 0x40000, 32, 1);
+        let memory = Memory::<MemoryAccess>::new_and_register(
+            &engine,
+            &clock,
+            engine.top(),
+            "memory",
+            config,
+        )
+        .unwrap();
         let memory_map = Rc::new(create_default_memory_map());
-        let access = create_read(engine.top(), &memory_map, 64, DST_ADDR, SRC_ADDR, 8);
-        let mut harness = DelayHarness::new(engine, delay);
+        let request = create_read(
+            engine.top(),
+            &memory_map,
+            ACCESS_SIZE_BYTES,
+            DST_ADDR,
+            SRC_ADDR,
+            OVERHEAD_SIZE_BYTES,
+        );
+        let mut harness = MemoryHarness::new(engine, memory);
 
         harness.run_steps([
-            send_rx!(access),
-            expect_tx!(MemoryTxn::read_req(DST_ADDR)),
+            send_rx!(request),
+            expect_tx!(MemoryTxn::read_rsp(DST_ADDR)),
         ]);
     }
 }

--- a/gwr-models/src/test_helpers.rs
+++ b/gwr-models/src/test_helpers.rs
@@ -297,6 +297,7 @@ pub struct MemoryTxn {
     dst_addr: u64,
     src_addr: Option<u64>,
     bytes: Option<usize>,
+    total_bytes: Option<usize>,
     destination: Option<u64>,
     dst_device: Option<DeviceId>,
     src_device: Option<DeviceId>,
@@ -311,6 +312,7 @@ impl MemoryTxn {
             dst_addr,
             src_addr: None,
             bytes: None,
+            total_bytes: None,
             destination: None,
             dst_device: None,
             src_device: None,
@@ -357,6 +359,12 @@ impl MemoryTxn {
     #[must_use]
     pub fn with_bytes(mut self, bytes: usize) -> Self {
         self.bytes = Some(bytes);
+        self
+    }
+
+    #[must_use]
+    pub fn with_total_bytes(mut self, total_bytes: usize) -> Self {
+        self.total_bytes = Some(total_bytes);
         self
     }
 
@@ -421,6 +429,13 @@ where
                 "{check_id}: byte count mismatch for actual {actual:?}",
             );
         }
+        if let Some(total_bytes) = self.total_bytes {
+            assert_eq!(
+                actual.total_bytes(),
+                total_bytes,
+                "{check_id}: total byte count mismatch for actual {actual:?}",
+            );
+        }
         if let Some(destination) = self.destination {
             assert_eq!(
                 actual.destination(),
@@ -460,6 +475,7 @@ where
         MemoryTxn::new(self.access_type(), self.dst_addr())
             .with_src_addr(self.src_addr())
             .with_bytes(self.access_size_bytes())
+            .with_total_bytes(self.total_bytes())
             .with_destination(self.destination())
             .with_dst_device(self.dst_device())
             .with_src_device(self.src_device())

--- a/gwr-models/tests/fc_pipeline.rs
+++ b/gwr-models/tests/fc_pipeline.rs
@@ -8,57 +8,81 @@ use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 use gwr_models::fc_pipeline::{FcPipeline, FcPipelineConfig};
 
-fn test_fc_pipeline(buffer_size: usize, data_delay: usize, credit_delay: usize) {
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
+mod fc_pipeline_harness {
+    use std::rc::Rc;
 
-    let num_puts = 10;
+    use gwr_components::build_component_harness;
 
-    // Create a pair of tasks that use a pipeline
-    let top = engine.top();
-    let source = Source::new_and_register(&engine, top, "source", option_box_repeat!(1 ; num_puts));
-    let pipe_config = FcPipelineConfig::new(buffer_size, data_delay, credit_delay);
-    let pipeline =
-        FcPipeline::new_and_register(&engine, &clock, top, "pipe", &pipe_config).unwrap();
-    let sink = Sink::new_and_register(&engine, &clock, top, "sink");
+    use super::*;
 
-    connect_port!(source, tx => pipeline, rx).unwrap();
-    connect_port!(pipeline, tx => sink, rx).unwrap();
+    build_component_harness! {
+        harness FcPipelineHarness<T> {
+            component: pipeline: Rc<FcPipeline<T>>,
+            rx ports: {
+                Rx<T> => rx,
+            },
+            tx ports: {
+                Tx<T> => tx,
+            },
+        }
+    }
 
-    run_simulation!(engine);
+    fn test_fc_pipeline(buffer_size: usize, data_delay: usize, credit_delay: usize) {
+        const NUM_PUTS: usize = 10;
+        const VALUE: i32 = 1;
 
-    assert_eq!(sink.num_sunk(), num_puts);
-}
+        let mut engine = start_test(file!());
+        let clock = engine.default_clock();
 
-#[test]
-fn matched() {
-    test_fc_pipeline(1, 1, 1);
-    test_fc_pipeline(10, 10, 10);
-}
+        let top = engine.top();
 
-#[test]
-fn long_credit() {
-    test_fc_pipeline(1, 1, 10);
-}
+        let pipe_config = FcPipelineConfig::new(buffer_size, data_delay, credit_delay);
+        let pipeline =
+            FcPipeline::new_and_register(&engine, &clock, top, "pipe", &pipe_config).unwrap();
 
-#[test]
-fn long_data() {
-    test_fc_pipeline(1, 10, 1);
-}
+        let mut harness = FcPipelineHarness::new(engine, pipeline);
 
-#[test]
-fn instant_credit() {
-    test_fc_pipeline(1, 1, 0);
-}
+        let mut sends = Vec::new();
+        let mut expects = Vec::new();
 
-#[test]
-fn instant_data() {
-    test_fc_pipeline(1, 0, 1);
-}
+        for _ in 0..NUM_PUTS {
+            sends.push(send_rx!(VALUE));
+            expects.push(expect_tx!(VALUE));
+        }
 
-#[test]
-fn both_instant() {
-    test_fc_pipeline(1, 0, 0);
+        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+    }
+
+    #[test]
+    fn matched() {
+        test_fc_pipeline(1, 1, 1);
+        test_fc_pipeline(10, 10, 10);
+    }
+
+    #[test]
+    fn long_credit() {
+        test_fc_pipeline(1, 1, 10);
+    }
+
+    #[test]
+    fn long_data() {
+        test_fc_pipeline(1, 10, 1);
+    }
+
+    #[test]
+    fn instant_credit() {
+        test_fc_pipeline(1, 1, 0);
+    }
+
+    #[test]
+    fn instant_data() {
+        test_fc_pipeline(1, 0, 1);
+    }
+
+    #[test]
+    fn both_instant() {
+        test_fc_pipeline(1, 0, 0);
+    }
 }
 
 fn test_fc_pipeline_throughput(

--- a/gwr-models/tests/fc_pipeline.rs
+++ b/gwr-models/tests/fc_pipeline.rs
@@ -27,7 +27,12 @@ mod fc_pipeline_harness {
         }
     }
 
-    fn test_fc_pipeline(buffer_size: usize, data_delay: usize, credit_delay: usize) {
+    fn test_fc_pipeline(
+        buffer_size: usize,
+        data_delay: usize,
+        credit_delay: usize,
+        expected_ticks: u64,
+    ) {
         const NUM_PUTS: usize = 10;
         const VALUE: i32 = 1;
 
@@ -42,46 +47,43 @@ mod fc_pipeline_harness {
 
         let mut harness = FcPipelineHarness::new(engine, pipeline);
 
-        let mut sends = Vec::new();
-        let mut expects = Vec::new();
+        harness.run_steps([par!([
+            seq!(vec![send_rx!(VALUE); NUM_PUTS]),
+            seq!(vec![expect_tx!(VALUE); NUM_PUTS]),
+        ])]);
 
-        for _ in 0..NUM_PUTS {
-            sends.push(send_rx!(VALUE));
-            expects.push(expect_tx!(VALUE));
-        }
-
-        harness.run_steps([par!([seq!(sends), seq!(expects)])]);
+        assert_eq!(harness.clock.tick_now().tick(), expected_ticks);
     }
 
     #[test]
     fn matched() {
-        test_fc_pipeline(1, 1, 1);
-        test_fc_pipeline(10, 10, 10);
+        test_fc_pipeline(1, 1, 1, 19);
+        test_fc_pipeline(10, 10, 10, 10);
     }
 
     #[test]
     fn long_credit() {
-        test_fc_pipeline(1, 1, 10);
+        test_fc_pipeline(1, 1, 10, 100);
     }
 
     #[test]
     fn long_data() {
-        test_fc_pipeline(1, 10, 1);
+        test_fc_pipeline(1, 10, 1, 109);
     }
 
     #[test]
     fn instant_credit() {
-        test_fc_pipeline(1, 1, 0);
+        test_fc_pipeline(1, 1, 0, 10);
     }
 
     #[test]
     fn instant_data() {
-        test_fc_pipeline(1, 0, 1);
+        test_fc_pipeline(1, 0, 1, 9);
     }
 
     #[test]
     fn both_instant() {
-        test_fc_pipeline(1, 0, 0);
+        test_fc_pipeline(1, 0, 0, 0);
     }
 }
 

--- a/gwr-models/tests/memory.rs
+++ b/gwr-models/tests/memory.rs
@@ -7,11 +7,9 @@ use gwr_components::sink::Sink;
 use gwr_components::source::Source;
 use gwr_components::{connect_port, option_box_repeat};
 use gwr_engine::engine::Engine;
-use gwr_engine::port::{InPort, OutPort};
 use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
-use gwr_engine::traits::{Routable, SimObject, TotalBytes};
-use gwr_engine::types::AccessType;
+use gwr_engine::traits::SimObject;
 use gwr_models::memory::memory_access::MemoryAccess;
 use gwr_models::memory::memory_map::MemoryMap;
 use gwr_models::memory::traits::AccessMemory;
@@ -121,49 +119,51 @@ fn memory_write_np() {
     let last_event_time = max(last_bw_limit_event, last_packet_ack);
     assert_eq!(engine.time_now_ns(), last_event_time as f64);
 }
+mod memory_harness {
+    use gwr_models::build_model_harness;
+    use gwr_models::test_helpers::MemoryTxn;
 
-#[test]
-fn read_becomes_read_response() {
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
-    let memory = create_memory(&mut engine);
-    let memory_map = Rc::new(create_default_memory_map());
-    let top = engine.top();
+    use super::*;
 
-    let mut mem_rx_driver = OutPort::new(top, "mem_rx_driver");
-    mem_rx_driver.connect(memory.port_rx()).unwrap();
+    build_model_harness! {
+        harness MemoryHarness<T> {
+            component: memory: Rc<Memory<T>>,
+            rx ports: {
+                Rx<T> => rx,
+            },
+            tx ports: {
+                Tx<T> => tx,
+            },
+        }
+    }
 
-    let mut mem_tx_recv = InPort::new(&engine, &clock, top, "mem_tx_recv");
-    memory.connect_port_tx(mem_tx_recv.state()).unwrap();
-
-    engine.spawn(async move {
+    #[test]
+    fn read_becomes_read_response() {
+        let mut engine = start_test(file!());
+        let memory = create_memory(&mut engine);
+        let memory_map = Rc::new(create_default_memory_map());
         let dst_addr = DST_ADDR + 0x40;
 
-        // Make a device request
         let request = create_read(
-            mem_rx_driver.entity(),
+            engine.top(),
             &memory_map,
             ACCESS_SIZE_BYTES,
             dst_addr,
             SRC_ADDR,
             OVERHEAD_SIZE_BYTES,
         );
-        mem_rx_driver.put(request)?.await;
 
-        let response = mem_tx_recv.get()?.await;
+        let mut harness = MemoryHarness::new(engine, memory);
 
-        // The memory should reply to a Read with a ReadResponse
-        assert_eq!(response.access_type(), AccessType::ReadResponse);
-        assert_eq!(response.access_size_bytes(), ACCESS_SIZE_BYTES);
-        assert_eq!(
-            response.total_bytes(),
-            ACCESS_SIZE_BYTES + OVERHEAD_SIZE_BYTES
-        );
+        harness.run_steps([
+            send_rx!(request),
+            expect_tx!(
+                MemoryTxn::read_rsp(dst_addr)
+                    .with_bytes(ACCESS_SIZE_BYTES)
+                    .with_total_bytes(ACCESS_SIZE_BYTES + OVERHEAD_SIZE_BYTES)
+            ),
+        ]);
 
-        Ok(())
-    });
-
-    run_simulation!(engine);
-
-    assert_eq!(engine.time_now_ns(), DELAY_TICKS as f64);
+        assert_eq!(harness.engine.time_now_ns(), DELAY_TICKS as f64);
+    }
 }


### PR DESCRIPTION
Part of #266.

## Summary

- Convert straightforward `gwr-components` and `gwr-models` tests to use test harnesses.
- Preserve concurrent producer/consumer behaviour in bulk tests.
- Add total-byte matching to `MemoryTxn` so the converted memory test retains its existing assertions.
- Correct the `gwr-models` README example to demonstrate a model harness.

I deliberately left tests unchanged where using a harness would make the setup more complicated or obscure the behaviour being tested.

## Testing

- `prek run --all-files --show-diff-on-failure`
- `cargo test --all-features`