### PR TITLE
test(gwr-models): extend test harness coverage

### DIFF
--- a/gwr-models/src/ethernet_frame.rs
+++ b/gwr-models/src/ethernet_frame.rs
@@ -39,7 +39,7 @@ pub fn u64_to_mac(value: u64) -> [u8; DEST_MAC_BYTES] {
     mac
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EthernetFrame {
     id: Id,
 

--- a/gwr-models/tests/cache.rs
+++ b/gwr-models/tests/cache.rs
@@ -175,6 +175,7 @@ mod full_cache_harness {
                 ),
             ]),
             expect_no_traffic!(&[Port::DevTx, Port::MemTx], cycles_per_request),
+            expect_no_traffic!(&[Port::DevTx, Port::MemTx], DELAY_TICKS as u64),
         ]);
 
         // All accesses are to the same address, so only the first should be passed

--- a/gwr-models/tests/cache.rs
+++ b/gwr-models/tests/cache.rs
@@ -1,12 +1,8 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 use std::rc::Rc;
 
-use gwr_components::sink::Sink;
-use gwr_components::source::Source;
-use gwr_components::{connect_port, option_box_repeat};
+use gwr_components::connect_port;
 use gwr_engine::engine::Engine;
-use gwr_engine::port::OutPort;
-use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 use gwr_engine::traits::SimObject;
 use gwr_models::build_model_harness;
@@ -75,49 +71,6 @@ where
     connect_port!(memory, tx => cache, mem_rx).unwrap();
 
     memory
-}
-
-#[test]
-fn cache_dev_read_goes_to_mem() {
-    let num_accesses = 100;
-
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
-
-    let memory_map = Rc::new(create_default_memory_map());
-
-    let cache = create_cache(&mut engine);
-    let top = engine.top();
-    let source = Source::new_and_register(&engine, top, "source", None);
-    let to_put = create_read(
-        source.entity(),
-        &memory_map,
-        ACCESS_SIZE_BYTES,
-        DST_ADDR,
-        SRC_ADDR,
-        OVERHEAD_SIZE_BYTES,
-    );
-    source.set_generator(option_box_repeat!(to_put ; num_accesses));
-
-    let dev_req_sink = Sink::new_and_register(&engine, &clock, top, "dev_req_sink");
-    let mem_req_sink = Sink::new_and_register(&engine, &clock, top, "mem_req_sink");
-
-    connect_port!(source, tx => cache, dev_rx).unwrap();
-    connect_port!(cache, dev_tx => dev_req_sink, rx).unwrap();
-    connect_port!(cache, mem_tx => mem_req_sink, rx).unwrap();
-
-    // Even though we are not driving it we need to connect it.
-    let mut mem_rx_driver = OutPort::new(top, "mem_rx_driver");
-    mem_rx_driver.connect(cache.port_mem_rx()).unwrap();
-
-    run_simulation!(engine);
-    assert_eq!(dev_req_sink.num_sunk(), 0);
-
-    // All accesses are to the same address, so only the first should be passed
-    // through
-    assert_eq!(mem_req_sink.num_sunk(), 1);
-    assert_eq!(cache.payload_bytes_read(), num_accesses * ACCESS_SIZE_BYTES);
-    assert_eq!(cache.payload_bytes_written(), 0);
 }
 
 /// Test the basics of the cache by driving/handling all of the ports manually
@@ -190,6 +143,44 @@ mod full_cache_harness {
         assert_eq!(cache.payload_bytes_written(), 0);
         assert_eq!(cache.num_misses(), 1);
         assert_eq!(cache.num_hits(), 1);
+    }
+
+    #[test]
+    fn cache_dev_read_goes_to_mem() {
+        let num_accesses = 100;
+        let cycles_per_request = OVERHEAD_SIZE_BYTES.div_ceil(BW_BYTES_PER_CYCLE) as u64;
+
+        let mut engine = start_test(file!());
+        let cache = create_cache(&mut engine);
+        let memory_map = Rc::new(create_default_memory_map());
+
+        let request = create_read(
+            cache.entity(),
+            &memory_map,
+            ACCESS_SIZE_BYTES,
+            DST_ADDR,
+            SRC_ADDR,
+            OVERHEAD_SIZE_BYTES,
+        );
+
+        let mut harness = CacheHarness::<MemoryAccess>::new(engine, cache.clone());
+
+        harness.run_steps([
+            par!([
+                seq!(vec![send_dev_rx!(request); num_accesses]),
+                expect_mem_tx!(
+                    MemoryTxn::read_req(DST_ADDR)
+                        .with_src_addr(SRC_ADDR)
+                        .with_bytes(ACCESS_SIZE_BYTES)
+                ),
+            ]),
+            expect_no_traffic!(&[Port::DevTx, Port::MemTx], cycles_per_request),
+        ]);
+
+        // All accesses are to the same address, so only the first should be passed
+        // through
+        assert_eq!(cache.payload_bytes_read(), num_accesses * ACCESS_SIZE_BYTES);
+        assert_eq!(cache.payload_bytes_written(), 0);
     }
 }
 

--- a/gwr-models/tests/ethernet_link.rs
+++ b/gwr-models/tests/ethernet_link.rs
@@ -56,8 +56,14 @@ mod ethernet_link_harness {
         let mut harness = EthernetLinkHarness::new(engine, link);
 
         harness.run_steps([par!([
-            seq!([send_rx_a!(value), expect_tx_a!(value),]),
-            expect_no_traffic!(&[Port::TxB], ethernet_link::DELAY_TICKS as u64),
+            send_rx_a!(value),
+            seq!([
+                expect_no_traffic!(
+                    &[Port::TxA, Port::TxB],
+                    (ethernet_link::DELAY_TICKS - 1) as u64
+                ),
+                expect_tx_a!(value),
+            ]),
         ])]);
 
         assert_eq!(
@@ -134,10 +140,12 @@ mod ethernet_link_harness {
 
         harness.run_steps([par!([
             seq!(vec![send_rx_a!(frame.clone()); num_puts]),
-            seq!(vec![expect_tx_a!(frame); num_puts]),
-            expect_no_traffic!(&[Port::TxB], expected_ticks as u64),
+            seq!([
+                seq!(vec![expect_tx_a!(frame); num_puts]),
+                expect_no_traffic!(&[Port::TxA, Port::TxB], 1),
+            ]),
         ])]);
 
-        assert_eq!(harness.clock.tick_now().tick(), expected_ticks as u64);
+        assert_eq!(harness.clock.tick_now().tick(), expected_ticks as u64 + 1);
     }
 }

--- a/gwr-models/tests/ethernet_link.rs
+++ b/gwr-models/tests/ethernet_link.rs
@@ -2,167 +2,142 @@
 
 use std::rc::Rc;
 
-use gwr_components::sink::Sink;
-use gwr_components::source::Source;
-use gwr_components::{connect_port, option_box_repeat};
-use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
-use gwr_engine::time::clock::Clock;
 use gwr_models::ethernet_frame::{EthernetFrame, FRAME_OVERHEAD_BYTES};
 use gwr_models::ethernet_link::{self, EthernetLink};
-use gwr_track::entity::GetEntity;
 
-fn run_test(
-    num_put_a: usize,
-    num_put_b: usize,
-    payload_bytes: usize,
-) -> (Rc<Sink<EthernetFrame>>, Rc<Sink<EthernetFrame>>, Clock) {
-    let mut engine = start_test(file!());
+mod ethernet_link_harness {
+    use gwr_components::build_component_harness;
 
-    let clock = engine.clock_ghz(1.0);
-    let top = engine.top();
+    use super::*;
 
-    let source_a = Source::new_and_register(&engine, top, "src_a", None);
-    let frame_a = EthernetFrame::new(source_a.entity(), payload_bytes);
-    source_a.set_generator(option_box_repeat!(frame_a; num_put_a));
+    build_component_harness! {
+        harness EthernetLinkHarness<T> {
+            component: link: Rc<EthernetLink<T>>,
+            rx ports: {
+                RxA<T> => rx_a,
+                RxB<T> => rx_b,
+            },
+            tx ports: {
+                TxA<T> => tx_a,
+                TxB<T> => tx_b,
+            },
+        }
+    }
+    #[test]
+    fn change_delay() {
+        let delay_ticks = 100;
+        let value = 42;
 
-    let source_b = Source::new_and_register(&engine, top, "src_b", None);
-    let frame_b = EthernetFrame::new(source_b.entity(), payload_bytes);
-    source_b.set_generator(option_box_repeat!(frame_b; num_put_b));
+        let mut engine = start_test(file!());
+        let clock = engine.clock_ghz(1.0);
+        let top = engine.top();
 
-    let link = EthernetLink::new_and_register(&engine, &clock, top, "link").unwrap();
+        let link = EthernetLink::<i32>::new_and_register(&engine, &clock, top, "link").unwrap();
+        link.set_delay(delay_ticks).unwrap();
 
-    let sink_a = Sink::new_and_register(&engine, &clock, top, "sink_a");
-    let sink_b = Sink::new_and_register(&engine, &clock, top, "sink_b");
+        let mut harness = EthernetLinkHarness::new(engine, link);
 
-    connect_port!(source_a, tx => link, rx_a).unwrap();
-    connect_port!(source_b, tx => link, rx_b).unwrap();
-    connect_port!(link, tx_a => sink_a, rx).unwrap();
-    connect_port!(link, tx_b => sink_b, rx).unwrap();
+        harness.run_steps([send_rx_a!(value), expect_tx_a!(value)]);
 
-    run_simulation!(engine);
-    (sink_a, sink_b, clock)
-}
+        assert_eq!(harness.clock.time_now_ns(), delay_ticks as f64);
+    }
 
-#[test]
-fn source_sink() {
-    let num_puts_a = 100;
-    let num_puts_b = 50;
-    let (sink_a, sink_b, _) = run_test(num_puts_a, num_puts_b, 128);
+    #[test]
+    fn latency() {
+        let value = 42;
 
-    let num_sunk = sink_a.num_sunk();
-    assert_eq!(num_sunk, num_puts_a);
+        let mut engine = start_test(file!());
+        let clock = engine.clock_ghz(1.0);
+        let top = engine.top();
 
-    let num_sunk = sink_b.num_sunk();
-    assert_eq!(num_sunk, num_puts_b);
-}
+        let link = EthernetLink::<i32>::new_and_register(&engine, &clock, top, "link").unwrap();
 
-#[test]
-fn latency() {
-    let num_puts_a = 1;
-    let num_puts_b = 0;
-    let (sink_a, sink_b, clock) = run_test(num_puts_a, num_puts_b, 128);
+        let mut harness = EthernetLinkHarness::new(engine, link);
 
-    let num_sunk = sink_a.num_sunk();
-    assert_eq!(num_sunk, num_puts_a);
+        harness.run_steps([par!([
+            seq!([send_rx_a!(value), expect_tx_a!(value),]),
+            expect_no_traffic!(&[Port::TxB], ethernet_link::DELAY_TICKS as u64),
+        ])]);
 
-    let num_sunk = sink_b.num_sunk();
-    assert_eq!(num_sunk, num_puts_b);
+        assert_eq!(
+            harness.clock.time_now_ns(),
+            ethernet_link::DELAY_TICKS as f64
+        );
+    }
 
-    let expected_time = ethernet_link::DELAY_TICKS as f64;
-    assert_eq!(clock.time_now_ns(), expected_time);
-}
+    #[test]
+    fn source_sink() {
+        let num_puts_a = 100;
+        let num_puts_b = 50;
+        let value_a = 42;
+        let value_b = 43;
 
-#[test]
-fn throughput() {
-    let num_puts_a = 1000;
-    let num_puts_b = 0;
-    let payload_bytes: usize = 128;
-    let (sink_a, sink_b, clock) = run_test(num_puts_a, num_puts_b, payload_bytes);
+        let mut engine = start_test(file!());
+        let clock = engine.clock_ghz(1.0);
+        let top = engine.top();
 
-    let num_sunk = sink_a.num_sunk();
-    assert_eq!(num_sunk, num_puts_a);
+        let link = EthernetLink::<i32>::new_and_register(&engine, &clock, top, "link").unwrap();
 
-    let num_sunk = sink_b.num_sunk();
-    assert_eq!(num_sunk, num_puts_b);
+        let mut harness = EthernetLinkHarness::new(engine, link);
 
-    let latency = ethernet_link::DELAY_TICKS as f64;
-    let frame_bits = (payload_bytes + FRAME_OVERHEAD_BYTES) * 8;
-    let frame_ticks = frame_bits.div_ceil(ethernet_link::BITS_PER_TICK);
+        harness.run_steps([
+            par!([
+                seq!(vec![send_rx_a!(value_a); num_puts_a]),
+                seq!(vec![send_rx_b!(value_b); num_puts_b]),
+                seq!(vec![expect_tx_a!(value_a); num_puts_a]),
+                seq!(vec![expect_tx_b!(value_b); num_puts_b]),
+            ]),
+            expect_no_traffic!(&[Port::TxA, Port::TxB], 1),
+        ]);
+    }
 
-    // Assume each tick is 1ns (1GHz clock) and that the throughput of the last
-    // frame doesn't need to be counted
-    let frames_time = (frame_ticks * (num_puts_a - 1)) as f64;
-    assert_eq!(clock.time_now_ns(), (latency + frames_time));
-}
+    #[test]
+    fn change_delay_after_simulation_started_errors() {
+        let delay_ticks = 100;
 
-#[test]
-fn change_delay() {
-    const DELAY_TICKS: usize = 100;
+        let mut engine = start_test(file!());
+        let clock = engine.clock_ghz(1.0);
+        let top = engine.top();
 
-    let mut engine = start_test(file!());
+        let link = EthernetLink::<i32>::new_and_register(&engine, &clock, top, "link").unwrap();
+        let mut harness = EthernetLinkHarness::new(engine, link);
 
-    let clock = engine.clock_ghz(1.0);
-    let top = engine.top();
+        // Starting the simulation causes the component to take ownership of its ports.
+        harness.run_steps([delay!(1)]);
 
-    let source_a = Source::new_and_register(&engine, top, "src_a", None);
-    let etwr = EthernetFrame::new(source_a.entity(), 128);
-    source_a.set_generator(option_box_repeat!(etwr; 1));
+        let error = harness.link.set_delay(delay_ticks).unwrap_err();
 
-    let source_b = Source::new_and_register(&engine, top, "src_b", None);
+        assert_eq!(
+            format!("{error}"),
+            "top::link::a: can't change the delay after the simulation has started"
+        );
+    }
 
-    let link = EthernetLink::new_and_register(&engine, &clock, top, "link").unwrap();
-    link.set_delay(DELAY_TICKS).unwrap();
+    #[test]
+    fn throughput() {
+        let num_puts = 1000;
+        let payload_bytes = 128;
 
-    let sink_a = Sink::new_and_register(&engine, &clock, top, "sink_a");
-    let sink_b = Sink::new_and_register(&engine, &clock, top, "sink_b");
+        let mut engine = start_test(file!());
+        let clock = engine.clock_ghz(1.0);
+        let top = engine.top();
 
-    connect_port!(source_a, tx => link, rx_a).unwrap();
-    connect_port!(source_b, tx => link, rx_b).unwrap();
-    connect_port!(link, tx_a => sink_a, rx).unwrap();
-    connect_port!(link, tx_b => sink_b, rx).unwrap();
+        let frame = EthernetFrame::new(top, payload_bytes);
+        let link =
+            EthernetLink::<EthernetFrame>::new_and_register(&engine, &clock, top, "link").unwrap();
+        let mut harness = EthernetLinkHarness::new(engine, link);
 
-    run_simulation!(engine);
+        let frame_bits = (payload_bytes + FRAME_OVERHEAD_BYTES) * 8;
+        let frame_ticks = frame_bits.div_ceil(ethernet_link::BITS_PER_TICK);
+        let expected_ticks = ethernet_link::DELAY_TICKS + frame_ticks * (num_puts - 1);
 
-    let num_sunk = sink_a.num_sunk();
-    assert_eq!(num_sunk, 1);
+        harness.run_steps([par!([
+            seq!(vec![send_rx_a!(frame.clone()); num_puts]),
+            seq!(vec![expect_tx_a!(frame); num_puts]),
+            expect_no_traffic!(&[Port::TxB], expected_ticks as u64),
+        ])]);
 
-    let expected_time = DELAY_TICKS as f64;
-    assert_eq!(clock.time_now_ns(), expected_time);
-}
-
-#[test]
-fn change_delay_after_simulation_started_errors() {
-    const DELAY_TICKS: usize = 100;
-
-    let mut engine = start_test(file!());
-
-    let clock = engine.clock_ghz(1.0);
-    let top = engine.top();
-
-    let source_a = Source::new_and_register(&engine, top, "src_a", None);
-    let frame_a = EthernetFrame::new(source_a.entity(), 128);
-    source_a.set_generator(option_box_repeat!(frame_a; 1));
-
-    let source_b = Source::new_and_register(&engine, top, "src_b", None);
-
-    let link = EthernetLink::new_and_register(&engine, &clock, top, "link").unwrap();
-
-    let sink_a = Sink::new_and_register(&engine, &clock, top, "sink_a");
-    let sink_b = Sink::new_and_register(&engine, &clock, top, "sink_b");
-
-    connect_port!(source_a, tx => link, rx_a).unwrap();
-    connect_port!(source_b, tx => link, rx_b).unwrap();
-    connect_port!(link, tx_a => sink_a, rx).unwrap();
-    connect_port!(link, tx_b => sink_b, rx).unwrap();
-
-    engine.spawn(async move {
-        clock.wait_ticks(1).await;
-        link.set_delay(DELAY_TICKS)
-    });
-
-    run_simulation!(
-        engine,
-        "top::link::a: can't change the delay after the simulation has started"
-    );
+        assert_eq!(harness.clock.tick_now().tick(), expected_ticks as u64);
+    }
 }

--- a/gwr-models/tests/memory.rs
+++ b/gwr-models/tests/memory.rs
@@ -70,24 +70,27 @@ mod memory_harness {
 
         let mut harness = MemoryHarness::new(engine, memory.clone());
 
-        harness.run_steps([par!([
-            seq!(vec![send_rx!(request); num_accesses]),
-            seq!(vec![
-                expect_tx!(
-                    MemoryTxn::read_rsp(DST_ADDR)
-                        .with_bytes(ACCESS_SIZE_BYTES)
-                        .with_total_bytes(ACCESS_SIZE_BYTES + OVERHEAD_SIZE_BYTES)
-                );
-                num_accesses
+        harness.run_steps([
+            par!([
+                seq!(vec![send_rx!(request); num_accesses]),
+                seq!(vec![
+                    expect_tx!(
+                        MemoryTxn::read_rsp(DST_ADDR)
+                            .with_bytes(ACCESS_SIZE_BYTES)
+                            .with_total_bytes(ACCESS_SIZE_BYTES + OVERHEAD_SIZE_BYTES)
+                    );
+                    num_accesses
+                ]),
             ]),
-        ])]);
+            expect_no_traffic!(&[Port::Tx], DELAY_TICKS as u64),
+        ]);
 
         assert_eq!(memory.bytes_read(), num_accesses * ACCESS_SIZE_BYTES);
         assert_eq!(memory.bytes_written(), 0);
 
         let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
         let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
-        let last_event_time = max(last_bw_limit_event, last_packet_ack);
+        let last_event_time = max(last_bw_limit_event, last_packet_ack) + DELAY_TICKS as u64;
 
         assert_eq!(harness.engine.time_now_ns(), last_event_time as f64);
     }
@@ -144,6 +147,7 @@ mod memory_harness {
         harness.run_steps([
             seq!(vec![send_rx!(request); num_accesses]),
             expect_no_traffic!(&[Port::Tx], CYCLES_PER_ACCESS),
+            expect_no_traffic!(&[Port::Tx], DELAY_TICKS as u64),
         ]);
 
         assert_eq!(memory.bytes_written(), num_accesses * ACCESS_SIZE_BYTES);
@@ -152,7 +156,7 @@ mod memory_harness {
         // Simulation will only complete once the Memory has finished handling all the
         // delay imposed by the data it is carrying
         let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
-        let last_event_time = last_bw_limit_event;
+        let last_event_time = last_bw_limit_event + DELAY_TICKS as u64;
         assert_eq!(harness.engine.time_now_ns(), last_event_time as f64);
     }
 
@@ -175,24 +179,27 @@ mod memory_harness {
 
         let mut harness = MemoryHarness::new(engine, memory.clone());
 
-        harness.run_steps([par!([
-            seq!(vec![send_rx!(request); num_accesses]),
-            seq!(vec![
-                expect_tx!(
-                    MemoryTxn::write_np_rsp(DST_ADDR)
-                        .with_bytes(ACCESS_SIZE_BYTES)
-                        .with_total_bytes(OVERHEAD_SIZE_BYTES)
-                );
-                num_accesses
+        harness.run_steps([
+            par!([
+                seq!(vec![send_rx!(request); num_accesses]),
+                seq!(vec![
+                    expect_tx!(
+                        MemoryTxn::write_np_rsp(DST_ADDR)
+                            .with_bytes(ACCESS_SIZE_BYTES)
+                            .with_total_bytes(OVERHEAD_SIZE_BYTES)
+                    );
+                    num_accesses
+                ]),
             ]),
-        ])]);
+            expect_no_traffic!(&[Port::Tx], DELAY_TICKS as u64),
+        ]);
 
         assert_eq!(memory.bytes_written(), num_accesses * ACCESS_SIZE_BYTES);
         assert_eq!(memory.bytes_read(), 0);
 
         let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
         let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
-        let last_event_time = max(last_bw_limit_event, last_packet_ack);
+        let last_event_time = max(last_bw_limit_event, last_packet_ack) + DELAY_TICKS as u64;
         assert_eq!(harness.engine.time_now_ns(), last_event_time as f64);
     }
 }

--- a/gwr-models/tests/memory.rs
+++ b/gwr-models/tests/memory.rs
@@ -3,21 +3,14 @@
 use std::cmp::max;
 use std::rc::Rc;
 
-use gwr_components::sink::Sink;
-use gwr_components::source::Source;
-use gwr_components::{connect_port, option_box_repeat};
 use gwr_engine::engine::Engine;
-use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 use gwr_engine::traits::SimObject;
-use gwr_models::memory::memory_access::MemoryAccess;
-use gwr_models::memory::memory_map::MemoryMap;
 use gwr_models::memory::traits::AccessMemory;
 use gwr_models::memory::{Memory, MemoryConfig};
 use gwr_models::test_helpers::{
     create_default_memory_map, create_read, create_write, create_write_np,
 };
-use gwr_track::entity::{Entity, GetEntity};
 
 const DST_ADDR: u64 = 0x80000;
 const SRC_ADDR: u64 = DST_ADDR + 0x1000;
@@ -40,85 +33,6 @@ where
     Memory::new_and_register(engine, &clock, top, "memory", config).unwrap()
 }
 
-#[expect(clippy::type_complexity)]
-fn setup_system(
-    num_accesses: usize,
-    create_fn: fn(&Rc<Entity>, &Rc<MemoryMap>, usize, u64, u64, usize) -> MemoryAccess,
-) -> (Engine, Rc<Sink<MemoryAccess>>, Rc<Memory<MemoryAccess>>) {
-    let mut engine = start_test(file!());
-    let clock = engine.default_clock();
-    let memory = create_memory(&mut engine);
-    let memory_map = Rc::new(create_default_memory_map());
-    let top = engine.top();
-
-    let source = Source::new_and_register(&engine, top, "source", None);
-    let to_put = create_fn(
-        source.entity(),
-        &memory_map,
-        ACCESS_SIZE_BYTES,
-        DST_ADDR,
-        SRC_ADDR,
-        OVERHEAD_SIZE_BYTES,
-    );
-    source.set_generator(option_box_repeat!(to_put ; num_accesses));
-
-    let sink = Sink::new_and_register(&engine, &clock, top, "sink");
-
-    connect_port!(source, tx => memory, rx).unwrap();
-    connect_port!(memory, tx => sink, rx).unwrap();
-
-    (engine, sink, memory)
-}
-
-#[test]
-fn memory_read() {
-    let num_accesses = 100;
-    let (mut engine, sink, memory) = setup_system(num_accesses, create_read);
-
-    run_simulation!(engine);
-    assert_eq!(sink.num_sunk(), num_accesses);
-    assert_eq!(memory.bytes_read(), (num_accesses * ACCESS_SIZE_BYTES));
-    assert_eq!(memory.bytes_written(), 0);
-
-    let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
-    let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
-    let last_event_time = max(last_bw_limit_event, last_packet_ack);
-    assert_eq!(engine.time_now_ns(), last_event_time as f64);
-}
-
-#[test]
-fn memory_write() {
-    let num_accesses = 100;
-    let (mut engine, sink, memory) = setup_system(num_accesses, create_write);
-
-    run_simulation!(engine);
-    assert_eq!(sink.num_sunk(), 0);
-    assert_eq!(memory.bytes_written(), num_accesses * ACCESS_SIZE_BYTES);
-    assert_eq!(memory.bytes_read(), 0);
-
-    // Simulation will only complete once the Memory has finished handling all the
-    // delay imposed by the data it is carrying
-    let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
-    let last_event_time = last_bw_limit_event;
-    assert_eq!(engine.time_now_ns(), last_event_time as f64);
-}
-
-#[test]
-fn memory_write_np() {
-    let num_accesses = 100;
-    let (mut engine, sink, memory) = setup_system(num_accesses, create_write_np);
-
-    run_simulation!(engine);
-
-    assert_eq!(sink.num_sunk(), num_accesses);
-    assert_eq!(memory.bytes_written(), num_accesses * ACCESS_SIZE_BYTES);
-    assert_eq!(memory.bytes_read(), 0);
-
-    let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
-    let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
-    let last_event_time = max(last_bw_limit_event, last_packet_ack);
-    assert_eq!(engine.time_now_ns(), last_event_time as f64);
-}
 mod memory_harness {
     use gwr_models::build_model_harness;
     use gwr_models::test_helpers::MemoryTxn;
@@ -135,6 +49,47 @@ mod memory_harness {
                 Tx<T> => tx,
             },
         }
+    }
+
+    #[test]
+    fn memory_read() {
+        let num_accesses = 100;
+
+        let mut engine = start_test(file!());
+        let memory = create_memory(&mut engine);
+        let memory_map = Rc::new(create_default_memory_map());
+
+        let request = create_read(
+            engine.top(),
+            &memory_map,
+            ACCESS_SIZE_BYTES,
+            DST_ADDR,
+            SRC_ADDR,
+            OVERHEAD_SIZE_BYTES,
+        );
+
+        let mut harness = MemoryHarness::new(engine, memory.clone());
+
+        harness.run_steps([par!([
+            seq!(vec![send_rx!(request); num_accesses]),
+            seq!(vec![
+                expect_tx!(
+                    MemoryTxn::read_rsp(DST_ADDR)
+                        .with_bytes(ACCESS_SIZE_BYTES)
+                        .with_total_bytes(ACCESS_SIZE_BYTES + OVERHEAD_SIZE_BYTES)
+                );
+                num_accesses
+            ]),
+        ])]);
+
+        assert_eq!(memory.bytes_read(), num_accesses * ACCESS_SIZE_BYTES);
+        assert_eq!(memory.bytes_written(), 0);
+
+        let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
+        let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
+        let last_event_time = max(last_bw_limit_event, last_packet_ack);
+
+        assert_eq!(harness.engine.time_now_ns(), last_event_time as f64);
     }
 
     #[test]
@@ -165,5 +120,79 @@ mod memory_harness {
         ]);
 
         assert_eq!(harness.engine.time_now_ns(), DELAY_TICKS as f64);
+    }
+
+    #[test]
+    fn memory_write() {
+        let num_accesses = 100;
+
+        let mut engine = start_test(file!());
+        let memory = create_memory(&mut engine);
+        let memory_map = Rc::new(create_default_memory_map());
+
+        let request = create_write(
+            engine.top(),
+            &memory_map,
+            ACCESS_SIZE_BYTES,
+            DST_ADDR,
+            SRC_ADDR,
+            OVERHEAD_SIZE_BYTES,
+        );
+
+        let mut harness = MemoryHarness::new(engine, memory.clone());
+
+        harness.run_steps([
+            seq!(vec![send_rx!(request); num_accesses]),
+            expect_no_traffic!(&[Port::Tx], CYCLES_PER_ACCESS),
+        ]);
+
+        assert_eq!(memory.bytes_written(), num_accesses * ACCESS_SIZE_BYTES);
+        assert_eq!(memory.bytes_read(), 0);
+
+        // Simulation will only complete once the Memory has finished handling all the
+        // delay imposed by the data it is carrying
+        let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
+        let last_event_time = last_bw_limit_event;
+        assert_eq!(harness.engine.time_now_ns(), last_event_time as f64);
+    }
+
+    #[test]
+    fn memory_write_np() {
+        let num_accesses = 100;
+
+        let mut engine = start_test(file!());
+        let memory = create_memory(&mut engine);
+        let memory_map = Rc::new(create_default_memory_map());
+
+        let request = create_write_np(
+            engine.top(),
+            &memory_map,
+            ACCESS_SIZE_BYTES,
+            DST_ADDR,
+            SRC_ADDR,
+            OVERHEAD_SIZE_BYTES,
+        );
+
+        let mut harness = MemoryHarness::new(engine, memory.clone());
+
+        harness.run_steps([par!([
+            seq!(vec![send_rx!(request); num_accesses]),
+            seq!(vec![
+                expect_tx!(
+                    MemoryTxn::write_np_rsp(DST_ADDR)
+                        .with_bytes(ACCESS_SIZE_BYTES)
+                        .with_total_bytes(OVERHEAD_SIZE_BYTES)
+                );
+                num_accesses
+            ]),
+        ])]);
+
+        assert_eq!(memory.bytes_written(), num_accesses * ACCESS_SIZE_BYTES);
+        assert_eq!(memory.bytes_read(), 0);
+
+        let last_bw_limit_event = CYCLES_PER_ACCESS * num_accesses as u64;
+        let last_packet_ack = CYCLES_PER_ACCESS * ((num_accesses - 1) as u64) + DELAY_TICKS as u64;
+        let last_event_time = max(last_bw_limit_event, last_packet_ack);
+        assert_eq!(harness.engine.time_now_ns(), last_event_time as f64);
     }
 }


### PR DESCRIPTION
Follow-up to #275, continuing #266.

Converted more tests to use `TestHarness`.

`EthernetFrame` now derives `PartialEq` so the harness can verify forwarded frames exactly.