### PR TITLE
feat(gwr-models): Add state machine macro API helpers

### DIFF
--- a/gwr-components/src/lib.rs
+++ b/gwr-components/src/lib.rs
@@ -11,6 +11,7 @@ pub mod queue;
 pub mod router;
 pub mod sink;
 pub mod source;
+pub mod state_machine;
 pub mod store;
 pub mod test_helpers;
 pub mod types;

--- a/gwr-components/src/state_machine.rs
+++ b/gwr-components/src/state_machine.rs
@@ -1,0 +1,602 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+//! State-machine builders.
+
+#[doc(hidden)]
+pub use paste::paste;
+
+/// Build a state enum, transition metadata, runtime transition checks, and
+/// typestate proof helpers.
+///
+/// The macro takes a list of states, the default state, and a set of named
+/// transitions. Each transition declares one or more source states and a single
+/// destination state.
+///
+/// ```rust
+/// gwr_components::create_state_machine!(
+///     pub JobMachine {
+///         states: [Queued, Running, Complete, Failed],
+///         default: Queued,
+///         transitions: [
+///             start: [Queued] => Running,
+///             finish: [Running] => Complete,
+///             fail: [Queued, Running] => Failed,
+///             retry: [Failed] => Queued,
+///         ],
+///     }
+/// );
+/// ```
+///
+/// The generated state enum can be used as a runtime state machine. Transition
+/// marker types are named from the machine, action, and `Transition` suffix.
+///
+/// ```rust
+/// # gwr_components::create_state_machine!(
+/// #     JobMachine {
+/// #         states: [Queued, Running, Complete, Failed],
+/// #         default: Queued,
+/// #         transitions: [
+/// #             start: [Queued] => Running,
+/// #             finish: [Running] => Complete,
+/// #             fail: [Queued, Running] => Failed,
+/// #             retry: [Failed] => Queued,
+/// #         ],
+/// #     }
+/// # );
+/// #
+/// let mut state = JobMachine::default();
+/// assert_eq!(state, JobMachine::Queued);
+/// assert!(state.apply::<JobMachineStartTransition>());
+/// assert_eq!(state, JobMachine::Running);
+/// assert!(!state.apply::<JobMachineRetryTransition>());
+/// assert_eq!(state, JobMachine::Running);
+/// ```
+///
+/// The macro also generates typestate wrappers. Valid transition methods are
+/// only implemented for the source states listed in the transition declaration,
+/// so invalid transition chains fail to compile.
+///
+/// ```rust
+/// # gwr_components::create_state_machine!(
+/// #     JobMachine {
+/// #         states: [Queued, Running, Complete, Failed],
+/// #         default: Queued,
+/// #         transitions: [
+/// #             start: [Queued] => Running,
+/// #             finish: [Running] => Complete,
+/// #             fail: [Queued, Running] => Failed,
+/// #             retry: [Failed] => Queued,
+/// #         ],
+/// #     }
+/// # );
+/// #
+/// let queued = JobMachineTypestate::default();
+/// let running = queued.start();
+/// let complete = running.finish();
+/// assert_eq!(complete.into_state(), JobMachineComplete);
+/// ```
+///
+/// `cfg_attr` is rejected because it can expand to a `cfg` attribute after
+/// macro parsing, which would allow the generated enum to be disabled without
+/// disabling the rest of the generated state-machine items.
+///
+/// ```compile_fail
+/// gwr_components::create_state_machine!(
+///     #[cfg_attr(all(), cfg(any()))]
+///     pub DisabledByCfgAttr {
+///         states: [Idle, Busy],
+///         default: Idle,
+///         transitions: [
+///             start: [Idle] => Busy,
+///         ],
+///     }
+/// );
+/// ```
+#[macro_export]
+macro_rules! create_state_machine {
+    (
+        @impl
+        [$cfg:meta]
+        [$(#[$($machine_attrs:tt)*])*]
+        $vis:vis $machine:ident {
+            states: [ $( $state:ident ),+ $(,)? ],
+            default: $default:ident,
+            transitions: [
+                $(
+                    $action:ident: [ $( $from:ident ),+ $(,)? ] => $to:ident
+                ),+ $(,)?
+            ],
+        }
+    ) => {
+        $crate::state_machine::paste! {
+            #[cfg($cfg)]
+            $(#[$($machine_attrs)*])*
+            #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+            $vis enum $machine {
+                $( $state, )+
+            }
+
+            #[cfg($cfg)]
+            impl ::std::default::Default for $machine {
+                fn default() -> Self {
+                    Self::$default
+                }
+            }
+
+            #[cfg($cfg)]
+            impl ::std::fmt::Display for $machine {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    f.write_str(self.name())
+                }
+            }
+
+            #[cfg($cfg)]
+            #[allow(dead_code)]
+            impl $machine {
+                $vis const STATES: &'static [&'static str] = &[
+                    $( stringify!($state), )+
+                ];
+
+                $vis const TRANSITIONS: &'static [(&'static str, &'static str)] = &[
+                    $(
+                        $( (stringify!($from), stringify!($to)), )+
+                    )+
+                ];
+
+                #[must_use]
+                $vis fn name(self) -> &'static str {
+                    match self {
+                        $( Self::$state => stringify!($state), )+
+                    }
+                }
+
+                #[must_use]
+                $vis fn states() -> &'static [&'static str] {
+                    Self::STATES
+                }
+
+                #[must_use]
+                $vis fn transitions() -> &'static [(&'static str, &'static str)] {
+                    Self::TRANSITIONS
+                }
+
+                #[must_use]
+                #[allow(unreachable_patterns)]
+                $vis fn transition_allowed(from: Self, to: Self) -> bool {
+                    matches!(
+                        (from, to),
+                        $(
+                            $( (Self::$from, Self::$to) )|+
+                        )|+
+                    )
+                }
+
+                $vis fn apply<TTransition>(&mut self) -> bool
+                where
+                    TTransition: [< $machine Transition >],
+                {
+                    if !TTransition::FROM.contains(self)
+                        || !Self::transition_allowed(*self, TTransition::TO)
+                    {
+                        return false;
+                    }
+
+                    *self = TTransition::TO;
+                    true
+                }
+
+                #[must_use]
+                $vis fn as_str(self) -> &'static str {
+                    self.name()
+                }
+
+                #[must_use]
+                $vis fn mermaid() -> ::std::string::String {
+                    let mut diagram = ::std::string::String::from("stateDiagram-v2\n");
+                    diagram.push_str("    [*] --> ");
+                    diagram.push_str(stringify!($default));
+                    diagram.push('\n');
+
+                    $(
+                        $(
+                            diagram.push_str("    ");
+                            diagram.push_str(stringify!($from));
+                            diagram.push_str(" --> ");
+                            diagram.push_str(stringify!($to));
+                            diagram.push_str(": ");
+                            diagram.push_str(stringify!($action));
+                            diagram.push('\n');
+                        )+
+                    )+
+
+                    diagram
+                }
+            }
+
+            $(
+                #[cfg($cfg)]
+                #[allow(non_camel_case_types)]
+                $vis struct [< $machine $action:camel Transition >];
+            )+
+
+            #[cfg($cfg)]
+            mod [< $machine:snake _transition_seal >] {
+                pub trait Sealed {}
+            }
+
+            #[cfg($cfg)]
+            #[allow(private_bounds)]
+            $vis trait [< $machine Transition >]: [< $machine:snake _transition_seal >]::Sealed {
+                const FROM: &'static [$machine];
+                const TO: $machine;
+            }
+
+            $(
+                #[cfg($cfg)]
+                impl [< $machine:snake _transition_seal >]::Sealed
+                    for [< $machine $action:camel Transition >]
+                {
+                }
+
+                #[cfg($cfg)]
+                impl [< $machine Transition >] for [< $machine $action:camel Transition >] {
+                    const FROM: &'static [$machine] = &[
+                        $( $machine::$from, )+
+                    ];
+                    const TO: $machine = $machine::$to;
+                }
+            )+
+
+            $(
+                #[cfg($cfg)]
+                #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+                $vis struct [< $machine $state >];
+            )+
+
+            #[cfg($cfg)]
+            #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+            $vis struct [< $machine Typestate >]<S> {
+                state: S,
+            }
+
+            #[cfg($cfg)]
+            #[allow(dead_code)]
+            impl<S> [< $machine Typestate >]<S> {
+                #[must_use]
+                $vis const fn new(state: S) -> Self {
+                    Self {
+                        state,
+                    }
+                }
+
+                #[must_use]
+                $vis fn state(&self) -> &S {
+                    &self.state
+                }
+
+                #[must_use]
+                $vis fn into_state(self) -> S {
+                    self.state
+                }
+            }
+
+            #[cfg($cfg)]
+            impl ::std::default::Default for [< $machine Typestate >]<[< $machine $default >]> {
+                fn default() -> Self {
+                    Self::new([< $machine $default >])
+                }
+            }
+
+            #[cfg($cfg)]
+            const _: () = {
+                $(
+                    let _ = [< $machine $state >];
+                    let _ = [< $machine Typestate >]::new([< $machine $state >]);
+                )+
+
+                $(
+                    let _ = [< $machine $action:camel Transition >];
+                )+
+            };
+
+            $(
+                $(
+                    #[cfg($cfg)]
+                    #[allow(dead_code, non_snake_case)]
+                    impl [< $machine Typestate >]<[< $machine $from >]> {
+                        #[must_use]
+                        $vis fn $action(self) -> [< $machine Typestate >]<[< $machine $to >]> {
+                            [< $machine Typestate >]::new([< $machine $to >])
+                        }
+                    }
+                )+
+            )+
+        }
+    };
+
+    (
+        @parse
+        [$($cfgs:meta),*]
+        [$($machine_attrs:tt)*]
+        #[cfg($cfg:meta)]
+        $($rest:tt)*
+    ) => {
+        $crate::create_state_machine!(
+            @parse
+            [$($cfgs,)* $cfg]
+            [$($machine_attrs)*]
+            $($rest)*
+        );
+    };
+
+    (
+        @parse
+        [$($cfgs:meta),*]
+        [$($machine_attrs:tt)*]
+        #[cfg_attr($($cfg_attr:tt)*)]
+        $($rest:tt)*
+    ) => {
+        ::std::compile_error!(
+            "`create_state_machine!` does not support `cfg_attr`; use explicit `cfg` attributes instead"
+        );
+    };
+
+    (
+        @parse
+        [$($cfgs:meta),*]
+        [$($machine_attrs:tt)*]
+        #[$($machine_attr:tt)*]
+        $($rest:tt)*
+    ) => {
+        $crate::create_state_machine!(
+            @parse
+            [$($cfgs),*]
+            [$($machine_attrs)* #[$($machine_attr)*]]
+            $($rest)*
+        );
+    };
+
+    (
+        @parse
+        [$($cfgs:meta),*]
+        [$($machine_attrs:tt)*]
+        $vis:vis $machine:ident {
+            states: [ $( $state:ident ),+ $(,)? ],
+            default: $default:ident,
+            transitions: [
+                $(
+                    $action:ident: [ $( $from:ident ),+ $(,)? ] => $to:ident
+                ),+ $(,)?
+            ],
+        }
+    ) => {
+        $crate::create_state_machine!(
+            @impl
+            [all($($cfgs),*)]
+            [$($machine_attrs)*]
+            $vis $machine {
+                states: [ $( $state ),+ ],
+                default: $default,
+                transitions: [
+                    $(
+                        $action: [ $( $from ),+ ] => $to
+                    ),+
+                ],
+            }
+        );
+    };
+
+    ($($input:tt)*) => {
+        $crate::create_state_machine!(@parse [] [] $($input)*);
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    create_state_machine!(
+        TestMachine {
+            states: [Idle, Busy, Fault],
+            default: Idle,
+            transitions: [
+                start: [Idle] => Busy,
+                fail: [Idle, Busy] => Fault,
+                finish: [Busy] => Idle,
+                reset: [Fault] => Idle,
+            ],
+        }
+    );
+
+    create_state_machine!(
+        pub(crate) DoorMachine {
+            states: [Closed, Open, Locked],
+            default: Closed,
+            transitions: [
+                open: [Closed] => Open,
+                close: [Open] => Closed,
+                lock: [Closed] => Locked,
+                reset: [Open, Locked] => Closed,
+            ],
+        }
+    );
+
+    create_state_machine!(
+        pub(crate) DeviceMachine {
+            states: [Reset, Ready],
+            default: Reset,
+            transitions: [
+                reset: [Ready] => Reset,
+                ready: [Reset] => Ready,
+            ],
+        }
+    );
+
+    #[test]
+    fn generated_state_machine_exports_metadata() {
+        assert_eq!(TestMachine::states(), &["Idle", "Busy", "Fault"]);
+        assert_eq!(TestMachine::default(), TestMachine::Idle);
+        assert_eq!(TestMachine::Busy.name(), "Busy");
+        assert_eq!(TestMachine::Fault.as_str(), "Fault");
+        assert_eq!(TestMachine::Idle.to_string(), "Idle");
+        assert_eq!(
+            TestMachine::transitions(),
+            &[
+                ("Idle", "Busy"),
+                ("Idle", "Fault"),
+                ("Busy", "Fault"),
+                ("Busy", "Idle"),
+                ("Fault", "Idle"),
+            ]
+        );
+    }
+
+    #[test]
+    fn generated_state_machine_checks_transition_matrix() {
+        assert!(TestMachine::transition_allowed(
+            TestMachine::Idle,
+            TestMachine::Busy
+        ));
+        assert!(TestMachine::transition_allowed(
+            TestMachine::Idle,
+            TestMachine::Fault
+        ));
+        assert!(TestMachine::transition_allowed(
+            TestMachine::Busy,
+            TestMachine::Fault
+        ));
+        assert!(TestMachine::transition_allowed(
+            TestMachine::Busy,
+            TestMachine::Idle
+        ));
+        assert!(TestMachine::transition_allowed(
+            TestMachine::Fault,
+            TestMachine::Idle
+        ));
+
+        assert!(!TestMachine::transition_allowed(
+            TestMachine::Fault,
+            TestMachine::Busy
+        ));
+        assert!(!TestMachine::transition_allowed(
+            TestMachine::Idle,
+            TestMachine::Idle
+        ));
+        assert!(!TestMachine::transition_allowed(
+            TestMachine::Busy,
+            TestMachine::Busy
+        ));
+    }
+
+    #[test]
+    fn generated_transition_markers_support_runtime_state_updates() {
+        let mut state = TestMachine::Idle;
+
+        assert!(!state.apply::<TestMachineFinishTransition>());
+        assert_eq!(state, TestMachine::Idle);
+
+        assert!(state.apply::<TestMachineStartTransition>());
+        assert_eq!(state, TestMachine::Busy);
+
+        assert!(state.apply::<TestMachineFailTransition>());
+        assert_eq!(state, TestMachine::Fault);
+
+        assert!(state.apply::<TestMachineResetTransition>());
+        assert_eq!(state, TestMachine::Idle);
+    }
+
+    #[test]
+    fn generated_transition_markers_export_source_and_target_metadata() {
+        assert_eq!(TestMachineStartTransition::FROM, &[TestMachine::Idle]);
+        assert_eq!(TestMachineStartTransition::TO, TestMachine::Busy);
+
+        assert_eq!(
+            TestMachineFailTransition::FROM,
+            &[TestMachine::Idle, TestMachine::Busy]
+        );
+        assert_eq!(TestMachineFailTransition::TO, TestMachine::Fault);
+    }
+
+    #[test]
+    fn generated_typestate_helpers_chain_valid_transitions() {
+        fn expect_idle(_: TestMachineTypestate<TestMachineIdle>) {}
+        fn expect_busy(_: TestMachineTypestate<TestMachineBusy>) {}
+        fn expect_fault(_: TestMachineTypestate<TestMachineFault>) {}
+
+        let idle = TestMachineTypestate::default();
+        assert_eq!(*idle.state(), TestMachineIdle);
+
+        let busy = idle.start();
+        expect_busy(busy);
+
+        let busy = TestMachineTypestate::new(TestMachineBusy);
+        let fault = busy.fail();
+        expect_fault(fault);
+
+        let fault = TestMachineTypestate::new(TestMachineFault);
+        let idle = fault.reset();
+        assert_eq!(idle.into_state(), TestMachineIdle);
+        expect_idle(idle);
+    }
+
+    #[test]
+    fn generated_names_do_not_collide_when_events_repeat_across_machines() {
+        assert_eq!(
+            DoorMachineResetTransition::FROM,
+            &[DoorMachine::Open, DoorMachine::Locked]
+        );
+        assert_eq!(DoorMachineResetTransition::TO, DoorMachine::Closed);
+        assert_eq!(DeviceMachineResetTransition::FROM, &[DeviceMachine::Ready]);
+        assert_eq!(DeviceMachineResetTransition::TO, DeviceMachine::Reset);
+        assert!(DeviceMachine::transition_allowed(
+            DeviceMachine::Ready,
+            DeviceMachine::Reset
+        ));
+    }
+
+    #[test]
+    fn generated_public_visibility_exports_machine_api() {
+        assert_eq!(
+            DoorMachine::transitions(),
+            &[
+                ("Closed", "Open"),
+                ("Open", "Closed"),
+                ("Closed", "Locked"),
+                ("Open", "Closed"),
+                ("Locked", "Closed"),
+            ]
+        );
+        assert_eq!(DoorMachine::default(), DoorMachine::Closed);
+        assert_eq!(DoorMachine::Locked.to_string(), "Locked");
+    }
+
+    #[test]
+    fn generated_mermaid_diagram_uses_default_state_and_action_labels() {
+        assert_eq!(
+            TestMachine::mermaid(),
+            concat!(
+                "stateDiagram-v2\n",
+                "    [*] --> Idle\n",
+                "    Idle --> Busy: start\n",
+                "    Idle --> Fault: fail\n",
+                "    Busy --> Fault: fail\n",
+                "    Busy --> Idle: finish\n",
+                "    Fault --> Idle: reset\n",
+            )
+        );
+    }
+
+    #[test]
+    fn generated_mermaid_diagram_expands_shared_events_in_declaration_order() {
+        assert_eq!(
+            DoorMachine::mermaid(),
+            concat!(
+                "stateDiagram-v2\n",
+                "    [*] --> Closed\n",
+                "    Closed --> Open: open\n",
+                "    Open --> Closed: close\n",
+                "    Closed --> Locked: lock\n",
+                "    Open --> Closed: reset\n",
+                "    Locked --> Closed: reset\n",
+            )
+        );
+    }
+}

--- a/gwr-components/tests/fail/invalid_typestate_transition.rs
+++ b/gwr-components/tests/fail/invalid_typestate_transition.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+gwr_components::create_state_machine!(
+    JobMachine {
+        states: [Queued, Running, Complete, Failed],
+        default: Queued,
+        transitions: [
+            start: [Queued] => Running,
+            finish: [Running] => Complete,
+            fail: [Queued, Running] => Failed,
+            retry: [Failed] => Queued,
+        ],
+    }
+);
+
+fn main() {
+    let queued = JobMachineTypestate::default();
+    let complete = queued.finish();
+
+    let _ = complete;
+}

--- a/gwr-components/tests/fail/invalid_typestate_transition.stderr
+++ b/gwr-components/tests/fail/invalid_typestate_transition.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no method named `finish` found for struct `JobMachineTypestate<JobMachineQueued>` in the current scope
+  --> tests/fail/invalid_typestate_transition.rs:18:27
+   |
+ 3 | / gwr_components::create_state_machine!(
+ 4 | |     JobMachine {
+ 5 | |         states: [Queued, Running, Complete, Failed],
+ 6 | |         default: Queued,
+...  |
+14 | | );
+   | |_- method `finish` not found for this struct
+...
+18 |       let complete = queued.finish();
+   |                             ^^^^^^ method not found in `JobMachineTypestate<JobMachineQueued>`
+   |
+   = note: the method was found for `JobMachineTypestate<JobMachineRunning>`
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `finish`, perhaps you need to implement one of them:
+           candidate #1: `Hasher`
+           candidate #2: `regex_syntax::ast::visitor::Visitor`
+           candidate #3: `regex_syntax::hir::visitor::Visitor`

--- a/gwr-components/tests/state_machine.rs
+++ b/gwr-components/tests/state_machine.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+mod generated {
+    gwr_components::create_state_machine!(
+        pub PublicMachine {
+            states: [Idle, Busy, Fault],
+            default: Idle,
+            transitions: [
+                start: [Idle] => Busy,
+                fail: [Idle, Busy] => Fault,
+                reset: [Fault] => Idle,
+            ],
+        }
+    );
+
+    gwr_components::create_state_machine!(
+        /// A disabled state machine.
+        #[cfg(any())]
+        pub DisabledMachine {
+            states: [Idle, Busy],
+            default: Idle,
+            transitions: [
+                start: [Idle] => Busy,
+            ],
+        }
+    );
+}
+
+use generated::{
+    PublicMachine, PublicMachineBusy, PublicMachineFailTransition, PublicMachineFault,
+    PublicMachineIdle, PublicMachineResetTransition, PublicMachineStartTransition,
+    PublicMachineTransition, PublicMachineTypestate,
+};
+
+#[test]
+fn public_machine_api_supports_runtime_transition_updates() {
+    fn assert_transition<TTransition>(from: PublicMachine, expected: Option<PublicMachine>)
+    where
+        TTransition: PublicMachineTransition,
+    {
+        let mut state = from;
+
+        assert_eq!(state.apply::<TTransition>(), expected.is_some());
+        assert_eq!(state, expected.unwrap_or(from));
+    }
+
+    assert!(PublicMachine::transition_allowed(
+        PublicMachine::Idle,
+        PublicMachine::Busy
+    ));
+    assert!(PublicMachine::transition_allowed(
+        PublicMachine::Idle,
+        PublicMachine::Fault
+    ));
+    assert!(PublicMachine::transition_allowed(
+        PublicMachine::Busy,
+        PublicMachine::Fault
+    ));
+    assert!(PublicMachine::transition_allowed(
+        PublicMachine::Fault,
+        PublicMachine::Idle
+    ));
+
+    assert!(!PublicMachine::transition_allowed(
+        PublicMachine::Idle,
+        PublicMachine::Idle
+    ));
+    assert!(!PublicMachine::transition_allowed(
+        PublicMachine::Busy,
+        PublicMachine::Idle
+    ));
+    assert!(!PublicMachine::transition_allowed(
+        PublicMachine::Busy,
+        PublicMachine::Busy
+    ));
+    assert!(!PublicMachine::transition_allowed(
+        PublicMachine::Fault,
+        PublicMachine::Busy
+    ));
+    assert!(!PublicMachine::transition_allowed(
+        PublicMachine::Fault,
+        PublicMachine::Fault
+    ));
+
+    assert_transition::<PublicMachineStartTransition>(
+        PublicMachine::Idle,
+        Some(PublicMachine::Busy),
+    );
+    assert_transition::<PublicMachineStartTransition>(PublicMachine::Busy, None);
+    assert_transition::<PublicMachineStartTransition>(PublicMachine::Fault, None);
+
+    assert_transition::<PublicMachineFailTransition>(
+        PublicMachine::Idle,
+        Some(PublicMachine::Fault),
+    );
+    assert_transition::<PublicMachineFailTransition>(
+        PublicMachine::Busy,
+        Some(PublicMachine::Fault),
+    );
+    assert_transition::<PublicMachineFailTransition>(PublicMachine::Fault, None);
+
+    assert_transition::<PublicMachineResetTransition>(PublicMachine::Idle, None);
+    assert_transition::<PublicMachineResetTransition>(PublicMachine::Busy, None);
+    assert_transition::<PublicMachineResetTransition>(
+        PublicMachine::Fault,
+        Some(PublicMachine::Idle),
+    );
+}
+
+#[test]
+fn public_machine_api_supports_typestate_construction() {
+    fn expect_idle(_: PublicMachineTypestate<PublicMachineIdle>) {}
+    fn expect_busy(_: PublicMachineTypestate<PublicMachineBusy>) {}
+    fn expect_fault(_: PublicMachineTypestate<PublicMachineFault>) {}
+
+    let idle = PublicMachineTypestate::default();
+    assert_eq!(*idle.state(), PublicMachineIdle);
+    expect_idle(idle);
+
+    let busy = PublicMachineTypestate::new(PublicMachineIdle).start();
+    assert_eq!(busy.into_state(), PublicMachineBusy);
+    expect_busy(busy);
+
+    let fault = PublicMachineTypestate::new(PublicMachineBusy).fail();
+    assert_eq!(*fault.state(), PublicMachineFault);
+    expect_fault(fault);
+}


### PR DESCRIPTION
Introduce a create_state_machine! macro that generates state enums,
transition metadata, runtime transition checks, and typestate helpers.

Add unit and integration coverage for transition metadata, runtime updates,
typestate chaining, repeated transition names across machines, and external
public API use.
