### PR TITLE
Add draft multi-engine sync and channel primitives.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,6 +1923,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-engine"
+version = "0.1.0"
+dependencies = [
+ "gwr-engine",
+ "gwr-track",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "check-copyright",
   "examples/flaky-component",
   "examples/flaky-with-delay",
+  "examples/multi-engine",
   "examples/scrambler",
   "examples/sim-fabric",
   "examples/sim-pipe",

--- a/examples/multi-engine/Cargo.toml
+++ b/examples/multi-engine/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+[package]
+name = "multi-engine"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Example showing multiple GWR engines running concurrently"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-track = { path = "../../gwr-track", version = "0.13.0" }

--- a/examples/multi-engine/src/main.rs
+++ b/examples/multi-engine/src/main.rs
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+//! This example demonstrates how to run two engines in parallel. Each engine
+//! runs in its own thread, exchanges a message with the other engine, and then
+//! synchronizes to the later of the two engine times before continuing.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run -p multi-engine
+//! ```
+
+use gwr_engine::engine::Engine;
+use gwr_engine::multi_engine::{
+    MultiEngineChannel, MultiEngineChannelReceiver, MultiEngineChannelSender, MultiEngineSync,
+    MultiEngineSyncParticipant,
+};
+use gwr_engine::time::clock::Clock;
+use gwr_engine::types::{SimError, SimResult};
+use gwr_track::tracker::dev_null_tracker;
+
+const WORK_CHUNKS: usize = 2;
+const ENGINE_0_WORK_TICKS: u64 = 10;
+const ENGINE_1_WORK_TICKS: u64 = 20;
+const EXPECTED_FINAL_TIME_NS: f64 = 40.0;
+
+#[derive(Debug, PartialEq, Eq)]
+struct EngineMessage {
+    from_engine: usize,
+    sequence: usize,
+}
+
+async fn wait_until(clock: &Clock, time_ns: f64) {
+    let now_ns = clock.time_now_ns();
+    if time_ns > now_ns {
+        let ticks = ((time_ns - now_ns) * clock.freq_mhz() / 1000.0).ceil() as u64;
+        clock.wait_ticks(ticks).await;
+    }
+}
+
+fn run_engine(
+    engine_id: usize,
+    ticks: u64,
+    sync: MultiEngineSyncParticipant,
+    tx: MultiEngineChannelSender<EngineMessage>,
+    rx: MultiEngineChannelReceiver<EngineMessage>,
+) -> Result<f64, SimError> {
+    let tracker = dev_null_tracker();
+    let mut engine = Engine::new(&tracker);
+    let clock = engine.default_clock();
+
+    println!("starting engine {engine_id}");
+
+    let wait_handle = engine.external_wait_handle();
+
+    engine.spawn(async move {
+        for sequence in 0..WORK_CHUNKS {
+            clock.wait_ticks(ticks).await;
+
+            tx.send(EngineMessage {
+                from_engine: engine_id,
+                sequence,
+            })
+            .expect("send should succeed");
+
+            let message = rx
+                .recv(wait_handle.clone())
+                .await
+                .expect("sender should still exist");
+            assert_eq!(message.from_engine, 1 - engine_id);
+            assert_eq!(message.sequence, sequence);
+
+            let local_time_ns = clock.time_now_ns();
+            let synced_time_ns = sync.sync(local_time_ns, wait_handle.clone()).await;
+            wait_until(&clock, synced_time_ns).await;
+        }
+
+        Ok(())
+    });
+
+    engine.run()?;
+
+    Ok(engine.time_now_ns())
+}
+
+fn main() -> SimResult {
+    let sync = MultiEngineSync::new(2);
+    let (tx_0, rx_0) = MultiEngineChannel::channel();
+    let (tx_1, rx_1) = MultiEngineChannel::channel();
+
+    let sync_0 = sync.participant(0);
+    let sync_1 = sync.participant(1);
+
+    let handles = [
+        (
+            0,
+            std::thread::spawn(move || run_engine(0, ENGINE_0_WORK_TICKS, sync_0, tx_1, rx_0)),
+        ),
+        (
+            1,
+            std::thread::spawn(move || run_engine(1, ENGINE_1_WORK_TICKS, sync_1, tx_0, rx_1)),
+        ),
+    ];
+
+    for (engine_id, handle) in handles {
+        let final_time_ns = handle.join().expect("engine thread panicked")?;
+        assert_eq!(
+            final_time_ns, EXPECTED_FINAL_TIME_NS,
+            "engine {engine_id} finished at an unexpected time"
+        );
+        println!("engine {engine_id} finished at {final_time_ns:.2} ns");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_engine_advances_to_sync_time() {
+        let sync_0 = MultiEngineSync::new(2);
+        let sync_1 = sync_0.participant(1);
+        let sync_0 = sync_0.participant(0);
+        let (tx_0, rx_0) = MultiEngineChannel::channel();
+        let (tx_1, rx_1) = MultiEngineChannel::channel();
+
+        let handle_0 =
+            std::thread::spawn(move || run_engine(0, ENGINE_0_WORK_TICKS, sync_0, tx_1, rx_0));
+        let handle_1 =
+            std::thread::spawn(move || run_engine(1, ENGINE_1_WORK_TICKS, sync_1, tx_0, rx_1));
+
+        let thread_0_time_ns = handle_0
+            .join()
+            .expect("engine thread panicked")
+            .expect("engine run failed");
+
+        let thread_1_time_ns = handle_1
+            .join()
+            .expect("engine thread panicked")
+            .expect("engine run failed");
+
+        assert_eq!(thread_0_time_ns, thread_1_time_ns);
+        assert_eq!(thread_0_time_ns, EXPECTED_FINAL_TIME_NS);
+    }
+}

--- a/gwr-engine/src/engine.rs
+++ b/gwr-engine/src/engine.rs
@@ -8,7 +8,7 @@ use gwr_track::entity::{Entity, toplevel};
 use gwr_track::tracker::stdout_tracker;
 use gwr_track::{Tracker, trace};
 
-use crate::executor::{self, Executor, Spawner};
+use crate::executor::{self, Executor, ExternalWaitHandle, Spawner};
 use crate::time::clock::Clock;
 use crate::types::{Component, Eventable, SimResult};
 
@@ -142,6 +142,11 @@ impl Engine {
     #[must_use]
     pub fn time_now_ns(&self) -> f64 {
         self.executor.time_now_ns()
+    }
+
+    #[must_use]
+    pub fn external_wait_handle(&self) -> ExternalWaitHandle {
+        self.executor.external_wait_handle()
     }
 
     #[must_use]

--- a/gwr-engine/src/executor.rs
+++ b/gwr-engine/src/executor.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::mem;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::{Arc, Condvar, Mutex};
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use gwr_track::entity::Entity;
@@ -16,59 +17,88 @@ use crate::time::clock::Clock;
 use crate::time::simtime::SimTime;
 use crate::types::SimResult;
 
-fn no_op(_: *const ()) {}
+type TaskId = usize;
 
 unsafe fn drop_task(data: *const ()) {
     unsafe {
-        drop(Rc::from_raw(data as *const Task));
+        drop(Arc::from_raw(data as *const TaskWake));
     }
 }
 
-static VTABLE: RawWakerVTable = RawWakerVTable::new(clone_raw_waker, wake_task, no_op, drop_task);
+static VTABLE: RawWakerVTable =
+    RawWakerVTable::new(clone_raw_waker, wake_task, wake_by_ref, drop_task);
 
-fn task_raw_waker(task: Rc<Task>) -> RawWaker {
-    let ptr = Rc::into_raw(task) as *const ();
+fn task_raw_waker(wake: Arc<TaskWake>) -> RawWaker {
+    let ptr = Arc::into_raw(wake) as *const ();
     RawWaker::new(ptr, &VTABLE)
 }
 
-fn waker_for_task(task: Rc<Task>) -> Waker {
-    unsafe { Waker::from_raw(task_raw_waker(task)) }
+fn waker_for_task(task: &Rc<Task>) -> Waker {
+    let wake = Arc::new(TaskWake {
+        task_id: task.id,
+        external_wake: ExternalWakeHandle {
+            state: task.executor_state.external.clone(),
+        },
+    });
+
+    unsafe { Waker::from_raw(task_raw_waker(wake)) }
 }
 
 unsafe fn clone_raw_waker(data: *const ()) -> RawWaker {
     unsafe {
-        // Tasks are always wrapped in a reference counter to allow them to be shared
-        // read-only. The input `data` pointer is borrowed — we must not decrement its
-        // refcount, so we mem::forget the reconstructed Rc rather than letting it drop.
-        let rc_task = Rc::from_raw(data as *const Task);
-        let clone = rc_task.clone();
-        mem::forget(rc_task);
-        let ptr = Rc::into_raw(clone) as *const ();
+        // Raw wakers store an Arc<TaskWake>. The input pointer is borrowed here,
+        // so reconstruct it only long enough to clone it.
+        let wake = Arc::from_raw(data as *const TaskWake);
+        let clone = wake.clone();
+        mem::forget(wake);
+        let ptr = Arc::into_raw(clone) as *const ();
         RawWaker::new(ptr, &VTABLE)
     }
 }
 
 unsafe fn wake_task(data: *const ()) {
     unsafe {
-        // Tasks are always wrapped in a reference counter to allow them to be shared
-        // read-only.
-        let rc_task = Rc::from_raw(data as *const Task);
-        let cloned = rc_task.clone();
-        rc_task.executor_state.new_tasks.borrow_mut().push(cloned);
+        // We can safely take ownership of the Arc here, because the waker is being
+        // consumed.
+        let wake = Arc::from_raw(data as *const TaskWake);
+        wake.wake();
+        drop(wake);
+    }
+}
+
+unsafe fn wake_by_ref(data: *const ()) {
+    unsafe {
+        let wake = Arc::from_raw(data as *const TaskWake);
+        wake.wake();
+        mem::forget(wake);
+    }
+}
+
+struct TaskWake {
+    task_id: TaskId,
+    external_wake: ExternalWakeHandle,
+}
+
+impl TaskWake {
+    fn wake(&self) {
+        self.external_wake.wake_task(self.task_id);
     }
 }
 
 struct Task {
+    id: TaskId,
     future: RefCell<Option<Pin<Box<dyn Future<Output = SimResult>>>>>,
     executor_state: Rc<ExecutorState>,
 }
 
 impl Task {
     pub fn new(
+        id: TaskId,
         future: impl Future<Output = SimResult> + 'static,
         executor_state: Rc<ExecutorState>,
     ) -> Task {
         Task {
+            id,
             future: RefCell::new(Some(Box::pin(future))),
             executor_state,
         }
@@ -92,9 +122,12 @@ impl Task {
 struct ExecutorState {
     task_queue: RefCell<Vec<Rc<Task>>>,
     new_tasks: RefCell<Vec<Rc<Task>>>,
+    next_task_id: Cell<TaskId>,
     time: RefCell<SimTime>,
     randomize_task_order: Cell<bool>,
     task_order_rng: RefCell<StdRng>,
+    external: Arc<ExternalState>,
+    tasks: RefCell<Vec<Option<Rc<Task>>>>,
 }
 
 impl ExecutorState {
@@ -102,10 +135,107 @@ impl ExecutorState {
         Self {
             task_queue: RefCell::new(Vec::new()),
             new_tasks: RefCell::new(Vec::new()),
+            next_task_id: Cell::new(0),
             time: RefCell::new(SimTime::new(top)),
             randomize_task_order: Cell::new(false),
             task_order_rng: RefCell::new(StdRng::seed_from_u64(rand::random())),
+            external: Arc::new(ExternalState {
+                data: Mutex::new(ExternalStateData {
+                    waits: 0,
+                    time_blocking_waits: 0,
+                    wakes: Vec::new(),
+                }),
+                changed: Condvar::new(),
+            }),
+            tasks: RefCell::new(Vec::new()),
         }
+    }
+}
+
+struct ExternalStateData {
+    waits: usize,
+    time_blocking_waits: usize,
+    wakes: Vec<TaskId>,
+}
+
+struct ExternalState {
+    data: Mutex<ExternalStateData>,
+    changed: Condvar,
+}
+
+#[derive(Clone)]
+struct ExternalWakeHandle {
+    state: Arc<ExternalState>,
+}
+
+impl ExternalWakeHandle {
+    fn wake_task(&self, task_id: TaskId) {
+        {
+            let mut external_wakes = self.state.data.lock().unwrap();
+            external_wakes.wakes.push(task_id);
+        }
+        self.state.changed.notify_all();
+    }
+}
+
+/// Handle used to tell the executor that a task is waiting for external
+/// progress.
+#[derive(Clone)]
+pub struct ExternalWaitHandle {
+    state: Arc<ExternalState>,
+}
+
+/// Guard that keeps the executor alive while a task waits for external
+/// progress.
+pub struct ExternalWaitGuard {
+    state: Arc<ExternalState>,
+    blocks_time: bool,
+}
+
+impl ExternalWaitHandle {
+    /// Register that a task is waiting for progress from outside this executor.
+    #[must_use]
+    pub fn begin_wait(&self) -> ExternalWaitGuard {
+        let mut state = self.state.data.lock().unwrap();
+        state.waits += 1;
+        ExternalWaitGuard {
+            state: self.state.clone(),
+            blocks_time: false,
+        }
+    }
+
+    /// Register that a task is waiting for external progress and simulated time
+    /// must not advance until that progress happens.
+    #[must_use]
+    pub fn begin_time_blocking_wait(&self) -> ExternalWaitGuard {
+        let mut state = self.state.data.lock().unwrap();
+        state.waits += 1;
+        state.time_blocking_waits += 1;
+        ExternalWaitGuard {
+            state: self.state.clone(),
+            blocks_time: true,
+        }
+    }
+}
+
+impl Drop for ExternalWaitGuard {
+    fn drop(&mut self) {
+        {
+            let mut state = self.state.data.lock().unwrap();
+            assert!(
+                state.waits > 0,
+                "ExternalWaitGuard dropped without a matching begin_wait"
+            );
+            state.waits -= 1;
+            if self.blocks_time {
+                assert!(
+                    state.time_blocking_waits > 0,
+                    "ExternalWaitGuard dropped without a matching begin_time_blocking_wait"
+                );
+                state.time_blocking_waits -= 1;
+            }
+        }
+        self.state.changed.notify_all();
     }
 }
 
@@ -130,16 +260,22 @@ impl Executor {
                 break;
             }
 
+            self.queue_external_wakes();
+
             if self.state.new_tasks.borrow().is_empty() {
-                if self.state.time.borrow().can_exit() {
+                if self.can_exit_now() {
                     break;
                 }
 
-                if let Some(wakers) = self.state.time.borrow_mut().advance_time() {
+                if self.has_time_blocking_external_waits() {
+                    self.wait_for_time_blocking_external_progress();
+                } else if let Some(wakers) = self.state.time.borrow_mut().advance_time() {
                     // No events left, advance time
                     for task_waker in wakers.into_iter() {
                         task_waker.waker.wake();
                     }
+                } else if self.has_external_waits() {
+                    self.wait_for_external_progress();
                 } else {
                     break;
                 }
@@ -148,7 +284,53 @@ impl Executor {
         Ok(())
     }
 
+    fn wait_for_external_progress(&self) {
+        let mut external_waits = self.state.external.data.lock().unwrap();
+        while external_waits.waits > 0 && external_waits.wakes.is_empty() {
+            external_waits = self.state.external.changed.wait(external_waits).unwrap();
+        }
+    }
+
+    fn wait_for_time_blocking_external_progress(&self) {
+        let mut external_waits = self.state.external.data.lock().unwrap();
+        while external_waits.time_blocking_waits > 0 && external_waits.wakes.is_empty() {
+            external_waits = self.state.external.changed.wait(external_waits).unwrap();
+        }
+    }
+
+    fn take_external_wakes(&self) -> Vec<TaskId> {
+        let mut external_wakes = self.state.external.data.lock().unwrap();
+        std::mem::take(&mut external_wakes.wakes)
+    }
+
+    fn queue_external_wakes(&self) {
+        let tasks = self.state.tasks.borrow();
+        let new_tasks = &mut self.state.new_tasks.borrow_mut();
+
+        for task_id in self.take_external_wakes() {
+            if let Some(Some(task)) = tasks.get(task_id) {
+                new_tasks.push(task.clone());
+            }
+        }
+    }
+
+    fn can_exit_now(&self) -> bool {
+        self.state.time.borrow().can_exit() && !self.has_external_waits()
+    }
+
+    fn has_external_waits(&self) -> bool {
+        let external_waits = self.state.external.data.lock().unwrap();
+        external_waits.waits > 0
+    }
+
+    fn has_time_blocking_external_waits(&self) -> bool {
+        let external_waits = self.state.external.data.lock().unwrap();
+        external_waits.time_blocking_waits > 0
+    }
+
     pub fn step(&self, finished: &Rc<RefCell<bool>>) -> SimResult {
+        self.queue_external_wakes();
+
         // Append new tasks created since the last step into the task queue
         let mut task_queue = self.state.task_queue.borrow_mut();
         task_queue.append(&mut self.state.new_tasks.borrow_mut());
@@ -164,16 +346,18 @@ impl Executor {
             }
 
             // Dummy waker and context (not used as we poll all tasks)
-            let waker = waker_for_task(task.clone());
+            let waker = waker_for_task(&task);
             let mut context = Context::from_waker(&waker);
 
             match task.poll(&mut context) {
                 Poll::Ready(Err(e)) => {
                     // Error - return early
+                    self.state.tasks.borrow_mut()[task.id] = None;
                     return Err(e);
                 }
                 Poll::Ready(Ok(())) => {
                     // Otherwise, drop task as it is complete
+                    self.state.tasks.borrow_mut()[task.id] = None;
                 }
                 Poll::Pending => {
                     // Task will have parked itself waiting somewhere
@@ -181,6 +365,13 @@ impl Executor {
             }
         }
         Ok(())
+    }
+
+    #[must_use]
+    pub fn external_wait_handle(&self) -> ExternalWaitHandle {
+        ExternalWaitHandle {
+            state: self.state.external.clone(),
+        }
     }
 
     #[must_use]
@@ -210,10 +401,13 @@ pub struct Spawner {
 
 impl Spawner {
     pub fn spawn(&self, future: impl Future<Output = SimResult> + 'static) {
-        self.state
-            .new_tasks
-            .borrow_mut()
-            .push(Rc::new(Task::new(future, self.state.clone())));
+        let id = self.state.next_task_id.get();
+        self.state.next_task_id.set(id + 1);
+
+        let task = Rc::new(Task::new(id, future, self.state.clone()));
+        self.state.tasks.borrow_mut().push(Some(task.clone()));
+
+        self.state.new_tasks.borrow_mut().push(task);
     }
 }
 
@@ -230,11 +424,13 @@ pub fn new_executor_and_spawner(top: &Rc<Entity>) -> (Executor, Spawner) {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::future::Future;
     use std::pin::Pin;
     use std::rc::Rc;
-    use std::task::{Context, Poll};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll, Waker};
 
     use futures::task::noop_waker;
     use gwr_track::entity::toplevel;
@@ -242,6 +438,51 @@ mod tests {
 
     use super::*;
     use crate::time::clock::TaskWaker;
+
+    struct StoresWakerThenCompletes {
+        polls: Rc<Cell<usize>>,
+        stored_waker: Arc<Mutex<Option<Waker>>>,
+    }
+
+    impl Future for StoresWakerThenCompletes {
+        type Output = SimResult;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let polls = self.polls.get() + 1;
+            self.polls.set(polls);
+
+            if polls == 1 {
+                *self.stored_waker.lock().unwrap() = Some(cx.waker().clone());
+                Poll::Pending
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+
+    struct WaitsForExternalProgress {
+        wait_handle: ExternalWaitHandle,
+        wait: Arc<Mutex<Option<ExternalWaitGuard>>>,
+        blocks_time: bool,
+        started: bool,
+    }
+
+    impl Future for WaitsForExternalProgress {
+        type Output = SimResult;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if !self.started {
+                let wait = if self.blocks_time {
+                    self.wait_handle.begin_time_blocking_wait()
+                } else {
+                    self.wait_handle.begin_wait()
+                };
+                *self.wait.lock().unwrap() = Some(wait);
+                self.started = true;
+            }
+            Poll::Pending
+        }
+    }
 
     struct PanicIfPolled;
 
@@ -251,6 +492,135 @@ mod tests {
         fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
             panic!("finished executor step polled a task");
         }
+    }
+
+    #[test]
+    fn stored_waker_can_wake_task_from_another_thread() {
+        let tracker = dev_null_tracker();
+        let top = toplevel(&tracker, "top");
+        let (executor, spawner) = new_executor_and_spawner(&top);
+
+        let polls = Rc::new(Cell::new(0));
+        let stored_waker = Arc::new(Mutex::new(None));
+
+        spawner.spawn(StoresWakerThenCompletes {
+            polls: polls.clone(),
+            stored_waker: stored_waker.clone(),
+        });
+
+        let finished = Rc::new(RefCell::new(false));
+        executor.step(&finished).unwrap();
+        assert_eq!(polls.get(), 1, "Task should have been polled once");
+
+        let waker_option = stored_waker.lock().unwrap().take();
+        assert!(
+            waker_option.is_some(),
+            "Waker should have been stored in the mutex"
+        );
+
+        let waker_clone = waker_option.unwrap();
+        let thread_handle = std::thread::spawn(move || {
+            waker_clone.wake();
+        });
+
+        thread_handle.join().unwrap();
+
+        executor.step(&finished).unwrap();
+        assert_eq!(polls.get(), 2, "Task should have been polled twice");
+
+        assert!(
+            executor.state.tasks.borrow()[0].as_ref().is_none(),
+            "Task should be removed after completing"
+        );
+    }
+
+    #[test]
+    fn external_wait_blocks_time_advance() {
+        let tracker = dev_null_tracker();
+        let top = toplevel(&tracker, "top");
+        let (executor, spawner) = new_executor_and_spawner(&top);
+        let clock = executor.get_clock(1000.0);
+
+        let wait = Arc::new(Mutex::new(None));
+        let late_task_ran = Arc::new(AtomicBool::new(false));
+
+        spawner.spawn(WaitsForExternalProgress {
+            wait_handle: executor.external_wait_handle(),
+            wait: wait.clone(),
+            blocks_time: true,
+            started: false,
+        });
+
+        let late_task_clock = clock.clone();
+        let late_task_ran_for_task = late_task_ran.clone();
+        spawner.spawn(async move {
+            late_task_clock.wait_ticks(10).await;
+            late_task_ran_for_task.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let time_advanced_before_wait_finished = Arc::new(AtomicBool::new(false));
+        let time_advanced_for_thread = time_advanced_before_wait_finished.clone();
+        let thread_handle = std::thread::spawn(move || {
+            while wait.lock().unwrap().is_none() {
+                std::thread::yield_now();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            time_advanced_for_thread.store(late_task_ran.load(Ordering::SeqCst), Ordering::SeqCst);
+            drop(wait.lock().unwrap().take());
+        });
+
+        executor.run(&Rc::new(RefCell::new(false))).unwrap();
+        thread_handle.join().unwrap();
+        assert!(!time_advanced_before_wait_finished.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn external_wait_allows_time_advance() {
+        let tracker = dev_null_tracker();
+        let top = toplevel(&tracker, "top");
+        let (executor, spawner) = new_executor_and_spawner(&top);
+        let clock = executor.get_clock(1000.0);
+
+        let wait = Arc::new(Mutex::new(None));
+        let late_task_ran = Arc::new(AtomicBool::new(false));
+
+        spawner.spawn(WaitsForExternalProgress {
+            wait_handle: executor.external_wait_handle(),
+            wait: wait.clone(),
+            blocks_time: false,
+            started: false,
+        });
+
+        let late_task_clock = clock.clone();
+        let late_task_ran_for_task = late_task_ran.clone();
+        spawner.spawn(async move {
+            late_task_clock.wait_ticks(10).await;
+            late_task_ran_for_task.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let time_advanced_before_wait_finished = Arc::new(AtomicBool::new(false));
+        let time_advanced_for_thread = time_advanced_before_wait_finished.clone();
+        let thread_handle = std::thread::spawn(move || {
+            while wait.lock().unwrap().is_none() {
+                std::thread::yield_now();
+            }
+
+            for _ in 0..100 {
+                if late_task_ran.load(Ordering::SeqCst) {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+
+            time_advanced_for_thread.store(late_task_ran.load(Ordering::SeqCst), Ordering::SeqCst);
+            drop(wait.lock().unwrap().take());
+        });
+
+        executor.run(&Rc::new(RefCell::new(false))).unwrap();
+        thread_handle.join().unwrap();
+        assert!(time_advanced_before_wait_finished.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/gwr-engine/src/lib.rs
+++ b/gwr-engine/src/lib.rs
@@ -89,6 +89,7 @@ pub mod events;
 pub mod executor;
 #[cfg(feature = "global_allocator")]
 mod global_allocator;
+pub mod multi_engine;
 pub mod port;
 pub mod test_helpers;
 pub mod time;

--- a/gwr-engine/src/multi_engine.rs
+++ b/gwr-engine/src/multi_engine.rs
@@ -1,0 +1,597 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+//! Multi-engine synchronization and communication primitives.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use crate::executor::{ExternalWaitGuard, ExternalWaitHandle};
+
+#[derive(Clone)]
+pub struct MultiEngineSync {
+    shared: Arc<MultiEngineSyncShared>,
+}
+
+#[derive(Clone)]
+pub struct MultiEngineSyncParticipant {
+    sync: MultiEngineSync,
+    participant: usize,
+}
+
+struct MultiEngineSyncShared {
+    participants: usize,
+    state: Mutex<MultiEngineSyncState>,
+}
+
+struct MultiEngineSyncState {
+    arrivals: Vec<Option<f64>>,
+    arrived_count: usize,
+    generation: usize,
+    completed: VecDeque<CompletedSync>,
+    wakers: Vec<Option<Waker>>,
+}
+
+struct CompletedSync {
+    generation: usize,
+    time_ns: f64,
+    remaining: usize,
+}
+
+impl MultiEngineSyncState {
+    fn new(participants: usize) -> Self {
+        Self {
+            arrivals: vec![None; participants],
+            arrived_count: 0,
+            generation: 0,
+            completed: VecDeque::new(),
+            wakers: vec![None; participants],
+        }
+    }
+
+    fn complete_generation(&mut self) -> (f64, Vec<Waker>) {
+        let sync_time_ns = self.arrivals.iter().flatten().copied().fold(0.0, f64::max);
+        let remaining = self.arrived_count.saturating_sub(1);
+        if remaining > 0 {
+            self.completed.push_back(CompletedSync {
+                generation: self.generation,
+                time_ns: sync_time_ns,
+                remaining,
+            });
+        }
+        self.arrivals.fill(None);
+        self.arrived_count = 0;
+        self.generation += 1;
+        let wakers = self.wakers.iter_mut().filter_map(Option::take).collect();
+
+        (sync_time_ns, wakers)
+    }
+
+    fn take_completed_time(&mut self, generation: usize) -> Option<f64> {
+        let index = self
+            .completed
+            .iter()
+            .position(|sync| sync.generation == generation)?;
+        let time_ns = self.completed[index].time_ns;
+        self.completed[index].remaining -= 1;
+        if self.completed[index].remaining == 0 {
+            self.completed.remove(index);
+        }
+        Some(time_ns)
+    }
+}
+
+/// Future returned by [`MultiEngineSyncParticipant::sync`].
+pub struct MultiEngineSyncFuture {
+    sync: MultiEngineSync,
+    participant: usize,
+    time_ns: f64,
+    wait: Option<ExternalWaitGuard>,
+    generation: Option<usize>,
+    wait_handle: ExternalWaitHandle,
+}
+
+impl Future for MultiEngineSyncFuture {
+    type Output = f64;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        let mut state = this.sync.shared.state.lock().unwrap();
+
+        if let Some(my_generation) = this.generation {
+            if state.generation != my_generation {
+                let sync_time_ns = state
+                    .take_completed_time(my_generation)
+                    .expect("completed sync generation missing");
+                this.generation = None;
+                drop(state);
+                drop(this.wait.take());
+                return Poll::Ready(sync_time_ns);
+            }
+
+            if this.wait.is_none() {
+                this.wait = Some(this.wait_handle.begin_time_blocking_wait());
+            }
+            state.wakers[this.participant] = Some(cx.waker().clone());
+            return Poll::Pending;
+        }
+
+        assert!(
+            state.arrivals[this.participant].is_none(),
+            "sync participant already arrived"
+        );
+        this.generation = Some(state.generation);
+        state.arrivals[this.participant] = Some(this.time_ns);
+        state.arrived_count += 1;
+
+        if state.arrived_count == this.sync.shared.participants {
+            let (sync_time_ns, wakers) = state.complete_generation();
+            drop(state);
+
+            drop(this.wait.take());
+            this.generation = None;
+            for waker in wakers {
+                waker.wake();
+            }
+            Poll::Ready(sync_time_ns)
+        } else {
+            if this.wait.is_none() {
+                this.wait = Some(this.wait_handle.begin_time_blocking_wait());
+            }
+
+            state.wakers[this.participant] = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl Drop for MultiEngineSyncFuture {
+    fn drop(&mut self) {
+        let Some(generation) = self.generation else {
+            return;
+        };
+
+        let Ok(mut state) = self.sync.shared.state.lock() else {
+            return;
+        };
+        if state.generation == generation {
+            state.wakers[self.participant] = None;
+            if state.arrivals[self.participant].take().is_some() {
+                state.arrived_count -= 1;
+            }
+        } else {
+            state.take_completed_time(generation);
+        }
+    }
+}
+
+/// MultiEngineSync provides a synchronization primitive for multiple engines to
+/// synchronize their execution and share the maximum time_ns among them.
+impl MultiEngineSync {
+    /// Create a new MultiEngineSync with the specified number of participants.
+    /// Panics if participants is zero.
+    #[must_use]
+    pub fn new(participants: usize) -> Self {
+        assert!(participants > 0, "sync must have at least one participant");
+
+        Self {
+            shared: Arc::new(MultiEngineSyncShared {
+                participants,
+                state: Mutex::new(MultiEngineSyncState::new(participants)),
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn participant(&self, participant: usize) -> MultiEngineSyncParticipant {
+        assert!(
+            participant < self.shared.participants,
+            "sync participant out of range"
+        );
+
+        MultiEngineSyncParticipant {
+            sync: self.clone(),
+            participant,
+        }
+    }
+}
+
+impl MultiEngineSyncParticipant {
+    /// Synchronize asynchronously and return the maximum participant time.
+    #[must_use]
+    pub fn sync(&self, time_ns: f64, wait_handle: ExternalWaitHandle) -> MultiEngineSyncFuture {
+        MultiEngineSyncFuture {
+            sync: self.sync.clone(),
+            participant: self.participant,
+            time_ns,
+            wait: None,
+            generation: None,
+            wait_handle,
+        }
+    }
+}
+
+pub struct MultiEngineChannel;
+
+pub struct MultiEngineChannelSender<T: Send + 'static> {
+    shared: Arc<Mutex<MultiEngineChannelState<T>>>,
+}
+
+pub struct MultiEngineChannelReceiver<T: Send + 'static> {
+    shared: Arc<Mutex<MultiEngineChannelState<T>>>,
+}
+
+struct MultiEngineChannelState<T> {
+    messages: VecDeque<T>,
+    receiver_alive: bool,
+    sender_count: usize,
+    next_waker_id: usize,
+    wakers: Vec<(usize, Waker)>,
+}
+
+pub struct MultiEngineChannelRecvFuture<'a, T: Send + 'static> {
+    receiver: &'a MultiEngineChannelReceiver<T>,
+    wait: Option<ExternalWaitGuard>,
+    wait_handle: ExternalWaitHandle,
+    waker_id: Option<usize>,
+}
+
+impl MultiEngineChannel {
+    #[must_use]
+    pub fn channel<T: Send + 'static>()
+    -> (MultiEngineChannelSender<T>, MultiEngineChannelReceiver<T>) {
+        let shared = Arc::new(Mutex::new(MultiEngineChannelState {
+            messages: VecDeque::new(),
+            receiver_alive: true,
+            sender_count: 1,
+            next_waker_id: 0,
+            wakers: Vec::new(),
+        }));
+
+        (
+            MultiEngineChannelSender {
+                shared: shared.clone(),
+            },
+            MultiEngineChannelReceiver { shared },
+        )
+    }
+}
+
+impl<T: Send + 'static> Clone for MultiEngineChannelSender<T> {
+    fn clone(&self) -> Self {
+        self.shared.lock().unwrap().sender_count += 1;
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl<T: Send + 'static> Drop for MultiEngineChannelSender<T> {
+    fn drop(&mut self) {
+        let wakers = {
+            let mut state = self.shared.lock().unwrap();
+            state.sender_count -= 1;
+            if state.sender_count == 0 {
+                take_channel_wakers(&mut state)
+            } else {
+                Vec::new()
+            }
+        };
+
+        for waker in wakers {
+            waker.wake();
+        }
+    }
+}
+
+impl<T: Send + 'static> MultiEngineChannelSender<T> {
+    pub fn send(&self, message: T) -> Result<(), T> {
+        let wakers = {
+            let mut state = self.shared.lock().unwrap();
+            if !state.receiver_alive {
+                return Err(message);
+            }
+
+            state.messages.push_back(message);
+            take_channel_wakers(&mut state)
+        };
+
+        for waker in wakers {
+            waker.wake();
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: Send + 'static> Drop for MultiEngineChannelReceiver<T> {
+    fn drop(&mut self) {
+        let wakers = {
+            let mut state = self.shared.lock().unwrap();
+            state.receiver_alive = false;
+            take_channel_wakers(&mut state)
+        };
+
+        for waker in wakers {
+            waker.wake();
+        }
+    }
+}
+
+impl<T: Send + 'static> MultiEngineChannelReceiver<T> {
+    #[must_use]
+    pub fn recv(&self, wait_handle: ExternalWaitHandle) -> MultiEngineChannelRecvFuture<'_, T> {
+        MultiEngineChannelRecvFuture {
+            receiver: self,
+            wait: None,
+            wait_handle,
+            waker_id: None,
+        }
+    }
+}
+
+impl<T: Send + 'static> Future for MultiEngineChannelRecvFuture<'_, T> {
+    type Output = Option<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let mut state = this.receiver.shared.lock().unwrap();
+
+        if let Some(message) = state.messages.pop_front() {
+            this.waker_id = None;
+            drop(state);
+            drop(this.wait.take());
+            return Poll::Ready(Some(message));
+        }
+
+        if state.sender_count == 0 || !state.receiver_alive {
+            this.waker_id = None;
+            drop(state);
+            drop(this.wait.take());
+            return Poll::Ready(None);
+        }
+
+        if this.wait.is_none() {
+            this.wait = Some(this.wait_handle.begin_wait());
+        }
+
+        let waker_id = match this.waker_id {
+            Some(waker_id) => waker_id,
+            None => {
+                let waker_id = state.next_waker_id;
+                state.next_waker_id += 1;
+                this.waker_id = Some(waker_id);
+                waker_id
+            }
+        };
+
+        if let Some((_, waker)) = state
+            .wakers
+            .iter_mut()
+            .find(|(existing_id, _)| *existing_id == waker_id)
+        {
+            *waker = cx.waker().clone();
+        } else {
+            state.wakers.push((waker_id, cx.waker().clone()));
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<T: Send + 'static> Drop for MultiEngineChannelRecvFuture<'_, T> {
+    fn drop(&mut self) {
+        let Some(waker_id) = self.waker_id else {
+            return;
+        };
+
+        let Ok(mut state) = self.receiver.shared.lock() else {
+            return;
+        };
+        state
+            .wakers
+            .retain(|(existing_id, _)| *existing_id != waker_id);
+    }
+}
+
+fn take_channel_wakers<T>(state: &mut MultiEngineChannelState<T>) -> Vec<Waker> {
+    state.wakers.drain(..).map(|(_, waker)| waker).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll, Wake, Waker};
+
+    use futures::task::noop_waker;
+    use gwr_track::tracker::dev_null_tracker;
+
+    use super::*;
+    use crate::engine::Engine;
+
+    struct WakeCounter {
+        wakes: Arc<AtomicUsize>,
+    }
+
+    impl Wake for WakeCounter {
+        fn wake(self: Arc<Self>) {
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn counting_waker() -> (Arc<AtomicUsize>, Waker) {
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let waker = Waker::from(Arc::new(WakeCounter {
+            wakes: wakes.clone(),
+        }));
+        (wakes, waker)
+    }
+
+    #[test]
+    fn async_channel_receives_message_from_another_thread() {
+        let tracker = dev_null_tracker();
+        let engine = Engine::new(&tracker);
+        let (tx, rx) = MultiEngineChannel::channel();
+
+        let mut future = Box::pin(rx.recv(engine.external_wait_handle()));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+
+        let handle = std::thread::spawn(move || {
+            tx.send(String::from("hello")).expect("send should succeed");
+        });
+        handle.join().expect("sender thread panicked");
+
+        assert_eq!(
+            future.as_mut().poll(&mut cx),
+            Poll::Ready(Some(String::from("hello")))
+        );
+    }
+
+    #[test]
+    fn dropped_channel_recv_future_removes_waker() {
+        let tracker = dev_null_tracker();
+        let engine = Engine::new(&tracker);
+        let (tx, rx) = MultiEngineChannel::channel();
+
+        let mut future = Box::pin(rx.recv(engine.external_wait_handle()));
+        let (wakes, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+        drop(future);
+
+        tx.send(String::from("hello")).expect("send should succeed");
+        assert_eq!(wakes.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn async_sync_two_participants_returns_max_time() {
+        let tracker = dev_null_tracker();
+
+        let engine_0 = Engine::new(&tracker);
+        let engine_1 = Engine::new(&tracker);
+
+        let sync = MultiEngineSync::new(2);
+        let sync_0 = sync.participant(0);
+        let sync_1 = sync.participant(1);
+
+        let mut future_0 = Box::pin(sync_0.sync(10.0, engine_0.external_wait_handle()));
+        let mut future_1 = Box::pin(sync_1.sync(20.0, engine_1.external_wait_handle()));
+
+        let noop_waker = noop_waker();
+        let mut cx = Context::from_waker(&noop_waker);
+
+        let state = future_0.as_mut().poll(&mut cx);
+        assert_eq!(state, Poll::Pending);
+
+        let state = future_1.as_mut().poll(&mut cx);
+        assert_eq!(state, Poll::Ready(20.0));
+
+        let state = future_0.as_mut().poll(&mut cx);
+        assert_eq!(state, Poll::Ready(20.0));
+    }
+
+    #[test]
+    fn lagging_sync_future_returns_its_generation_time() {
+        let tracker = dev_null_tracker();
+        let engine_0 = Engine::new(&tracker);
+        let engine_1 = Engine::new(&tracker);
+        let sync = MultiEngineSync::new(2);
+        let sync_0 = sync.participant(0);
+        let sync_1 = sync.participant(1);
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut old_future_0 = Box::pin(sync_0.sync(10.0, engine_0.external_wait_handle()));
+        let mut old_future_1 = Box::pin(sync_1.sync(20.0, engine_1.external_wait_handle()));
+        assert_eq!(old_future_0.as_mut().poll(&mut cx), Poll::Pending);
+        assert_eq!(old_future_1.as_mut().poll(&mut cx), Poll::Ready(20.0));
+
+        let mut new_future_0 = Box::pin(sync_0.sync(30.0, engine_0.external_wait_handle()));
+        let mut new_future_1 = Box::pin(sync_1.sync(40.0, engine_1.external_wait_handle()));
+        assert_eq!(new_future_0.as_mut().poll(&mut cx), Poll::Pending);
+        assert_eq!(new_future_1.as_mut().poll(&mut cx), Poll::Ready(40.0));
+
+        assert_eq!(old_future_0.as_mut().poll(&mut cx), Poll::Ready(20.0));
+        assert_eq!(new_future_0.as_mut().poll(&mut cx), Poll::Ready(40.0));
+    }
+
+    #[test]
+    fn async_sync_single_participant_returns_time() {
+        let tracker = dev_null_tracker();
+        let engine = Engine::new(&tracker);
+        let sync = MultiEngineSync::new(1);
+        let sync = sync.participant(0);
+        let time_ns = 42.0;
+
+        let mut future = Box::pin(sync.sync(time_ns, engine.external_wait_handle()));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let result = future.as_mut().poll(&mut cx);
+        assert_eq!(result, Poll::Ready(time_ns));
+    }
+
+    #[test]
+    #[should_panic(expected = "sync must have at least one participant")]
+    fn sync_rejects_zero_participants() {
+        let _ = MultiEngineSync::new(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "sync participant already arrived")]
+    fn sync_rejects_concurrent_arrivals_from_same_participant() {
+        let tracker = dev_null_tracker();
+        let engine_0 = Engine::new(&tracker);
+        let engine_1 = Engine::new(&tracker);
+        let sync = MultiEngineSync::new(2).participant(0);
+
+        let mut future_0 = Box::pin(sync.sync(10.0, engine_0.external_wait_handle()));
+        let mut future_1 = Box::pin(sync.sync(20.0, engine_1.external_wait_handle()));
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert_eq!(future_0.as_mut().poll(&mut cx), Poll::Pending);
+        let _ = future_1.as_mut().poll(&mut cx);
+    }
+
+    #[test]
+    fn dropped_sync_future_removes_arrival_and_waker() {
+        let tracker = dev_null_tracker();
+        let engine_0 = Engine::new(&tracker);
+        let engine_1 = Engine::new(&tracker);
+        let sync = MultiEngineSync::new(2);
+        let sync_0 = sync.participant(0);
+        let sync_1 = sync.participant(1);
+
+        let (wakes, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut cancelled = Box::pin(sync_0.sync(10.0, engine_0.external_wait_handle()));
+        assert_eq!(cancelled.as_mut().poll(&mut cx), Poll::Pending);
+        drop(cancelled);
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut future_1 = Box::pin(sync_1.sync(20.0, engine_1.external_wait_handle()));
+        assert_eq!(future_1.as_mut().poll(&mut cx), Poll::Pending);
+
+        let mut future_0 = Box::pin(sync_0.sync(30.0, engine_0.external_wait_handle()));
+        assert_eq!(future_0.as_mut().poll(&mut cx), Poll::Ready(30.0));
+        assert_eq!(future_1.as_mut().poll(&mut cx), Poll::Ready(30.0));
+        assert_eq!(wakes.load(Ordering::SeqCst), 0);
+    }
+}

--- a/licenses.html
+++ b/licenses.html
@@ -45,7 +45,7 @@
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             <li><a href="#Apache-2.0">Apache License 2.0</a> (241)</li>
-            <li><a href="#MIT">MIT License</a> (109)</li>
+            <li><a href="#MIT">MIT License</a> (110)</li>
             <li><a href="#Zlib">zlib License</a> (2)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
@@ -7772,6 +7772,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/graphcore-research/gwr ">multi-engine 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">sim-restaurant 1.0.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-build 0.1.0</a></li>
                     <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream-impl 0.3.6</a></li>


### PR DESCRIPTION
Draft PR for early feedback on #200.

This adds an initial multi-engine path where each engine continues to own and poll its own non-Send tasks, while cross-thread communication happens through thread-safe wake signals, sync barriers, and typed channels.

I'd like to get feedback on the architecture before polishing further. In particular:

- whether `ExternalWaitHandle` is the right way to integrate external async waits with the executor
- whether `MultiEngineSyncParticipant` is the right shape for per-engine barrier participation
- whether the channel API is appropriate for moving `Send + 'static` data between engine threads
- whether the executor changes are acceptable or should be factored differently

And in general, whether this direction makes sense and whether I've interpreted the task correctly.