### PR TITLE
Pass client ID to the trusted amend workflow

### DIFF
--- a/.github/workflows/amend-dependabot-github-actions-update.yaml
+++ b/.github/workflows/amend-dependabot-github-actions-update.yaml
@@ -26,5 +26,5 @@ jobs:
     uses: >-
       graphcore-research/gwr/.github/workflows/trusted-amend-dependabot-github-actions-update.yaml@main
     secrets:
-      GWR_BOT_APP_ID: ${{ secrets.GWR_BOT_APP_ID }}
+      GWR_BOT_CLIENT_ID: ${{ secrets.GWR_BOT_CLIENT_ID }}
       GWR_BOT_PRIVATE_KEY: ${{ secrets.GWR_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Pass `GWR_BOT_CLIENT_ID` from the PR-side wrapper now that the trusted workflow has been updated on `main` to accept it (see #318).