### PR TITLE
infra(dependabot): fix the group update detection

### DIFF
--- a/.github/workflows/trusted-amend-dependabot-github-actions-update.yaml
+++ b/.github/workflows/trusted-amend-dependabot-github-actions-update.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build update summary
         if: >-
-          steps.metadata.outputs.dependency-group == 'actions-by-dependency'
+          steps.metadata.outputs.dependency-group != ''
         id: summary
         env:
           UPDATED_DEPENDENCIES: >-
@@ -133,7 +133,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$DEPENDENCY_GROUP" == "actions-by-dependency" ]]; then
+          if [[ -n "$DEPENDENCY_GROUP" ]]; then
             old_message="$RUNNER_TEMP/old-commit-message"
             new_message="$RUNNER_TEMP/new-commit-message"
             old_pr_body="$RUNNER_TEMP/old-pr-body"


### PR DESCRIPTION
The metadata for a PR where the message failed to be rewritten contained
`dependency-group: github_actions` rather than the group name
`actions-by-dependency` specified in dependabot.yaml.
