### PR TITLE
refactor(gwr-spotter): show creator for created events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-spotter"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "capnp",
  "clap",

--- a/gwr-spotter/Cargo.toml
+++ b/gwr-spotter/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-spotter"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-spotter/src/app/mod.rs
+++ b/gwr-spotter/src/app/mod.rs
@@ -31,7 +31,7 @@ pub trait ToFullness {
 #[derive(Debug, Clone)]
 pub enum EventLine {
     Create {
-        // Only need to keep the ID to be rendered.
+        created_by: u64,
         id: u64,
         time: f64,
     },

--- a/gwr-spotter/src/bin_loader.rs
+++ b/gwr-spotter/src/bin_loader.rs
@@ -102,7 +102,7 @@ impl TraceVisitor for BinLoader {
         });
     }
 
-    fn create_entity(&mut self, _created_by: Id, id: Id, name: &str) {
+    fn create_entity(&mut self, created_by: Id, id: Id, name: &str) {
         SHARED_STATE
             .lock()
             .unwrap()
@@ -113,12 +113,13 @@ impl TraceVisitor for BinLoader {
             .unwrap()
             .insert(id.0, name.to_owned());
         self.add_event(EventLine::Create {
+            created_by: created_by.0,
             id: id.0,
             time: self.current_time_ns,
         });
     }
 
-    fn create_monitor(&mut self, _created_by: Id, id: Id, name: &str) {
+    fn create_monitor(&mut self, created_by: Id, id: Id, name: &str) {
         SHARED_STATE
             .lock()
             .unwrap()
@@ -129,12 +130,13 @@ impl TraceVisitor for BinLoader {
             .unwrap()
             .insert(id.0, name.to_owned());
         self.add_event(EventLine::Create {
+            created_by: created_by.0,
             id: id.0,
             time: self.current_time_ns,
         });
     }
 
-    fn create_lane(&mut self, _created_by: Id, id: Id, name: &str) {
+    fn create_lane(&mut self, created_by: Id, id: Id, name: &str) {
         SHARED_STATE
             .lock()
             .unwrap()
@@ -145,6 +147,7 @@ impl TraceVisitor for BinLoader {
             .unwrap()
             .insert(id.0, name.to_owned());
         self.add_event(EventLine::Create {
+            created_by: created_by.0,
             id: id.0,
             time: self.current_time_ns,
         });
@@ -154,7 +157,7 @@ impl TraceVisitor for BinLoader {
 
     fn create_object(
         &mut self,
-        _created_by: Id,
+        created_by: Id,
         id: Id,
         _size: usize,
         units: &str,
@@ -180,6 +183,7 @@ impl TraceVisitor for BinLoader {
         );
         self.id_to_req_type.as_mut().unwrap().insert(id.0, req_type);
         self.add_event(EventLine::Create {
+            created_by: created_by.0,
             id: id.0,
             time: self.current_time_ns,
         });

--- a/gwr-spotter/src/filter.rs
+++ b/gwr-spotter/src/filter.rs
@@ -87,7 +87,9 @@ impl SearchState {
 
     pub fn search_matches(&self, line: &EventLine) -> bool {
         match line {
-            EventLine::Create { id, .. } => self.id_matches(id),
+            EventLine::Create { created_by, id, .. } => {
+                self.id_matches(created_by) || self.id_matches(id)
+            }
             EventLine::Connect { from_id, to_id, .. } => {
                 self.id_matches(from_id) || self.id_matches(to_id)
             }
@@ -381,7 +383,16 @@ mod tests {
     fn plain_text_search_matches_numeric_ids() {
         let search_state = build_search_state("41");
 
-        assert!(search_state.search_matches(&EventLine::Create { id: 41, time: 0.0 }));
+        assert!(search_state.search_matches(&EventLine::Create {
+            created_by: 40,
+            id: 41,
+            time: 0.0,
+        }));
+        assert!(search_state.search_matches(&EventLine::Create {
+            created_by: 41,
+            id: 99,
+            time: 0.0,
+        }));
         assert!(search_state.search_matches(&EventLine::Enter {
             id: 40,
             entered: 41,
@@ -391,6 +402,69 @@ mod tests {
         assert!(search_state.search_matches(&EventLine::Connect {
             from_id: 41,
             to_id: 99,
+            time: 0.0,
+        }));
+    }
+
+    #[test]
+    fn plain_text_search_matches_names_details_and_log_messages() {
+        let mut search_state = build_search_state("mailbox");
+        search_state.id_to_name.insert(7, "mailbox".to_string());
+        search_state
+            .id_to_details
+            .insert(8, "mailbox payload".to_string());
+
+        assert!(search_state.search_matches(&EventLine::Value {
+            id: 7,
+            value: 1.0,
+            time: 0.0,
+        }));
+        assert!(search_state.search_matches(&EventLine::ActivityEnd { id: 8, time: 0.0 }));
+        assert!(search_state.search_matches(&EventLine::Log {
+            level: log::Level::Info,
+            id: 99,
+            msg: "sent to mailbox".to_string(),
+            time: 0.0,
+        }));
+        assert!(!search_state.search_matches(&EventLine::Create {
+            created_by: 0,
+            id: 99,
+            time: 0.0,
+        }));
+    }
+
+    #[test]
+    fn explicit_id_filter_matches_only_that_id() {
+        let search_state = SearchState {
+            filter_id: Some(41),
+            ..build_search_state("")
+        };
+
+        assert!(search_state.search_matches(&EventLine::Create {
+            created_by: 0,
+            id: 41,
+            time: 0.0,
+        }));
+        assert!(search_state.search_matches(&EventLine::Create {
+            created_by: 41,
+            id: 99,
+            time: 0.0,
+        }));
+        assert!(search_state.search_matches(&EventLine::Enter {
+            id: 1,
+            entered: 41,
+            fullness: 1,
+            time: 0.0,
+        }));
+        assert!(!search_state.search_matches(&EventLine::Create {
+            created_by: 0,
+            id: 141,
+            time: 0.0,
+        }));
+        assert!(!search_state.search_matches(&EventLine::Log {
+            level: log::Level::Info,
+            id: 1,
+            msg: "mentions id 41".to_string(),
             time: 0.0,
         }));
     }

--- a/gwr-spotter/src/log_parser.rs
+++ b/gwr-spotter/src/log_parser.rs
@@ -10,7 +10,7 @@ use std::thread;
 
 use itertools::Itertools;
 use log::Level;
-use regex::Regex;
+use regex::{Captures, Regex};
 
 use crate::app::{CHUNK_SIZE, EventLine};
 use crate::filter::Filter;
@@ -34,6 +34,11 @@ struct LogParser {
     activity_lanes: HashMap<u64, u64>,
 
     current_time: f64,
+}
+
+fn u64_value(e: &Captures, field_name: &str) -> u64 {
+    let value_str = e.name(field_name).unwrap().as_str();
+    value_str.parse().unwrap()
 }
 
 impl LogParser {
@@ -73,8 +78,7 @@ impl LogParser {
     ) -> EventLine {
         match self.log_line_re.captures(full_line) {
             Some(e) => {
-                let id_str = e.name("id").unwrap().as_str();
-                let id = id_str.parse().unwrap();
+                let id = u64_value(&e, "id");
                 let level_str = e.name("level").unwrap().as_str();
                 let msg = e.name("msg").unwrap().as_str();
                 EventLine::Log {
@@ -252,20 +256,22 @@ impl LogParser {
         id_to_details: &mut HashMap<u64, String>,
     ) -> Option<EventLine> {
         let e = self.create_re.captures(msg)?;
+        let by = u64_value(&e, "by");
         let kind = e.name("kind").unwrap().as_str();
         let rest = e.name("rest").unwrap().as_str();
 
         match kind {
             "entity" | "monitor" | "lane" | "group" | "activity" => {
-                self.parse_named_create(rest, id_to_name)
+                self.parse_named_create(by, rest, id_to_name)
             }
-            "object" => self.parse_object_create(rest, id_to_name, id_to_details),
+            "object" => self.parse_object_create(by, rest, id_to_name, id_to_details),
             _ => None,
         }
     }
 
     fn parse_named_create(
         &self,
+        by: u64,
         rest: &str,
         id_to_name: &mut HashMap<u64, String>,
     ) -> Option<EventLine> {
@@ -282,6 +288,7 @@ impl LogParser {
         id_to_name.insert(id, name);
 
         Some(EventLine::Create {
+            created_by: by,
             id,
             time: self.current_time,
         })
@@ -289,6 +296,7 @@ impl LogParser {
 
     fn parse_object_create(
         &self,
+        by: u64,
         rest: &str,
         id_to_name: &mut HashMap<u64, String>,
         id_to_details: &mut HashMap<u64, String>,
@@ -318,6 +326,7 @@ impl LogParser {
         );
 
         Some(EventLine::Create {
+            created_by: by,
             id,
             time: self.current_time,
         })

--- a/gwr-spotter/src/renderer.rs
+++ b/gwr-spotter/src/renderer.rs
@@ -226,99 +226,127 @@ impl Renderer {
         }
 
         let event_line = event_line.unwrap();
-        let mut tmp0 = String::new();
-        let mut tmp1 = String::new();
-        let (mut line, time) = match event_line {
-            EventLine::Enter {
-                id,
-                entered,
-                fullness,
-                time,
-            } => {
-                let name = self.name_id(id, &mut tmp0);
-                let object = self.object_id(entered, &mut tmp1);
-                (format!("{name}: <= {object}({fullness})").to_owned(), time)
-            }
-
-            EventLine::Exit {
-                id,
-                exited,
-                fullness,
-                time,
-            } => {
-                let name = self.name_id(id, &mut tmp0);
-                let object = self.object_id(exited, &mut tmp1);
-                (format!("{name}: => {object}({fullness})").to_owned(), time)
-            }
-
-            EventLine::Value { id, value, time } => {
-                let name = self.name_id(id, &mut tmp0);
-                (format!("{name}: {value}").to_owned(), time)
-            }
-
-            EventLine::Log { id, msg, time, .. } => {
-                let name = self.name_id(id, &mut tmp0);
-                (format!("{name}: {msg}").to_owned(), time)
-            }
-
-            EventLine::ActivityBegin {
-                id,
-                name,
-                correlation_id,
-                time,
-            } => {
-                let track = self.name_id(id, &mut tmp0);
-                let suffix = correlation_id
-                    .map(|correlation_id| format!(" correlation {correlation_id}"))
-                    .unwrap_or_default();
-                (
-                    format!("{track}: activity begin {name}{suffix}").to_owned(),
-                    time,
-                )
-            }
-
-            EventLine::ActivityEnd { id, time } => {
-                let name = self.name_id(id, &mut tmp0);
-                (format!("{name}: activity end").to_owned(), time)
-            }
-
-            EventLine::Create { id, time } => {
-                let details = self.details(id, &mut tmp1);
-                if self.id_to_name.get(id).map(String::as_str) == Some("object") {
-                    if !self.print_details || details.is_empty() {
-                        (format!("{id}: created object").to_owned(), time)
-                    } else {
-                        (format!("{id}: created object ({details})").to_owned(), time)
-                    }
-                } else {
-                    let name = self.name_id(id, &mut tmp0);
-                    if !self.print_details || details.is_empty() {
-                        (format!("{name}: created").to_owned(), time)
-                    } else {
-                        (format!("{name}: created ({details})").to_owned(), time)
-                    }
-                }
-            }
-
-            EventLine::Connect {
-                from_id,
-                to_id,
-                time,
-            } => {
-                let from_name = self.name_id(from_id, &mut tmp0);
-                let to_name = self.name_id(to_id, &mut tmp1);
-                (
-                    format!("{from_name}: connect to {to_name}").to_owned(),
-                    time,
-                )
-            }
-        };
+        let (mut line, time) = self.render_event_line(event_line);
 
         if self.print_times {
             let _ = write!(line, " @{time:.1}ns");
         }
 
         line
+    }
+
+    fn render_event_line(&self, event_line: &EventLine) -> (String, f64) {
+        match event_line {
+            EventLine::Enter {
+                id,
+                entered,
+                fullness,
+                time,
+            } => (self.render_enter(id, entered, fullness), *time),
+
+            EventLine::Exit {
+                id,
+                exited,
+                fullness,
+                time,
+            } => (self.render_exit(id, exited, fullness), *time),
+
+            EventLine::Value { id, value, time } => (self.render_value(id, value), *time),
+
+            EventLine::Log { id, msg, time, .. } => (self.render_log(id, msg), *time),
+
+            EventLine::ActivityBegin {
+                id,
+                name,
+                correlation_id,
+                time,
+            } => (self.render_activity_begin(id, name, *correlation_id), *time),
+
+            EventLine::ActivityEnd { id, time } => (self.render_activity_end(id), *time),
+
+            EventLine::Create {
+                created_by,
+                id,
+                time,
+            } => (self.render_create(created_by, id), *time),
+
+            EventLine::Connect {
+                from_id,
+                to_id,
+                time,
+            } => (self.render_connect(from_id, to_id), *time),
+        }
+    }
+
+    fn render_enter(&self, id: &u64, entered: &u64, fullness: &u64) -> String {
+        let mut tmp0 = String::new();
+        let mut tmp1 = String::new();
+        let name = self.name_id(id, &mut tmp0);
+        let object = self.object_id(entered, &mut tmp1);
+        format!("{name}: <= {object}({fullness})")
+    }
+
+    fn render_exit(&self, id: &u64, exited: &u64, fullness: &u64) -> String {
+        let mut tmp0 = String::new();
+        let mut tmp1 = String::new();
+        let name = self.name_id(id, &mut tmp0);
+        let object = self.object_id(exited, &mut tmp1);
+        format!("{name}: => {object}({fullness})")
+    }
+
+    fn render_value(&self, id: &u64, value: &f64) -> String {
+        let mut tmp = String::new();
+        let name = self.name_id(id, &mut tmp);
+        format!("{name}: {value}")
+    }
+
+    fn render_log(&self, id: &u64, msg: &str) -> String {
+        let mut tmp = String::new();
+        let name = self.name_id(id, &mut tmp);
+        format!("{name}: {msg}")
+    }
+
+    fn render_activity_begin(&self, id: &u64, name: &str, correlation_id: Option<u64>) -> String {
+        let mut tmp = String::new();
+        let track = self.name_id(id, &mut tmp);
+        let suffix = correlation_id
+            .map(|correlation_id| format!(" correlation {correlation_id}"))
+            .unwrap_or_default();
+        format!("{track}: activity begin {name}{suffix}")
+    }
+
+    fn render_activity_end(&self, id: &u64) -> String {
+        let mut tmp = String::new();
+        let name = self.name_id(id, &mut tmp);
+        format!("{name}: activity end")
+    }
+
+    fn render_create(&self, created_by: &u64, id: &u64) -> String {
+        let mut tmp0 = String::new();
+        let mut tmp1 = String::new();
+        let details = self.details(id, &mut tmp1);
+        if self.id_to_name.get(id).map(String::as_str) == Some("object") {
+            if !self.print_details || details.is_empty() {
+                format!("{created_by}: created object {id}")
+            } else {
+                format!("{created_by}: created object {id} ({details})")
+            }
+        } else {
+            let name = self.name_id(id, &mut tmp0);
+            if !self.print_details || details.is_empty() {
+                format!("{created_by}: created {name}")
+            } else {
+                format!("{created_by}: created {name} ({details})")
+            }
+        }
+    }
+
+    fn render_connect(&self, from_id: &u64, to_id: &u64) -> String {
+        let mut tmp0 = String::new();
+        let mut tmp1 = String::new();
+        let from_name = self.name_id(from_id, &mut tmp0);
+        let to_name = self.name_id(to_id, &mut tmp1);
+        format!("{from_name}: connect to {to_name}")
     }
 
     pub fn add_chunk(&mut self, lines: Vec<EventLine>) {
@@ -499,5 +527,68 @@ mod tests {
             renderer.render_line(1),
             "7: pe0::lane::compute::0: activity end @15.0ns"
         );
+    }
+
+    #[test]
+    fn renders_create_events_with_creator_and_details() {
+        let mut renderer = Renderer::new();
+        renderer.extend_id_to_name(HashMap::from([
+            (1, "pe0::lane".to_string()),
+            (2, "object".to_string()),
+        ]));
+        renderer.extend_id_to_details(HashMap::from([
+            (1, "worker lane".to_string()),
+            (2, "packet<f32>".to_string()),
+        ]));
+        renderer.add_chunk(vec![
+            EventLine::Create {
+                created_by: 0,
+                id: 1,
+                time: 10.0,
+            },
+            EventLine::Create {
+                created_by: 1,
+                id: 2,
+                time: 20.0,
+            },
+        ]);
+
+        assert_eq!(
+            renderer.render_line(0),
+            "0: created 1: pe0::lane (worker lane) @10.0ns"
+        );
+        assert_eq!(
+            renderer.render_line(1),
+            "1: created object 2 (packet<f32>) @20.0ns"
+        );
+    }
+
+    #[test]
+    fn fullnesses_at_returns_latest_fullnesses_up_to_absolute_index() {
+        let mut renderer = Renderer::new();
+        renderer.add_chunk(vec![
+            EventLine::Enter {
+                id: 7,
+                entered: 100,
+                fullness: 1,
+                time: 10.0,
+            },
+            EventLine::Enter {
+                id: 8,
+                entered: 101,
+                fullness: 2,
+                time: 11.0,
+            },
+            EventLine::Exit {
+                id: 7,
+                exited: 100,
+                fullness: 0,
+                time: 12.0,
+            },
+        ]);
+
+        assert_eq!(renderer.fullnesses_at(0), HashMap::from([(7, 1)]));
+        assert_eq!(renderer.fullnesses_at(2), HashMap::from([(7, 0), (8, 2)]));
+        assert_eq!(renderer.fullnesses_at(99), HashMap::from([(7, 0), (8, 2)]));
     }
 }

--- a/licenses.html
+++ b/licenses.html
@@ -8418,7 +8418,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.6.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.9.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.10.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-terminus 0.4.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-timetable 0.3.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.13.0</a></li>


### PR DESCRIPTION
Track the creator ID on create events from both binary traces and parsed logs,
and render create lines in a form that makes the parent/creator relationship
visible.

Refactor event rendering into smaller helpers while preserving existing output
for non-create events, and add unit coverage for create rendering, fullness
state reconstruction, and filter matching behavior.
