### PR TITLE
feat(gwr-components): Add CapacityAllocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-components"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "byte-unit",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-models"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/examples/flaky-component/Cargo.toml
+++ b/examples/flaky-component/Cargo.toml
@@ -21,7 +21,7 @@ publish.workspace = true
 [dependencies]
 async-trait.workspace = true
 clap.workspace = true
-gwr-components = { path = "../../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.13.0" }

--- a/examples/flaky-with-delay/Cargo.toml
+++ b/examples/flaky-with-delay/Cargo.toml
@@ -21,7 +21,7 @@ publish.workspace = true
 [dependencies]
 async-trait.workspace = true
 clap.workspace = true
-gwr-components = { path = "../../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.13.0" }

--- a/examples/scrambler/Cargo.toml
+++ b/examples/scrambler/Cargo.toml
@@ -21,7 +21,7 @@ publish.workspace = true
 [dependencies]
 async-trait.workspace = true
 clap.workspace = true
-gwr-components = { path = "../../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.13.0" }

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -21,10 +21,10 @@ publish.workspace = true
 [dependencies]
 byte-unit.workspace = true
 clap.workspace = true
-gwr-components = { path = "../../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -21,10 +21,10 @@ publish.workspace = true
 [dependencies]
 byte-unit.workspace = true
 clap.workspace = true
-gwr-components = { path = "../../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-restaurant/Cargo.toml
+++ b/examples/sim-restaurant/Cargo.toml
@@ -20,7 +20,7 @@ publish.workspace = true
 clap.workspace = true
 crossterm.workspace = true
 futures.workspace = true
-gwr-components = { path = "../../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 log.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -20,10 +20,10 @@ publish.workspace = true
 
 [dependencies]
 clap.workspace = true
-gwr-components = { path = "../../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/gwr-components/Cargo.toml
+++ b/gwr-components/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-components"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-components/src/capacity_allocator.rs
+++ b/gwr-components/src/capacity_allocator.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+//! Capacity accounting and scoped reservations.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gwr_engine::events::repeated::Repeated;
+use gwr_engine::sim_error;
+use gwr_engine::traits::Event;
+use gwr_engine::types::{SimError, SimResult};
+use gwr_model_builder::{EntityDisplay, EntityGet};
+use gwr_track::entity::Entity;
+
+/// A reusable capacity allocator for object counts, bytes, or other units.
+#[derive(Clone, EntityGet, EntityDisplay)]
+pub struct CapacityAllocator {
+    entity: Rc<Entity>,
+    capacity: usize,
+    capacity_unit: Rc<String>,
+    used: Rc<RefCell<usize>>,
+    level_change: Repeated<usize>,
+}
+
+pub struct CapacityReservation {
+    allocator: CapacityAllocator,
+    units: usize,
+}
+
+impl Drop for CapacityReservation {
+    fn drop(&mut self) {
+        self.allocator.release(self.units);
+    }
+}
+
+impl CapacityAllocator {
+    /// Create a standalone allocator with its own child entity.
+    pub fn new(
+        parent: &Rc<Entity>,
+        name: &str,
+        capacity: usize,
+        capacity_unit: impl Into<String>,
+    ) -> Result<Self, SimError> {
+        let entity = Rc::new(Entity::new(parent, name));
+        Self::for_entity(&entity, capacity, capacity_unit)
+    }
+
+    /// Create allocator bookkeeping on an existing entity.
+    pub fn for_entity(
+        entity: &Rc<Entity>,
+        capacity: usize,
+        capacity_unit: impl Into<String>,
+    ) -> Result<Self, SimError> {
+        if capacity == 0 {
+            return sim_error!("Unsupported CapacityAllocator with capacity of 0");
+        }
+        let capacity_unit = capacity_unit.into();
+        entity.track_capacity(capacity, &capacity_unit);
+
+        Ok(Self {
+            entity: entity.clone(),
+            capacity,
+            capacity_unit: Rc::new(capacity_unit),
+            used: Rc::new(RefCell::new(0)),
+            level_change: Repeated::new(usize::default()),
+        })
+    }
+
+    #[must_use]
+    pub fn used(&self) -> usize {
+        *self.used.borrow()
+    }
+
+    #[must_use]
+    pub fn has_capacity_for(&self, units: usize) -> bool {
+        units <= self.capacity - self.used()
+    }
+
+    pub fn check_units_can_fit(&self, units: usize) -> SimResult {
+        if units > self.capacity {
+            return sim_error!(
+                "Cannot allocate {units} {} in {:?} with capacity {}",
+                self.capacity_unit,
+                self.entity.full_name(),
+                self.capacity
+            );
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    #[must_use]
+    pub fn capacity_unit(&self) -> &str {
+        self.capacity_unit.as_str()
+    }
+
+    #[must_use]
+    pub fn level_change_event(&self) -> Repeated<usize> {
+        self.level_change.clone()
+    }
+
+    pub async fn wait_for_capacity(&self, units: usize) -> SimResult {
+        self.check_units_can_fit(units)?;
+        let level_change = self.level_change_event();
+        while !self.has_capacity_for(units) {
+            level_change.listen().await;
+        }
+        Ok(())
+    }
+
+    pub fn allocate(&self, units: usize) -> SimResult {
+        self.check_units_can_fit(units)?;
+        if !self.has_capacity_for(units) {
+            return sim_error!("Overflow in {:?}", self.entity.full_name());
+        }
+
+        let used = {
+            let mut used = self.used.borrow_mut();
+            *used += units;
+            *used
+        };
+        self.level_change.notify_result(used);
+        Ok(())
+    }
+
+    pub fn release(&self, units: usize) {
+        let used = {
+            let mut used = self.used.borrow_mut();
+            *used = used
+                .checked_sub(units)
+                .expect("capacity allocator underflow");
+            *used
+        };
+        self.level_change.notify_result(used);
+    }
+
+    pub async fn reserve(&self, units: usize) -> Result<CapacityReservation, SimError> {
+        self.wait_for_capacity(units).await?;
+        self.allocate(units)?;
+        Ok(CapacityReservation {
+            allocator: self.clone(),
+            units,
+        })
+    }
+}

--- a/gwr-components/src/lib.rs
+++ b/gwr-components/src/lib.rs
@@ -3,6 +3,7 @@
 #![doc = include_str!(gwr_build::generated_crate_docs_path!())]
 
 pub mod arbiter;
+pub mod capacity_allocator;
 pub mod cli;
 pub mod connect;
 pub mod delay;

--- a/gwr-components/src/store/byte_store.rs
+++ b/gwr-components/src/store/byte_store.rs
@@ -34,16 +34,15 @@ where
         capacity_bytes: usize,
     ) -> Result<Rc<Store<T>>, SimError> {
         let entity = Rc::new(Entity::new(parent, name));
-        entity.track_capacity(capacity_bytes, "bytes");
         let store = Rc::new(Store::new(
             engine,
             clock,
             &entity,
             aka,
             capacity_bytes,
+            "bytes",
             |value: &T| value.total_bytes(),
         )?);
-        store.set_capacity_unit("bytes");
         engine.register(store.clone());
         Ok(store)
     }

--- a/gwr-components/src/store/mod.rs
+++ b/gwr-components/src/store/mod.rs
@@ -30,6 +30,7 @@ use gwr_model_builder::{EntityDisplay, EntityGet};
 use gwr_track::entity::Entity;
 use gwr_track::tracker::aka::Aka;
 
+use crate::capacity_allocator::CapacityAllocator;
 use crate::{connect_tx, port_rx, take_option};
 
 mod byte_store;
@@ -40,77 +41,16 @@ pub use object_store::ObjectStore;
 
 type ObjectToCapacity<T> = fn(&T) -> usize;
 
+#[derive(Clone)]
 struct State<T>
 where
     T: SimObject,
 {
     entity: Rc<Entity>,
-    capacity: usize,
-    capacity_unit: RefCell<String>,
-    used: RefCell<usize>,
-    data: RefCell<VecDeque<T>>,
-    error_on_overflow: RefCell<bool>,
-    level_change: Repeated<usize>,
+    capacity: CapacityAllocator,
+    data: Rc<RefCell<VecDeque<T>>>,
+    error_on_overflow: Rc<RefCell<bool>>,
     object_to_capacity: ObjectToCapacity<T>,
-}
-
-impl<T> State<T>
-where
-    T: SimObject,
-{
-    fn new(entity: &Rc<Entity>, capacity: usize, object_to_capacity: ObjectToCapacity<T>) -> Self {
-        Self {
-            entity: entity.clone(),
-            capacity,
-            capacity_unit: RefCell::new("objects".to_string()),
-            used: RefCell::new(0),
-            data: RefCell::new(VecDeque::new()),
-            error_on_overflow: RefCell::new(false),
-            level_change: Repeated::new(usize::default()),
-            object_to_capacity,
-        }
-    }
-
-    fn has_capacity_for(&self, units: usize) -> bool {
-        units <= self.capacity - *self.used.borrow()
-    }
-
-    fn check_units_can_fit(&self, units: usize) -> SimResult {
-        if units > self.capacity {
-            let capacity_unit = self.capacity_unit.borrow();
-            return sim_error!(
-                "Cannot store {units} {capacity_unit} in {:?} with capacity {}",
-                self.entity.full_name(),
-                self.capacity
-            );
-        }
-        Ok(())
-    }
-
-    fn push_value(&self, value: T) -> SimResult {
-        let units = (self.object_to_capacity)(&value);
-        self.entity.track_enter(value.id());
-        if *self.error_on_overflow.borrow() {
-            if !self.has_capacity_for(units) {
-                return sim_error!("Overflow in {:?}", self.entity.full_name());
-            }
-        } else {
-            assert!(self.has_capacity_for(units));
-        }
-
-        self.data.borrow_mut().push_back(value);
-        *self.used.borrow_mut() += units;
-        self.level_change.notify_result(*self.used.borrow());
-        Ok(())
-    }
-
-    fn pop_value(&self) -> Result<T, SimError> {
-        let value = self.data.borrow_mut().pop_front().unwrap();
-        *self.used.borrow_mut() -= (self.object_to_capacity)(&value);
-        self.level_change.notify_result(*self.used.borrow());
-        self.entity.track_exit(value.id());
-        Ok(value)
-    }
 }
 
 /// A component that can support a configurable number of capacity units.
@@ -124,7 +64,10 @@ where
 {
     entity: Rc<Entity>,
     spawner: Spawner,
-    state: Rc<State<T>>,
+    capacity: CapacityAllocator,
+    data: Rc<RefCell<VecDeque<T>>>,
+    error_on_overflow: Rc<RefCell<bool>>,
+    object_to_capacity: ObjectToCapacity<T>,
     tx: RefCell<Option<OutPort<T>>>,
     rx: RefCell<Option<InPort<T>>>,
 }
@@ -139,15 +82,20 @@ where
         entity: &Rc<Entity>,
         aka: Option<&Aka>,
         capacity: usize,
+        capacity_unit: &str,
         object_to_capacity: ObjectToCapacity<T>,
     ) -> Result<Self, SimError> {
         if capacity == 0 {
             return sim_error!("Unsupported Store with capacity of 0");
         }
+        let capacity = CapacityAllocator::for_entity(entity, capacity, capacity_unit)?;
         Ok(Self {
             entity: entity.clone(),
             spawner: engine.spawner(),
-            state: Rc::new(State::new(entity, capacity, object_to_capacity)),
+            capacity,
+            data: Rc::new(RefCell::new(VecDeque::new())),
+            error_on_overflow: Rc::new(RefCell::new(false)),
+            object_to_capacity,
             tx: RefCell::new(Some(OutPort::new_with_renames(entity, "tx", aka))),
             rx: RefCell::new(Some(InPort::new_with_renames(
                 engine, clock, entity, "rx", aka,
@@ -165,20 +113,26 @@ where
 
     #[must_use]
     pub fn capacity_used(&self) -> usize {
-        *self.state.used.borrow()
+        self.capacity.used()
     }
 
     pub fn set_error_on_overflow(&self) {
-        *self.state.error_on_overflow.borrow_mut() = true;
-    }
-
-    pub fn set_capacity_unit(&self, capacity_unit: impl Into<String>) {
-        *self.state.capacity_unit.borrow_mut() = capacity_unit.into();
+        *self.error_on_overflow.borrow_mut() = true;
     }
 
     #[must_use]
     pub fn get_level_change_event(&self) -> Repeated<usize> {
-        self.state.level_change.clone()
+        self.capacity.level_change_event()
+    }
+
+    fn state(&self) -> State<T> {
+        State {
+            entity: self.entity.clone(),
+            capacity: self.capacity.clone(),
+            data: self.data.clone(),
+            error_on_overflow: self.error_on_overflow.clone(),
+            object_to_capacity: self.object_to_capacity,
+        }
     }
 }
 
@@ -189,46 +143,71 @@ where
 {
     async fn run(&self) -> SimResult {
         let rx = take_option!(self.rx);
-        let state = self.state.clone();
-        self.spawner.spawn(async move { run_rx(rx, state).await });
+        let state = self.state();
+        self.spawner.spawn(async move { state.run_rx(rx).await });
 
         let tx = take_option!(self.tx);
-        let state = self.state.clone();
-        self.spawner.spawn(async move { run_tx(tx, state).await });
+        let state = self.state();
+        self.spawner.spawn(async move { state.run_tx(tx).await });
         Ok(())
     }
 }
 
-async fn run_rx<T>(mut rx: InPort<T>, state: Rc<State<T>>) -> SimResult
+impl<T> State<T>
 where
     T: SimObject,
 {
-    let level_change = state.level_change.clone();
-    loop {
-        let value = rx.start_get()?.await;
-        let units = (state.object_to_capacity)(&value);
-        state.check_units_can_fit(units)?;
-        while !state.has_capacity_for(units) && !*state.error_on_overflow.borrow() {
-            level_change.listen().await;
+    fn check_units_can_fit(&self, units: usize) -> SimResult {
+        if units > self.capacity.capacity() {
+            return sim_error!(
+                "Cannot store {units} {} in {:?} with capacity {}",
+                self.capacity.capacity_unit(),
+                self.entity.full_name(),
+                self.capacity.capacity()
+            );
         }
-        state.push_value(value)?;
-        rx.finish_get();
+        Ok(())
     }
-}
 
-async fn run_tx<T>(mut tx: OutPort<T>, state: Rc<State<T>>) -> SimResult
-where
-    T: SimObject,
-{
-    let level_change = state.level_change.clone();
-    loop {
-        let level = state.data.borrow().len();
-        if level > 0 {
-            tx.try_put()?.await;
-            let value = state.pop_value()?;
-            tx.put(value)?.await;
-        } else {
-            level_change.listen().await;
+    fn push_value(&self, value: T) -> SimResult {
+        let units = (self.object_to_capacity)(&value);
+        self.capacity.allocate(units)?;
+        self.entity.track_enter(value.id());
+        self.data.borrow_mut().push_back(value);
+        Ok(())
+    }
+
+    fn pop_value(&self) -> Result<T, SimError> {
+        let value = self.data.borrow_mut().pop_front().unwrap();
+        self.capacity.release((self.object_to_capacity)(&value));
+        self.entity.track_exit(value.id());
+        Ok(value)
+    }
+
+    async fn run_rx(&self, mut rx: InPort<T>) -> SimResult {
+        loop {
+            let value = rx.start_get()?.await;
+            let units = (self.object_to_capacity)(&value);
+            self.check_units_can_fit(units)?;
+            if !*self.error_on_overflow.borrow() {
+                self.capacity.wait_for_capacity(units).await?;
+            }
+            self.push_value(value)?;
+            rx.finish_get();
+        }
+    }
+
+    async fn run_tx(&self, mut tx: OutPort<T>) -> SimResult {
+        let level_change = self.capacity.level_change_event();
+        loop {
+            let level = self.data.borrow().len();
+            if level > 0 {
+                tx.try_put()?.await;
+                let value = self.pop_value()?;
+                tx.put(value)?.await;
+            } else {
+                level_change.listen().await;
+            }
         }
     }
 }

--- a/gwr-components/src/store/object_store.rs
+++ b/gwr-components/src/store/object_store.rs
@@ -32,8 +32,15 @@ where
         capacity: usize,
     ) -> Result<Rc<Store<T>>, SimError> {
         let entity = Rc::new(Entity::new(parent, name));
-        entity.track_capacity(capacity, "objects");
-        let store = Rc::new(Store::new(engine, clock, &entity, aka, capacity, |_| 1)?);
+        let store = Rc::new(Store::new(
+            engine,
+            clock,
+            &entity,
+            aka,
+            capacity,
+            "objects",
+            |_| 1,
+        )?);
         engine.register(store.clone());
         Ok(store)
     }

--- a/gwr-components/tests/byte_store.rs
+++ b/gwr-components/tests/byte_store.rs
@@ -148,12 +148,3 @@ fn byte_store_oversized_object_panics_when_error_on_overflow_set() {
 
     harness.run_steps([send_rx!(ByteObject::new(1, 9))]);
 }
-
-#[test]
-#[should_panic(expected = "Cannot store 9 flits")]
-fn byte_store_capacity_unit_can_be_overridden() {
-    let (store, mut harness) = byte_store_harness(8);
-    store.set_capacity_unit("flits");
-
-    harness.run_steps([send_rx!(ByteObject::new(1, 9))]);
-}

--- a/gwr-components/tests/capacity_allocator.rs
+++ b/gwr-components/tests/capacity_allocator.rs
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use futures::executor::block_on;
+use gwr_components::capacity_allocator::CapacityAllocator;
+use gwr_engine::run_simulation;
+use gwr_engine::test_helpers::start_test;
+
+#[test]
+fn rejects_zero_capacity() {
+    let engine = start_test(file!());
+
+    let err = match CapacityAllocator::new(engine.top(), "alloc", 0, "bytes") {
+        Ok(_) => panic!("zero-capacity allocator should fail"),
+        Err(err) => err,
+    };
+
+    assert!(
+        format!("{err}").contains("Unsupported CapacityAllocator with capacity of 0"),
+        "Unexpected error message: {err}"
+    );
+}
+
+#[test]
+fn allocate_and_release_update_used_capacity() {
+    let engine = start_test(file!());
+    let allocator = CapacityAllocator::new(engine.top(), "alloc", 8, "bytes").unwrap();
+
+    assert_eq!(allocator.used(), 0);
+    assert!(allocator.has_capacity_for(8));
+
+    allocator.allocate(3).unwrap();
+    assert_eq!(allocator.used(), 3);
+    assert!(allocator.has_capacity_for(5));
+    assert!(!allocator.has_capacity_for(6));
+
+    allocator.release(2);
+    assert_eq!(allocator.used(), 1);
+
+    allocator.release(1);
+    assert_eq!(allocator.used(), 0);
+}
+
+#[test]
+fn reject_allocation_larger_than_capacity() {
+    let engine = start_test(file!());
+    let allocator = CapacityAllocator::new(engine.top(), "alloc", 8, "bytes").unwrap();
+
+    let err = allocator.check_units_can_fit(9).unwrap_err();
+
+    assert!(
+        format!("{err}").contains("Cannot allocate 9 bytes"),
+        "Unexpected error message: {err}"
+    );
+}
+
+#[test]
+fn allocation_without_available_capacity_returns_error() {
+    let engine = start_test(file!());
+    let allocator = CapacityAllocator::new(engine.top(), "alloc", 4, "objects").unwrap();
+
+    allocator.allocate(3).unwrap();
+
+    let err = allocator.allocate(2).unwrap_err();
+
+    assert!(
+        format!("{err}").contains("Overflow"),
+        "Unexpected error message: {err}"
+    );
+    assert_eq!(allocator.used(), 3);
+}
+
+#[test]
+fn reservation_releases_capacity_when_dropped() {
+    let engine = start_test(file!());
+    let allocator = CapacityAllocator::new(engine.top(), "alloc", 8, "bytes").unwrap();
+
+    {
+        let _reservation = block_on(allocator.reserve(6)).unwrap();
+        assert_eq!(allocator.used(), 6);
+    }
+
+    assert_eq!(allocator.used(), 0);
+}
+
+#[test]
+fn reserve_waits_until_capacity_is_released() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let allocator = CapacityAllocator::new(engine.top(), "alloc", 4, "bytes").unwrap();
+
+    allocator.allocate(4).unwrap();
+    let reservation_done = Rc::new(Cell::new(false));
+
+    {
+        let allocator = allocator.clone();
+        let reservation_done = reservation_done.clone();
+        engine.spawn(async move {
+            let _reservation = allocator.reserve(2).await?;
+            reservation_done.set(true);
+            Ok(())
+        });
+    }
+
+    {
+        let allocator = allocator.clone();
+        let reservation_done = reservation_done.clone();
+        let clock = clock.clone();
+        engine.spawn(async move {
+            clock.wait_ticks(1).await;
+            assert!(!reservation_done.get());
+            assert_eq!(allocator.used(), 4);
+            allocator.release(4);
+            Ok(())
+        });
+    }
+
+    run_simulation!(engine);
+
+    assert!(reservation_done.get());
+    assert_eq!(allocator.used(), 0);
+    assert_eq!(clock.time_now_ns(), 1.0);
+}
+
+#[test]
+fn reserve_rechecks_capacity_after_shared_wakeup() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let allocator = CapacityAllocator::new(engine.top(), "alloc", 4, "bytes").unwrap();
+
+    allocator.allocate(4).unwrap();
+    let reservations_done = Rc::new(Cell::new(0));
+
+    for _ in 0..2 {
+        let allocator = allocator.clone();
+        let clock = clock.clone();
+        let reservations_done = reservations_done.clone();
+        engine.spawn(async move {
+            let _reservation = allocator.reserve(3).await?;
+            reservations_done.set(reservations_done.get() + 1);
+            clock.wait_ticks(10).await;
+            Ok(())
+        });
+    }
+
+    {
+        let allocator = allocator.clone();
+        let reservations_done = reservations_done.clone();
+        let clock = clock.clone();
+        engine.spawn(async move {
+            clock.wait_ticks(1).await;
+            allocator.release(3);
+
+            clock.wait_ticks(1).await;
+            assert_eq!(reservations_done.get(), 1);
+            assert_eq!(allocator.used(), 4);
+
+            Ok(())
+        });
+    }
+
+    run_simulation!(engine);
+
+    assert_eq!(reservations_done.get(), 2);
+    assert_eq!(allocator.used(), 1);
+    assert_eq!(clock.time_now_ns(), 21.0);
+}

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -30,7 +30,7 @@ rand.workspace = true
 
 [dev-dependencies]
 arc-swap = "1.6.0"
-gwr-components = { path = "../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../gwr-components", version = "0.12.0" }
 
 [features]
 default = ["global_allocator"]

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-models"
-version = "0.21.0"
+version = "0.22.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -31,7 +31,7 @@ async-trait.workspace = true
 clap.workspace = true
 futures.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
-gwr-components = { path = "../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -25,7 +25,7 @@ clap.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 regex.workspace = true

--- a/gwr-protocols/Cargo.toml
+++ b/gwr-protocols/Cargo.toml
@@ -22,6 +22,6 @@ publish.workspace = true
 paste.workspace = true
 
 [dev-dependencies]
-gwr-components = { path = "../gwr-components", version = "0.11.0" }
+gwr-components = { path = "../gwr-components", version = "0.12.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -29,7 +29,7 @@ byte-unit.workspace = true
 clap.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../gwr-models", version = "0.22.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.6.0" }
 gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true

--- a/licenses.html
+++ b/licenses.html
@@ -8403,14 +8403,14 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">sim-pipe 2.0.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">sim-ring 8.0.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-code-coverage 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-components 0.11.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-components 0.12.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-config 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-developer-guide 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-doc-builder 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-docpp 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.13.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-model-builder 0.2.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.21.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.22.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx-sys 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-perfetto 0.3.0</a></li>


### PR DESCRIPTION
Adds a reusable CapacityAllocator for capacity accounting and reservations.
Refactors Store to use it while keeping overflow policy in store state.
Includes allocator tests for capacity checks, overflow errors, reservations,
and release behavior.
