### PR TITLE
Rust dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
  "gwr-perfetto",
  "lazy_static",
  "log",
- "num-derive",
+ "num-derive 0.5.1",
  "num-traits",
  "prost",
  "rand 0.9.5",
@@ -2025,6 +2025,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3466,7 +3477,7 @@ dependencies = [
  "log",
  "memmem",
  "nix",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "ordered-float",
  "pest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,18 +333,18 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "capnp"
-version = "0.25.6"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4777a3bc19b8f8e5fb2d0196c6b5dfcbbcc8b2fe08ae57f873f2f35f15cfc210"
+checksum = "58ddce707ad9fb2ae92770523cd0e17a0cf34e79b66a9ca4db2dd993535fe718"
 dependencies = [
  "embedded-io",
 ]
 
 [[package]]
 name = "capnpc"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca02be865c8c5a78bfc24b9819006ab6b59bef238467203928e26459557af93"
+checksum = "13aea06b902f885cb0313b11e900e96cd57fef775e9e601a96e14e1d655f3cd3"
 dependencies = [
  "capnp",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "check-copyright"
 version = "1.0.0"
 dependencies = [
@@ -519,6 +530,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -965,7 +985,7 @@ dependencies = [
  "gwr-engine",
  "gwr-model-builder",
  "gwr-track",
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -978,7 +998,7 @@ dependencies = [
  "gwr-engine",
  "gwr-model-builder",
  "gwr-track",
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1148,6 +1168,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1226,7 +1247,7 @@ dependencies = [
  "gwr-track",
  "log",
  "paste",
- "rand 0.9.5",
+ "rand 0.10.2",
  "trybuild",
 ]
 
@@ -1287,7 +1308,7 @@ dependencies = [
  "gwr-track",
  "log",
  "mimalloc",
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1319,7 +1340,7 @@ dependencies = [
  "gwr-track",
  "log",
  "paste",
- "rand 0.9.5",
+ "rand 0.10.2",
  "serde",
 ]
 
@@ -1431,7 +1452,7 @@ dependencies = [
  "gwr-track",
  "indicatif",
  "log",
- "rand 0.9.5",
+ "rand 0.10.2",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -1452,7 +1473,7 @@ dependencies = [
  "num-derive 0.5.1",
  "num-traits",
  "prost",
- "rand 0.9.5",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serial_test",
@@ -2528,18 +2549,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.5"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2553,16 +2575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,20 +2585,17 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3123,7 +3132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3186,7 +3195,7 @@ dependencies = [
  "gwr-track",
  "indicatif",
  "log",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rand_xoshiro",
  "serde",
 ]
@@ -3218,7 +3227,7 @@ dependencies = [
  "gwr-engine",
  "gwr-track",
  "log",
- "rand 0.9.5",
+ "rand 0.10.2",
  "ratatui",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
  "regex",
  "serde",
  "serial_test",
- "syn 2.0.119",
+ "syn 3.0.3",
  "trybuild",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-stream"
@@ -142,7 +142,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -230,9 +230,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -262,22 +262,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "by_address"
@@ -321,30 +321,30 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "capnp"
-version = "0.25.2"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c982cc37b8f646c753f3b0a24d4d40ca2eac8a9c2b9ea6fff524be67ddc184cb"
+checksum = "4777a3bc19b8f8e5fb2d0196c6b5dfcbbcc8b2fe08ae57f873f2f35f15cfc210"
 dependencies = [
  "embedded-io",
 ]
 
 [[package]]
 name = "capnpc"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6cdfa6b0df161a71201367910265b97180541ecdb48bd08e05ef8694c295d1f"
+checksum = "fca02be865c8c5a78bfc24b9819006ab6b59bef238467203928e26459557af93"
 dependencies = [
  "capnp",
 ]
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -382,9 +382,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "check-copyright"
@@ -470,9 +470,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -566,9 +566,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -662,7 +662,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -673,7 +673,38 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -687,9 +718,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_more"
@@ -710,7 +738,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -743,7 +771,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -773,9 +801,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "either-or-both"
@@ -874,9 +902,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "figment"
@@ -937,7 +965,7 @@ dependencies = [
  "gwr-engine",
  "gwr-model-builder",
  "gwr-track",
- "rand 0.9.2",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -950,7 +978,7 @@ dependencies = [
  "gwr-engine",
  "gwr-model-builder",
  "gwr-track",
- "rand 0.9.2",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -979,9 +1007,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -994,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1004,15 +1032,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1021,38 +1049,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1113,22 +1141,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gungraun"
@@ -1155,7 +1181,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1200,7 +1226,7 @@ dependencies = [
  "gwr-track",
  "log",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.5",
  "trybuild",
 ]
 
@@ -1215,7 +1241,7 @@ dependencies = [
  "regex",
  "serde",
  "serial_test",
- "syn 2.0.117",
+ "syn 2.0.119",
  "trybuild",
 ]
 
@@ -1261,7 +1287,7 @@ dependencies = [
  "gwr-track",
  "log",
  "mimalloc",
- "rand 0.9.2",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -1293,7 +1319,7 @@ dependencies = [
  "gwr-track",
  "log",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
 ]
 
@@ -1405,7 +1431,7 @@ dependencies = [
  "gwr-track",
  "indicatif",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -1426,7 +1452,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "prost",
- "rand 0.9.2",
+ "rand 0.9.5",
  "regex",
  "serde",
  "serial_test",
@@ -1535,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1591,12 +1617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,12 +1624,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1652,7 +1672,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1698,10 +1718,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1710,23 +1732,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.23"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1738,7 +1771,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1754,16 +1787,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1783,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -1865,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmem"
@@ -1907,9 +1934,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -1926,7 +1953,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "httparse",
  "memchr",
  "mime",
@@ -1976,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -1988,7 +2015,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2077,7 +2104,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2135,7 +2162,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2146,9 +2173,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2156,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2166,25 +2193,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -2225,7 +2251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -2238,7 +2264,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2286,15 +2312,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -2321,7 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2330,7 +2356,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.6+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2372,7 +2398,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -2402,7 +2428,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -2416,7 +2442,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2477,9 +2503,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2488,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2584,7 +2610,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -2655,9 +2681,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2684,22 +2710,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2790,7 +2816,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.7",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -2818,7 +2844,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
  "version_check",
 ]
@@ -2852,18 +2878,19 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rkyv",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2890,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2911,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2953,15 +2980,15 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2969,22 +2996,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3011,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3091,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -3139,7 +3166,7 @@ dependencies = [
  "gwr-track",
  "indicatif",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_xoshiro",
  "serde",
 ]
@@ -3171,7 +3198,7 @@ dependencies = [
  "gwr-engine",
  "gwr-track",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "ratatui",
 ]
 
@@ -3208,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3220,9 +3247,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -3236,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3246,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable-pattern"
@@ -3307,7 +3334,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3323,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3351,9 +3378,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
@@ -3362,7 +3389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3464,11 +3491,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -3479,37 +3506,36 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -3521,15 +3547,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3547,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3562,36 +3588,36 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3600,13 +3626,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3625,17 +3652,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3649,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -3672,23 +3699,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.6+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db3bae107c9522f86d361697dee1d7386a2ddcf659d5aea5159819a21a3c4a7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3699,9 +3726,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower-service"
@@ -3728,7 +3755,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3788,14 +3815,14 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ubyte"
@@ -3830,9 +3857,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -3877,9 +3904,9 @@ checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
 
 [[package]]
 name = "utf8parse"
@@ -3889,12 +3916,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic 0.6.1",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3956,27 +3983,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3987,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3997,65 +4015,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4339,100 +4323,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"
@@ -4454,26 +4356,26 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
  "clap",
  "crossterm",
  "gwr-track",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "ratatui",
  "regex",
@@ -1706,6 +1706,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ proc-macro2 = "1.0.69"
 prost = "0.14.1"
 prost-build = "0.14.1"
 quote = "1.0.33"
-rand = "0.9.2"
+rand = "0.10.2"
 ratatui = "0.30.0"
 regex = "1.9.6"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ figment = { version = "0.10.19", features = ["env", "toml"] }
 futures = "0.3.28"
 gungraun = "0.19.4"
 indicatif = "0.18.0"
-itertools = "0.14.0"
+itertools = "0.15.0"
 log = { version = "0.4.20", features = ["serde", "std"] }
 num = "0.4.1"
 num-derive = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ indicatif = "0.18.0"
 itertools = "0.15.0"
 log = { version = "0.4.20", features = ["serde", "std"] }
 num = "0.4.1"
-num-derive = "0.4.1"
+num-derive = "0.5.1"
 num-traits = "0.2"
 paste = "1.0.14"
 proc-macro2 = "1.0.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ publish = true
 approx = "0.5.1"
 async-trait = "0.1.88"
 byte-unit = "5.1.6"
-capnp = "0.25.0"
-capnpc = "0.25.0"
+capnp = "0.26.2"
+capnpc = "0.26.0"
 cfg-if = "1.0.4"
 clap = { version = "4.4.6", features = ["derive"] }
 criterion = "0.8.2"

--- a/examples/flaky-component/src/lib.rs
+++ b/examples/flaky-component/src/lib.rs
@@ -34,7 +34,7 @@ use gwr_track::trace;
 /// Random library is just used by this component to implement its drop
 /// decisions.
 use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 
 // ANCHOR_END: use
 

--- a/examples/flaky-with-delay/src/lib.rs
+++ b/examples/flaky-with-delay/src/lib.rs
@@ -40,7 +40,7 @@ use gwr_track::{build_aka, trace};
 /// Random library is just used by this component to implement its drop
 /// decisions.
 use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 
 /// A struct containing configuration options for the component
 pub struct Config {

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -28,6 +28,6 @@ gwr-models = { path = "../../gwr-models", version = "0.20.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true
-rand_xoshiro = "0.7.0"
+rand_xoshiro = "0.8.1"
 rand.workspace = true
 serde.workspace = true

--- a/examples/sim-restaurant/src/customer.rs
+++ b/examples/sim-restaurant/src/customer.rs
@@ -12,7 +12,7 @@ use gwr_engine::time::clock::Clock;
 use gwr_engine::traits::Event;
 use gwr_engine::types::SimResult;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 use crate::config::RestaurantConfig;
 use crate::menu::choose_order_index;

--- a/examples/sim-restaurant/src/menu.rs
+++ b/examples/sim-restaurant/src/menu.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Graphcore Ltd. All rights reserved.
 
-use rand::Rng;
+use rand::RngExt;
 use rand::rngs::StdRng;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/gwr-config/Cargo.toml
+++ b/gwr-config/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 regex.workspace = true
-syn = { version = "2.0.114", features = ["derive", "extra-traits", "full"] }
+syn = { version = "3.0.3", features = ["derive", "extra-traits", "full"] }
 
 [dev-dependencies]
 clap.workspace = true

--- a/gwr-models/src/memory/memory_access_gen/random.rs
+++ b/gwr-models/src/memory/memory_access_gen/random.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use gwr_engine::types::AccessType;
 use gwr_track::entity::Entity;
 use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 
 use crate::memory::memory_access::MemoryAccess;
 use crate::memory::memory_map::MemoryMap;

--- a/gwr-models/src/processing_element/operators/add.rs
+++ b/gwr-models/src/processing_element/operators/add.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use gwr_engine::sim_error;
 use gwr_engine::types::{SimError, SimResult};
-use rand::Rng;
+use rand::RngExt;
 
 use super::{Operator, Shape, Tensor, TensorPartition};
 use crate::processing_element::operators::{
@@ -59,7 +59,7 @@ fn broadcast_shapes(a: &Shape, b: &Shape) -> Result<Shape, SimError> {
     Ok(Shape(result))
 }
 
-fn choose_input_shape(output: &Tensor, rng: &mut impl Rng, expand_ratio: f64) -> Shape {
+fn choose_input_shape(output: &Tensor, rng: &mut impl RngExt, expand_ratio: f64) -> Shape {
     let keep_prob = expand_ratio.clamp(0.0, 1.0);
     let mut dims = output.shape.0.clone();
 
@@ -129,7 +129,7 @@ impl OperatorAdd {
         &self,
         inputs: &[Option<Tensor>],
         _expand_ratio: f64,
-        _rng: &mut impl Rng,
+        _rng: &mut impl RngExt,
     ) -> Result<Vec<Option<Tensor>>, gwr_engine::types::SimError> {
         let (input_a, input_b) = validate_inputs(inputs)?;
 
@@ -152,7 +152,7 @@ impl OperatorAdd {
         &self,
         outputs: &[Option<Tensor>],
         expand_ratio: f64,
-        rng: &mut impl Rng,
+        rng: &mut impl RngExt,
     ) -> Result<Vec<Option<Tensor>>, gwr_engine::types::SimError> {
         let output = validate_outputs(outputs)?;
 
@@ -263,7 +263,9 @@ impl Operator for OperatorAdd {
 
 #[cfg(test)]
 mod tests {
-    use rand::RngCore;
+    use std::convert::Infallible;
+
+    use rand::TryRng;
 
     use super::*;
     use crate::processing_element::operators::dtype::DataType;
@@ -298,20 +300,23 @@ mod tests {
         }
     }
 
-    impl RngCore for FixedBoolRng {
-        fn next_u32(&mut self) -> u32 {
-            if self.next_bool() { 0 } else { u32::MAX }
+    impl TryRng for FixedBoolRng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(if self.next_bool() { 0 } else { u32::MAX })
         }
 
-        fn next_u64(&mut self) -> u64 {
-            if self.next_bool() { 0 } else { u64::MAX }
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            Ok(if self.next_bool() { 0 } else { u64::MAX })
         }
 
-        fn fill_bytes(&mut self, dst: &mut [u8]) {
+        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
             for chunk in dst.chunks_mut(size_of::<u64>()) {
-                let bytes = self.next_u64().to_le_bytes();
+                let bytes = self.try_next_u64()?.to_le_bytes();
                 chunk.copy_from_slice(&bytes[..chunk.len()]);
             }
+            Ok(())
         }
     }
 

--- a/gwr-models/src/processing_element/operators/gemm.rs
+++ b/gwr-models/src/processing_element/operators/gemm.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use gwr_engine::sim_error;
 use gwr_engine::types::{SimError, SimResult};
-use rand::Rng;
+use rand::RngExt;
 
 use super::{Operator, Tensor, TensorPartition};
 use crate::processing_element::operators::{
@@ -66,7 +66,7 @@ pub fn gemm_rhs_shape<T: HasShape>(input_a: &T) -> Result<Shape, SimError> {
 ///
 /// Starts with the maximum of M and N and then grows or shrinks depending
 /// on the `expand_ratio` specified
-fn choose_gemm_k(output: &Tensor, rng: &mut impl Rng, expand_ratio: f64) -> usize {
+fn choose_gemm_k(output: &Tensor, rng: &mut impl RngExt, expand_ratio: f64) -> usize {
     let m = get_inner_dim(output, OUTPUT_OFFSET_M);
     let n = get_inner_dim(output, OUTPUT_OFFSET_N);
     let reference = m.max(n);
@@ -81,7 +81,7 @@ fn choose_gemm_k(output: &Tensor, rng: &mut impl Rng, expand_ratio: f64) -> usiz
     }
 }
 
-fn should_add_input_c(rng: &mut impl Rng, expand_ratio: f64) -> bool {
+fn should_add_input_c(rng: &mut impl RngExt, expand_ratio: f64) -> bool {
     if !expand_ratio.is_finite() || expand_ratio <= 0.0 {
         false
     } else if expand_ratio >= 1.0 {
@@ -112,7 +112,7 @@ fn output_tensor_from_inputs(inputs: &[Option<Tensor>]) -> Result<Tensor, SimErr
 pub fn maybe_add_input_c(
     inputs: &mut Vec<Option<Tensor>>,
     expand_ratio: f64,
-    rng: &mut impl Rng,
+    rng: &mut impl RngExt,
 ) -> Result<bool, SimError> {
     if inputs.len() >= 3 || !should_add_input_c(rng, expand_ratio) {
         return Ok(false);
@@ -300,7 +300,7 @@ impl OperatorGemm {
         &self,
         inputs: &[Option<Tensor>],
         _expand_ratio: f64,
-        _rng: &mut impl Rng,
+        _rng: &mut impl RngExt,
     ) -> Result<Vec<Option<Tensor>>, gwr_engine::types::SimError> {
         Ok(vec![Some(output_tensor_from_inputs(inputs)?)])
     }
@@ -309,7 +309,7 @@ impl OperatorGemm {
         &self,
         outputs: &[Option<Tensor>],
         expand_ratio: f64,
-        rng: &mut impl Rng,
+        rng: &mut impl RngExt,
     ) -> Result<Vec<Option<Tensor>>, gwr_engine::types::SimError> {
         let output = validate_outputs(outputs)?;
 

--- a/gwr-models/src/processing_element/operators/maxpool.rs
+++ b/gwr-models/src/processing_element/operators/maxpool.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use gwr_engine::sim_error;
 use gwr_engine::types::{SimError, SimResult};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::{Operator, Shape, Tensor, TensorPartition};
@@ -529,7 +529,7 @@ fn validate_tensor_dtypes(input: &Tensor, output: &Tensor, indices: Option<&Tens
     Ok(())
 }
 
-fn should_add_indices_output(rng: &mut impl Rng, expand_ratio: f64) -> bool {
+fn should_add_indices_output(rng: &mut impl RngExt, expand_ratio: f64) -> bool {
     if !expand_ratio.is_finite() || expand_ratio <= 0.0 {
         false
     } else if expand_ratio >= 1.0 {
@@ -542,7 +542,7 @@ fn should_add_indices_output(rng: &mut impl Rng, expand_ratio: f64) -> bool {
 pub fn maybe_add_indices_output(
     outputs: &mut Vec<Option<Tensor>>,
     expand_ratio: f64,
-    rng: &mut impl Rng,
+    rng: &mut impl RngExt,
 ) -> Result<bool, SimError> {
     if outputs.len() >= 2 || !should_add_indices_output(rng, expand_ratio) {
         return Ok(false);
@@ -667,7 +667,7 @@ impl OperatorMaxPool {
         &self,
         inputs: &[Option<Tensor>],
         expand_ratio: f64,
-        rng: &mut impl Rng,
+        rng: &mut impl RngExt,
     ) -> Result<Vec<Option<Tensor>>, SimError> {
         let input = validate_inputs(inputs)?;
         let (output_shape, _) = self.output_shape_and_resolved_params(input)?;
@@ -686,7 +686,7 @@ impl OperatorMaxPool {
         &self,
         outputs: &[Option<Tensor>],
         _expand_ratio: f64,
-        _rng: &mut impl Rng,
+        _rng: &mut impl RngExt,
     ) -> Result<Vec<Option<Tensor>>, SimError> {
         let (output, indices) = validate_outputs(outputs)?;
         if let Some(indices) = indices

--- a/licenses.html
+++ b/licenses.html
@@ -7269,8 +7269,8 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnp 0.25.6</a></li>
-                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnpc 0.25.3</a></li>
+                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnp 0.26.2</a></li>
+                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnpc 0.26.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2013-2018 Sandstorm Development Group, Inc. and contributors
 

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (246)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (243)</li>
             <li><a href="#MIT">MIT License</a> (109)</li>
             <li><a href="#Zlib">zlib License</a> (2)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
@@ -5221,13 +5221,11 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.6</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.4+wasi-0.2.12</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.126</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.126</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.126</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.126</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.103</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.57.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5424,6 +5422,216 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.1</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.3.0</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
@@ -5650,8 +5858,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-random/rand_core ">rand_core 0.10.1</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.5</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5847,7 +6055,6 @@ APPENDIX: How to apply the Apache License to your work.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
-                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.3</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                 </ul>
@@ -6860,12 +7067,10 @@ limitations under the License.
                     <li><a href=" https://github.com/SergioBenitez/proc-macro2-diagnostics ">proc-macro2-diagnostics 0.10.1</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.107</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.47</a></li>
-                    <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 6.0.0</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.10.2</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand 0.8.7</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
-                    <li><a href=" https://github.com/rust-random/rngs ">rand_xoshiro 0.7.0</a></li>
+                    <li><a href=" https://github.com/rust-random/rngs ">rand_xoshiro 0.8.1</a></li>
                     <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast-impl 1.0.26</a></li>
                     <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast 1.0.26</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.23</a></li>

--- a/licenses.html
+++ b/licenses.html
@@ -44,8 +44,8 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (246)</li>
-            <li><a href="#MIT">MIT License</a> (108)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (245)</li>
+            <li><a href="#MIT">MIT License</a> (109)</li>
             <li><a href="#Zlib">zlib License</a> (2)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
@@ -459,216 +459,6 @@
       identification within third-party archives.
 
    Copyright 2023 Bincode 
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.0</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2023 Jacob Pratt
 
    Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
    you may not use this file except in compliance with the License.
@@ -1548,8 +1338,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.47</a></li>
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.47</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.55</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.55</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -1968,7 +1758,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/joshka/line-clipping ">line-clipping 0.3.5</a></li>
+                    <li><a href=" https://github.com/ratatui/line-clipping ">line-clipping 0.3.7</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2821,15 +2611,15 @@
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
                     <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                     <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 0.6.9</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 1.1.1</a></li>
                     <li><a href=" https://github.com/toml-rs/toml ">toml 0.8.23</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.0+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.4+spec-1.1.0</a></li>
                     <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.6.11</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.0+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
                     <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.22.27</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.0+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.3+spec-1.1.0</a></li>
                     <li><a href=" https://github.com/toml-rs/toml ">toml_write 0.1.2</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.1.0+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.1.2+spec-1.1.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3248,15 +3038,15 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.33</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.33</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4097,7 +3887,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/http ">http 0.2.12</a></li>
-                    <li><a href=" https://github.com/hyperium/http ">http 1.4.0</a></li>
+                    <li><a href=" https://github.com/hyperium/http ">http 1.5.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5351,40 +5141,40 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.2</a></li>
-                    <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
+                    <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.8</a></li>
                     <li><a href=" https://github.com/Amanieu/atomic-rs ">atomic 0.5.3</a></li>
                     <li><a href=" https://github.com/Amanieu/atomic-rs ">atomic 0.6.1</a></li>
-                    <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
+                    <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.1</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.13.1</a></li>
-                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
+                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.3</a></li>
                     <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.57</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.4.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                     <li><a href=" https://github.com/criterion-rs/criterion.rs ">criterion-plot 0.8.2</a></li>
                     <li><a href=" https://github.com/criterion-rs/criterion.rs ">criterion 0.8.2</a></li>
                     <li><a href=" https://github.com/rust-embedded/critical-section ">critical-section 1.2.0</a></li>
-                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
+                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.7</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.20</a></li>
-                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.21</a></li>
-                    <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
+                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.22</a></li>
+                    <li><a href=" https://github.com/rayon-rs/either ">either 1.17.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
-                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.5.0</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
-                    <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
+                    <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.4</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.1</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.13.0</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.14.0</a></li>
                     <li><a href=" https://github.com/fitzgen/inlinable_string ">inlinable_string 0.1.15</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.91</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.103</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                     <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
@@ -5404,7 +5194,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types 0.14.4</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost 0.14.4</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
-                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
+                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.16</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.11</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.13.1</a></li>
@@ -5415,27 +5205,28 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-mio 0.2.5</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook 0.3.18</a></li>
-                    <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
+                    <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.2</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.5</a></li>
                     <li><a href=" https://github.com/SergioBenitez/state ">state 0.6.0</a></li>
                     <li><a href=" https://github.com/luser/strip-ansi-escapes ">strip-ansi-escapes 0.2.1</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.27.0</a></li>
-                    <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.9</a></li>
+                    <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.10</a></li>
                     <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate 1.2.1</a></li>
-                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.3</a></li>
                     <li><a href=" https://github.com/Aetf/unicode-truncate ">unicode-truncate 2.0.1</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.6</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.114</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.114</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.114</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.114</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.91</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.4+wasi-0.2.12</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.126</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.126</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.126</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.126</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.103</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.57.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6056,7 +5847,7 @@ APPENDIX: How to apply the Apache License to your work.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
-                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.2</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.3</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -6476,7 +6267,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.0</a></li>
+                    <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.2</a></li>
                 </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -7046,7 +6837,7 @@ limitations under the License.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.104</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.91</a></li>
                     <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.12</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Figment ">figment 0.10.19</a></li>
@@ -7054,53 +6845,52 @@ limitations under the License.
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
                     <li><a href=" https://github.com/dtolnay/indoc ">indoc 2.0.7</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.183</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.189</a></li>
                     <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
+                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.2</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                     <li><a href=" https://github.com/as1100k/pastey ">pastey 0.2.3</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Pear ">pear 0.2.9</a></li>
                     <li><a href=" https://github.com/SergioBenitez/Pear ">pear_codegen 0.2.9</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
-                    <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.6</a></li>
-                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
+                    <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
+                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.14.0</a></li>
                     <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
                     <li><a href=" https://github.com/SergioBenitez/proc-macro2-diagnostics ">proc-macro2-diagnostics 0.10.1</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.107</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.47</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 6.0.0</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.7</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.5</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xoshiro 0.7.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast-impl 1.0.25</a></li>
-                    <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast 1.0.25</a></li>
-                    <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
+                    <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast-impl 1.0.26</a></li>
+                    <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast 1.0.26</a></li>
+                    <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.23</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.229</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.229</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.229</a></li>
                     <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.151</a></li>
                     <li><a href=" https://github.com/dtolnay/serde-yaml ">serde_yaml 0.9.34+deprecated</a></li>
-                    <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
+                    <li><a href=" https://github.com/comex/rust-shlex ">shlex 2.0.1</a></li>
                     <li><a href=" https://github.com/SergioBenitez/stable-pattern ">stable-pattern 0.1.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.119</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 3.0.3</a></li>
-                    <li><a href=" https://github.com/dtolnay/target-triple ">target-triple 1.0.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.18</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time-core 0.1.8</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.27</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time 0.3.47</a></li>
+                    <li><a href=" https://github.com/dtolnay/target-triple ">target-triple 1.0.1</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.19</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.19</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time-core 0.1.9</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.32</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time 0.3.54</a></li>
                     <li><a href=" https://github.com/dtolnay/trybuild ">trybuild 1.0.118</a></li>
                     <li><a href=" https://github.com/SergioBenitez/ubyte ">ubyte 0.10.4</a></li>
                     <li><a href=" https://github.com/SergioBenitez/uncased ">uncased 0.9.10</a></li>
                     <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">vte 0.14.1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
                 </ul>
@@ -7479,8 +7269,8 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnp 0.25.2</a></li>
-                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnpc 0.25.0</a></li>
+                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnp 0.25.6</a></li>
+                    <li><a href=" https://github.com/capnproto/capnproto-rust ">capnpc 0.25.3</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2013-2018 Sandstorm Development Group, Inc. and contributors
 
@@ -7506,7 +7296,7 @@ THE SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.2.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -7623,7 +7413,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.12.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -8019,7 +7809,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/paupino/rust-decimal ">rust_decimal 1.40.0</a></li>
+                    <li><a href=" https://github.com/paupino/rust-decimal ">rust_decimal 1.42.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8167,7 +7957,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.7.2</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8226,7 +8016,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/magiclen/utf8-width ">utf8-width 0.1.8</a></li>
+                    <li><a href=" https://github.com/magiclen/utf8-width ">utf8-width 0.1.9</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8284,7 +8074,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/ParkMyCar/compact_str ">compact_str 0.9.0</a></li>
+                    <li><a href=" https://github.com/ParkMyCar/compact_str ">compact_str 0.9.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8515,9 +8305,9 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.50.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.19</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.19</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.53.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8578,7 +8368,7 @@ SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/sunfishcode/is-terminal ">is-terminal 0.4.17</a></li>
                     <li><a href=" https://github.com/dtolnay/unsafe-libyaml ">unsafe-libyaml 0.2.11</a></li>
-                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
+                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.23</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -8610,7 +8400,7 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.15</a></li>
-                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.0</a></li>
+                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.4</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -8636,7 +8426,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mvdnes/spin-rs.git ">spin 0.9.8</a></li>
+                    <li><a href=" https://github.com/mvdnes/spin-rs.git ">spin 0.9.9</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -8665,8 +8455,9 @@ SOFTWARE.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.4</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.23</a></li>
-                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff-core 0.1.0</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.35</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.3</a></li>
                     <li><a href=" https://github.com/BurntSushi/termcolor ">termcolor 1.4.1</a></li>
                     <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                 </ul>

--- a/licenses.html
+++ b/licenses.html
@@ -5182,7 +5182,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-lang/log ">log 0.4.33</a></li>
                     <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                     <li><a href=" https://github.com/havarnov/multimap ">multimap 0.10.1</a></li>
-                    <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
+                    <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.5.1</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (245)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (246)</li>
             <li><a href="#MIT">MIT License</a> (109)</li>
             <li><a href="#Zlib">zlib License</a> (2)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
@@ -5174,6 +5174,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/fitzgen/inlinable_string ">inlinable_string 0.1.15</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
+                    <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.15.0</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.103</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                     <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>


### PR DESCRIPTION
- **chore: bump Rust dependencies to the latest non-major versions**
- **chore: bump capnp and capnpc from 0.25.x to 0.26.x**
- **chore: bump itertools from 0.14.0 to 0.15.0**
- **chore: bump num-derive from 0.4.1 to 0.5.1**
- **chore: bump serial_test from 3.2.0 to 4.0.1**
- **chore(gwr-config): bump syn from 2.0.114 to 3.0.3**
  The syn version used in the workspace manifest remains unchanged.
- **chore: bump rand from 0.9.2 to 0.10.2**
  This requires updates to the trait names uses as well as the way
  infallible RNGs are implemented. See
  https://rust-random.github.io/book/update-0.10.html for the update guide
  followed whilst making these changes.

  Also bump rand_xoshiro 0.7.0 to 0.8.1 to ensure a compatible version of
  rand_core is in used.