### PR TITLE
infra(dependabot): make gwr-bot the author when it commits modifications

### DIFF
--- a/.github/gwr-bot/gwr-bot-setup.md
+++ b/.github/gwr-bot/gwr-bot-setup.md
@@ -9,9 +9,10 @@
 </div>
 
 The [`regenerate-licenses-on-dependabot`](../workflows/regenerate-licenses-on-dependabot.yaml)
-workflow amends Dependabot's commits and force-pushes the result so that
-CI runs against a branch with an up-to-date `licenses.html`. It needs a
-token with `contents: write` on the repository, because:
+workflow regenerates `licenses.html`, makes `gwr-bot` the amended commit's
+author and committer, credits Dependabot as a co-author in the commit message,
+and force-pushes the result. It needs a token with `contents: write` on the
+repository, because:
 
 - The default `GITHUB_TOKEN` supplied to Dependabot-triggered workflows is
   read-only and cannot push.
@@ -123,8 +124,9 @@ secrets you just created. No workflow edits are required.
    `Regenerate dependency licenses on Dependabot cargo PRs` workflow run
    under **Actions**. It should succeed and produce a force-push.
 3. On the PR, confirm that:
-   - The tip commit is authored by `dependabot[bot]` and committed by
-     `gwr-bot[bot]`.
+   - The tip commit is authored and committed by `gwr-bot[bot]`.
+   - The commit message ends with a `Co-authored-by` trailer for
+     `dependabot[bot]`.
    - CI has run against the amended commit (the `gate` job is not
      skipped, because `github.actor` is now `gwr-bot[bot]`, not
      `dependabot[bot]`).

--- a/.github/workflows/regenerate-licenses-on-dependabot.yaml
+++ b/.github/workflows/regenerate-licenses-on-dependabot.yaml
@@ -2,15 +2,15 @@
 
 # When Dependabot bumps cargo dependencies, the workspace's dependency-
 # license report (`licenses.html`) also needs updating. This workflow
-# regenerates it and amends the change into Dependabot's commit and force pushes
-# back to the PR opened by Dependabot.
+# regenerates it, makes `gwr-bot` the amended commit's author and committer,
+# credits Dependabot as a co-author in the commit message, and force pushes back
+# to the PR opened by Dependabot.
 #
 # Prerequisites (repository configuration):
 #   - A `gwr-bot` GitHub App installed on this repository with
-#     `contents: write` permission. Its App ID and private key must be
-#     stored as *Dependabot* secrets named `GWR_BOT_APP_ID` and
-#     `GWR_BOT_PRIVATE_KEY` under
-#     Settings -> Secrets and variables -> Dependabot.
+#     `contents: write` permission. Its App ID and private key must be stored as
+#     *Dependabot* secrets named `GWR_BOT_APP_ID` and `GWR_BOT_PRIVATE_KEY`
+#     under Settings -> Secrets and variables -> Dependabot.
 #
 # Regular Actions secrets are not accessible to Dependabot-triggered workflows,
 # so they must be Dependabot secrets. Because pushes made with the default
@@ -75,8 +75,8 @@ jobs:
           GH_TOKEN: ${{ steps.gwr-bot-token.outputs.token }}
           APP_SLUG: ${{ steps.gwr-bot-token.outputs.app-slug }}
         run: |
-          # Resolve the committer identity from the App that owns the token
-          # minted above, so the commit's git committer matches the identity
+          # Resolve the author and committer identity from the App that owns the
+          # token minted above, so the amended commit matches the identity
           # GitHub records as the pusher of the resulting force-push.
           # Deriving the identity at run time means a future App rename or
           # swap only requires updating the two Dependabot secrets -- no
@@ -93,21 +93,29 @@ jobs:
           git config user.name "$user_login"
           git config user.email "${user_id}+${user_login}@users.noreply.github.com"
 
-      - name: Amend Dependabot commit with regenerated licenses
+      - name: Amend licenses and commit attribution
         env:
           GH_TOKEN: ${{ steps.gwr-bot-token.outputs.token }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           # Always amend and force-push, even when the regenerated
           # `licenses.html` matches the version already on the branch.
-          # Re-amending with a different committer identity produces a
-          # new commit SHA, which triggers `pull_request: synchronize`
-          # and causes CI (guarded on `github.actor`) to run against
-          # the amended commit. Without this, PRs whose dependency
-          # bumps did not affect the license report would leave CI
-          # stuck in the skipped state.
+          # Re-amending with a different author and committer identity produces
+          # a new commit SHA, which triggers `pull_request: synchronize` and
+          # causes CI (guarded on `github.actor`) to run against the amended
+          # commit. Without this, PRs whose dependency bumps did not affect the
+          # license report would leave CI stuck in the skipped state.
           set -euo pipefail
+
+          trailer_args=()
+          if [[ $(git log -1 --format=%an) != "$(git config user.name)" ]]; then
+            trailer_args=(
+              --trailer
+              "Co-authored-by: $(git log -1 --format='%an <%ae>')"
+            )
+          fi
+
           gh auth setup-git
           git add licenses.html
-          git commit --amend --no-edit
+          git commit --amend --reset-author --no-edit "${trailer_args[@]}"
           git push --force-with-lease origin "HEAD:${PR_HEAD_REF}"


### PR DESCRIPTION
To make understanding changes easier in future, and avoid the possible
confusion of finding changes which Dependabot should not be able to
make, gwr-bot will now be recorded as the author (for clarity when using
tools such as `git blame`.)

A co-author trailer line is added to the commit message to indicate that
Dependabot also contributed to the changes (which will be recognized by
GitHub's UI.)
