### PR TITLE
Dependabot refinements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
-# Exclude generated files from the language statistics
-licenses.html linguist-vendored
+# Hide generated files in diffs and exclude them from language statistics
+licenses.html linguist-generated

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "infra"
+    groups:
+      actions-by-dependency:
+        group-by: dependency-name
 
   - package-ecosystem: "rust-toolchain"
     directory: "/"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "infra"
+    labels:
+      - "A - dependencies"
+      - "A - infrastructure"
     pull-request-branch-name:
       separator: "-"
     groups:
@@ -22,6 +25,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "infra"
+    labels:
+      - "A - dependencies"
+      - "A - infrastructure"
     pull-request-branch-name:
       separator: "-"
 
@@ -31,6 +37,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    labels:
+      - "A - dependencies"
     pull-request-branch-name:
       separator: "-"
     groups:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "infra"
+    pull-request-branch-name:
+      separator: "-"
     groups:
       actions-by-dependency:
         group-by: dependency-name
@@ -20,6 +22,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "infra"
+    pull-request-branch-name:
+      separator: "-"
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -27,6 +31,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    pull-request-branch-name:
+      separator: "-"
     groups:
       # Group multiple updates together into a single PR
       non-major:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,7 +25,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     commit-message:
       prefix: "chore"
     groups:

--- a/.github/gwr-bot/gwr-bot-setup.md
+++ b/.github/gwr-bot/gwr-bot-setup.md
@@ -119,7 +119,7 @@ secrets you just created. No workflow edits are required.
 1. Trigger a Dependabot run manually (**Insights → Dependency graph →
    Dependabot → Recent update jobs → Check for updates**) or wait for the
    next scheduled run.
-2. When a `dependabot/cargo/*` PR appears, watch the
+2. When a `dependabot-cargo-*` PR appears, watch the
    `Regenerate dependency licenses on Dependabot cargo PRs` workflow run
    under **Actions**. It should succeed and produce a force-push.
 3. On the PR, confirm that:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches-ignore:
       - "pr-**"
-      - "dependabot/**"
+      - "dependabot-*"
   pull_request:
 
 env:
@@ -24,12 +24,12 @@ jobs:
     # CI here with `github.actor` no longer set to `dependabot[bot]`.
     #
     # This guard only skips running CI on the initial Dependabot Cargo update
-    # pushes. All other Dependabot PRs (e.g. `dependabot/github-actions/*`,
-    # `dependabot/rust-toolchain/*`) are not amended by other  workflows and
+    # pushes. All other Dependabot PRs (e.g. `dependabot-github-actions-*`,
+    # `dependabot-rust-toolchain-*`) are not amended by other workflows and
     # therefore must run CI normally.
     if: >-
       ${{ !(github.actor == 'dependabot[bot]' &&
-            startsWith(github.head_ref, 'dependabot/cargo/')) }}
+            startsWith(github.head_ref, 'dependabot-cargo-')) }}
     runs-on: ubuntu-latest
     steps:
       - run: ":"

--- a/.github/workflows/regenerate-licenses-on-dependabot.yaml
+++ b/.github/workflows/regenerate-licenses-on-dependabot.yaml
@@ -37,7 +37,7 @@ jobs:
   regenerate-licenses:
     if: >-
       github.actor == 'dependabot[bot]' &&
-      startsWith(github.head_ref, 'dependabot/cargo/')
+      startsWith(github.head_ref, 'dependabot-cargo-')
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
- **infra(dependabot): group github-actions updates**
- **infra(dependabot): remove the PR limit**
- **infra(dependabot): use a worktree friendly branch naming scheme**
- **infra(dependabot): use the existing labeling scheme**
- **chore: hide diffs of licenses.html by default on GitHub**
