### PR TITLE
refactor(gwr-engine,gwr-models): Route fabric traffic by destination device IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-models"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1343,6 +1343,7 @@ dependencies = [
  "log",
  "paste",
  "rand 0.10.2",
+ "rand_xoshiro",
  "serde",
 ]
 
@@ -1375,7 +1376,7 @@ version = "2.0.0"
 
 [[package]]
 name = "gwr-platform"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "byte-unit",

--- a/examples/flaky-component/Cargo.toml
+++ b/examples/flaky-component/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.13.0" }
 rand.workspace = true

--- a/examples/flaky-with-delay/Cargo.toml
+++ b/examples/flaky-with-delay/Cargo.toml
@@ -22,7 +22,7 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.13.0" }
 rand.workspace = true

--- a/examples/scrambler/Cargo.toml
+++ b/examples/scrambler/Cargo.toml
@@ -22,6 +22,6 @@ publish.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
 gwr-track = { path = "../../gwr-track", version = "0.13.0" }

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -22,9 +22,9 @@ publish.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-fabric/src/access_gen.rs
+++ b/examples/sim-fabric/src/access_gen.rs
@@ -4,11 +4,10 @@ use std::fmt;
 use std::rc::Rc;
 
 use clap::ValueEnum;
-use gwr_engine::types::AccessType;
+use gwr_engine::types::{AccessType, DeviceId};
 use gwr_model_builder::EntityGet;
 use gwr_models::fabric::FabricConfig;
 use gwr_models::memory::memory_access::MemoryAccess;
-use gwr_models::memory::memory_map::DeviceId;
 use gwr_track::entity::Entity;
 use rand::SeedableRng;
 use rand::seq::{IteratorRandom, SliceRandom};

--- a/examples/sim-fabric/src/main.rs
+++ b/examples/sim-fabric/src/main.rs
@@ -3,6 +3,7 @@
 //! Simulate a device comprising a rectangular fabric.
 //!
 //! See `lib.rs` for details.
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use clap::Parser;
@@ -148,7 +149,8 @@ fn start_frame_dump(
     });
 }
 
-fn create_config(engine: &Engine, args: &Cli) -> (Rc<FabricConfig>, usize) {
+fn create_config(engine: &Engine, args: &Cli) -> Result<(Rc<FabricConfig>, usize), SimError> {
+    let num_fabric_ports = args.fabric_columns * args.fabric_rows * args.fabric_ports_per_node;
     let config = FabricConfig::new(
         args.fabric_columns,
         args.fabric_rows,
@@ -159,7 +161,8 @@ fn create_config(engine: &Engine, args: &Cli) -> (Rc<FabricConfig>, usize) {
         args.rx_buffer_bytes,
         args.tx_buffer_bytes,
         args.port_bits_per_tick,
-    );
+        identity_destination_port_map(num_fabric_ports),
+    )?;
     let config = Rc::new(config);
 
     let num_payload_bytes_to_send = args.bytes_to_send;
@@ -180,7 +183,13 @@ fn create_config(engine: &Engine, args: &Cli) -> (Rc<FabricConfig>, usize) {
     );
     info!(top ; "Using traffic pattern {}. Random seed {}", args.traffic_pattern, args.seed);
 
-    (config, num_send_frames)
+    Ok((config, num_send_frames))
+}
+
+fn identity_destination_port_map(num_ports: usize) -> HashMap<u64, Vec<usize>> {
+    (0..num_ports)
+        .map(|port_idx| (port_idx as u64, vec![port_idx]))
+        .collect()
 }
 
 fn main() -> Result<(), SimError> {
@@ -191,7 +200,7 @@ fn main() -> Result<(), SimError> {
     let spawner = engine.spawner();
     let clock = engine.default_clock();
 
-    let (config, num_send_frames) = create_config(&engine, &args);
+    let (config, num_send_frames) = create_config(&engine, &args)?;
     let num_ports = config.num_ports();
     let top = engine.top().clone();
     let fabric: Rc<dyn Fabric<MemoryAccess>> = if args.routed {

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -22,9 +22,9 @@ publish.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-pipe/src/frame_gen.rs
+++ b/examples/sim-pipe/src/frame_gen.rs
@@ -2,10 +2,9 @@
 
 use std::rc::Rc;
 
-use gwr_engine::types::AccessType;
+use gwr_engine::types::{AccessType, DeviceId};
 use gwr_model_builder::EntityGet;
 use gwr_models::memory::memory_access::MemoryAccess;
-use gwr_models::memory::memory_map::DeviceId;
 use gwr_track::entity::Entity;
 
 /// A frame Generator that can be used by the `Source` to produce frames on

--- a/examples/sim-restaurant/Cargo.toml
+++ b/examples/sim-restaurant/Cargo.toml
@@ -21,7 +21,7 @@ clap.workspace = true
 crossterm.workspace = true
 futures.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.14.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 log.workspace = true
 rand.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -21,9 +21,9 @@ publish.workspace = true
 [dependencies]
 clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-ring/src/ring_builder.rs
+++ b/examples/sim-ring/src/ring_builder.rs
@@ -45,7 +45,7 @@ where
     fn route(&self, obj: &T) -> Result<usize, SimError> {
         // If the dest matches then exit via port 1, otherwise use port 0 as that is the
         // ring
-        let dest = obj.destination() as usize;
+        let dest = obj.dst_addr() as usize;
         Ok(if self.0 == dest { IO_INDEX } else { RING_INDEX })
     }
 }

--- a/gwr-components/Cargo.toml
+++ b/gwr-components/Cargo.toml
@@ -31,7 +31,7 @@ async-trait.workspace = true
 byte-unit.workspace = true
 futures.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }

--- a/gwr-components/src/router.rs
+++ b/gwr-components/src/router.rs
@@ -84,9 +84,9 @@ impl<T> Route<T> for DefaultAlgorithm
 where
     T: Routable,
 {
-    /// Determine route by taking the object destination as an index.
+    /// Determine route by taking the object destination device as an index.
     fn route(&self, obj_to_route: &T) -> Result<usize, SimError> {
-        Ok(obj_to_route.destination() as usize)
+        Ok(obj_to_route.dst_device().0 as usize)
     }
 }
 

--- a/gwr-components/tests/rate_limiter.rs
+++ b/gwr-components/tests/rate_limiter.rs
@@ -21,7 +21,10 @@ impl TotalBytes for RateLimiterTest {
 }
 
 impl Routable for RateLimiterTest {
-    fn destination(&self) -> u64 {
+    fn dst_addr(&self) -> u64 {
+        0
+    }
+    fn src_addr(&self) -> u64 {
         0
     }
     fn access_type(&self) -> AccessType {

--- a/gwr-components/tests/router.rs
+++ b/gwr-components/tests/router.rs
@@ -1,11 +1,13 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
 use gwr_components::connect_port;
-use gwr_components::router::{DefaultAlgorithm, Router};
+use gwr_components::router::{DefaultAlgorithm, Route, Router};
 use gwr_components::sink::Sink;
 use gwr_components::source::Source;
 use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
+use gwr_engine::traits::Routable;
+use gwr_engine::types::{AccessType, DeviceId};
 
 #[test]
 fn router() {
@@ -36,4 +38,40 @@ fn router() {
 
     assert_eq!(sink_a.num_sunk(), NUM_PUTS / 2);
     assert_eq!(sink_b.num_sunk(), NUM_PUTS / 2);
+}
+
+struct DeviceRoutable {
+    dst_addr: u64,
+    src_addr: u64,
+    dst_device: DeviceId,
+}
+
+impl Routable for DeviceRoutable {
+    fn dst_addr(&self) -> u64 {
+        self.dst_addr
+    }
+
+    fn src_addr(&self) -> u64 {
+        self.src_addr
+    }
+
+    fn dst_device(&self) -> DeviceId {
+        self.dst_device
+    }
+
+    fn access_type(&self) -> AccessType {
+        AccessType::ReadRequest
+    }
+}
+
+#[test]
+fn default_algorithm_routes_by_destination_device() {
+    let object = DeviceRoutable {
+        dst_addr: 0x1_0000_0000,
+        src_addr: 0,
+        dst_device: DeviceId(1),
+    };
+
+    assert_eq!(DefaultAlgorithm {}.route(&object).unwrap(), 1);
+    assert_eq!(DefaultAlgorithm {}.route(&7_usize).unwrap(), 7);
 }

--- a/gwr-engine/Cargo.toml
+++ b/gwr-engine/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-engine"
-version = "0.13.0"
+version = "0.14.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-engine/src/traits.rs
+++ b/gwr-engine/src/traits.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use async_trait::async_trait;
 use gwr_track::id::Unique;
 
-use crate::types::{AccessType, SimResult};
+use crate::types::{AccessType, DeviceId, SimResult};
 
 /// The `TotalBytes` trait is used to determine how many bytes an object
 /// represents
@@ -25,7 +25,14 @@ pub trait TotalBytes {
 /// The `Routable` trait provides an interface to an object to enable it to be
 /// routed
 pub trait Routable {
-    fn destination(&self) -> u64;
+    fn dst_addr(&self) -> u64;
+    fn src_addr(&self) -> u64;
+    fn dst_device(&self) -> DeviceId {
+        DeviceId(self.dst_addr())
+    }
+    fn src_device(&self) -> DeviceId {
+        DeviceId(self.src_addr())
+    }
     fn access_type(&self) -> AccessType;
 }
 
@@ -58,7 +65,10 @@ impl TotalBytes for i32 {
 }
 
 impl Routable for i32 {
-    fn destination(&self) -> u64 {
+    fn dst_addr(&self) -> u64 {
+        *self as u64
+    }
+    fn src_addr(&self) -> u64 {
         *self as u64
     }
     fn access_type(&self) -> AccessType {
@@ -83,7 +93,10 @@ impl TotalBytes for usize {
 }
 
 impl Routable for usize {
-    fn destination(&self) -> u64 {
+    fn dst_addr(&self) -> u64 {
+        *self as u64
+    }
+    fn src_addr(&self) -> u64 {
         *self as u64
     }
     fn access_type(&self) -> AccessType {
@@ -180,7 +193,10 @@ mod tests {
     #[test]
     fn integer_sim_object_defaults_are_available() {
         assert_eq!(0_i32.total_bytes(), size_of::<i32>());
-        assert_eq!(7_i32.destination(), 7);
+        assert_eq!(7_i32.dst_addr(), 7);
+        assert_eq!(7_i32.src_addr(), 7);
+        assert_eq!(7_i32.dst_device(), DeviceId(7));
+        assert_eq!(7_i32.src_device(), DeviceId(7));
         assert_eq!(0_i32.access_type(), AccessType::ReadRequest);
         assert_eq!(1_i32.access_type(), AccessType::WriteRequest);
         assert_eq!(2_i32.access_type(), AccessType::WriteNonPostedRequest);
@@ -189,7 +205,10 @@ mod tests {
         assert_eq!(5_i32.access_type(), AccessType::Control);
 
         assert_eq!(0_usize.total_bytes(), size_of::<usize>());
-        assert_eq!(7_usize.destination(), 7);
+        assert_eq!(7_usize.dst_addr(), 7);
+        assert_eq!(7_usize.src_addr(), 7);
+        assert_eq!(7_usize.dst_device(), DeviceId(7));
+        assert_eq!(7_usize.src_device(), DeviceId(7));
         assert_eq!(0_usize.access_type(), AccessType::ReadRequest);
         assert_eq!(1_usize.access_type(), AccessType::WriteRequest);
         assert_eq!(2_usize.access_type(), AccessType::WriteNonPostedRequest);

--- a/gwr-engine/src/types.rs
+++ b/gwr-engine/src/types.rs
@@ -42,6 +42,9 @@ impl Error for SimError {}
 /// The SimResult is the return type for most simulation functions
 pub type SimResult = Result<(), SimError>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DeviceId(pub u64);
+
 /// Generic access types
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub enum AccessType {

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-models"
-version = "0.21.0"
+version = "0.22.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -32,13 +32,14 @@ clap.workspace = true
 futures.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-components = { path = "../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
 gwr-resources = { path = "../gwr-resources", version = "0.1.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 paste.workspace = true
 rand.workspace = true
+rand_xoshiro = "0.8.1"
 serde.workspace = true
 
 [dev-dependencies]

--- a/gwr-models/src/ethernet_frame.rs
+++ b/gwr-models/src/ethernet_frame.rs
@@ -120,8 +120,12 @@ impl Unique for EthernetFrame {
 }
 
 impl Routable for EthernetFrame {
-    fn destination(&self) -> u64 {
+    fn dst_addr(&self) -> u64 {
         self.get_dst()
+    }
+
+    fn src_addr(&self) -> u64 {
+        self.get_src()
     }
 
     fn access_type(&self) -> AccessType {
@@ -146,10 +150,50 @@ impl Unique for Box<EthernetFrame> {
 }
 
 impl Routable for Box<EthernetFrame> {
-    fn destination(&self) -> u64 {
-        self.as_ref().destination()
+    fn dst_addr(&self) -> u64 {
+        self.as_ref().dst_addr()
+    }
+    fn src_addr(&self) -> u64 {
+        self.as_ref().src_addr()
     }
     fn access_type(&self) -> AccessType {
         self.as_ref().access_type()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gwr_engine::test_helpers::start_test;
+    use gwr_engine::traits::Routable;
+    use gwr_engine::types::DeviceId;
+
+    use super::{EthernetFrame, u64_to_mac};
+
+    #[test]
+    fn routable_source_uses_source_mac() {
+        let engine = start_test(file!());
+        let frame = EthernetFrame::new(engine.top(), 64)
+            .set_dest(u64_to_mac(7))
+            .set_src(u64_to_mac(4));
+
+        assert_eq!(frame.dst_addr(), 7);
+        assert_eq!(frame.src_addr(), 4);
+        assert_eq!(frame.dst_device(), DeviceId(7));
+        assert_eq!(frame.src_device(), DeviceId(4));
+    }
+
+    #[test]
+    fn boxed_routable_delegates_src_and_dst_addr() {
+        let engine = start_test(file!());
+        let frame = Box::new(
+            EthernetFrame::new(engine.top(), 64)
+                .set_dest(u64_to_mac(9))
+                .set_src(u64_to_mac(5)),
+        );
+
+        assert_eq!(frame.dst_addr(), 9);
+        assert_eq!(frame.src_addr(), 5);
+        assert_eq!(frame.dst_device(), DeviceId(9));
+        assert_eq!(frame.src_device(), DeviceId(5));
     }
 }

--- a/gwr-models/src/fabric/functional.rs
+++ b/gwr-models/src/fabric/functional.rs
@@ -19,12 +19,11 @@
 //!  - N = num_ports
 
 use std::cell::RefCell;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
 use async_trait::async_trait;
 use gwr_components::flow_controls::limiter::Limiter;
-use gwr_components::router::{DefaultAlgorithm, Route};
 use gwr_components::store::{ByteStore, Store};
 use gwr_components::{connect_port, rc_limiter};
 use gwr_engine::engine::Engine;
@@ -36,11 +35,11 @@ use gwr_engine::time::clock::{Clock, ClockTick};
 use gwr_engine::traits::{Event, Routable, Runnable, SimObject};
 use gwr_engine::types::{SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
-use gwr_track::build_aka;
 use gwr_track::entity::Entity;
 use gwr_track::tracker::aka::Aka;
+use gwr_track::{build_aka, debug};
 
-use crate::fabric::{Fabric, FabricConfig};
+use crate::fabric::{Fabric, FabricConfig, FabricPortSelection};
 
 /// Return the Manhatten time to travel between RX and TX ports specified.
 #[must_use]
@@ -212,6 +211,19 @@ where
         self.config
             .col_row_port_to_fabric_port_index(col, row, port)
     }
+
+    fn fabric_port_index_to_col_row_port(&self, fabric_port_index: usize) -> (usize, usize, usize) {
+        self.config
+            .fabric_port_index_to_col_row_port(fabric_port_index)
+    }
+
+    fn destination_port_map(&self) -> &HashMap<u64, Vec<usize>> {
+        self.config.destination_port_map()
+    }
+
+    fn port_selection(&self) -> FabricPortSelection {
+        self.config.port_selection()
+    }
 }
 
 #[async_trait(?Send)]
@@ -227,26 +239,14 @@ where
         }
         let port_states = Rc::new(port_states);
 
-        let routing_algorithm: Rc<Box<dyn Route<T>>> = Rc::new(Box::new(DefaultAlgorithm {}));
-
         for (i, internal_rx) in self.internal_rx.borrow_mut().drain(..).enumerate() {
             let entity = self.entity.clone();
             let clock = self.clock.clone();
             let port_states = port_states.clone();
-            let routing_algorithm = routing_algorithm.clone();
             let config = self.config.clone();
 
             self.spawner.spawn(async move {
-                run_rx(
-                    entity,
-                    clock,
-                    i,
-                    internal_rx,
-                    port_states,
-                    routing_algorithm,
-                    config,
-                )
-                .await
+                run_rx(entity, clock, i, internal_rx, port_states, config).await
             });
         }
 
@@ -292,7 +292,6 @@ async fn run_rx<T>(
     port_index: usize,
     mut internal_rx: InPort<T>,
     port_states: Rc<Vec<PortState<T>>>,
-    routing_algorithm: Rc<Box<dyn Route<T>>>,
     config: Rc<FabricConfig>,
 ) -> SimResult
 where
@@ -307,7 +306,8 @@ where
         entity.track_enter(value_id);
         let value_bytes = value.total_bytes();
 
-        let dest_index = routing_algorithm.route(&value)?;
+        let dest_index = config.resolve_destination_port(&value)?;
+        debug!(entity ; "Route {value_id} from {port_index} -> {dest_index}");
         let delay_ticks = manhatten_rx_to_tx_cycles(&config, port_index, dest_index);
 
         let mut tick = clock.tick_now();

--- a/gwr-models/src/fabric/mod.rs
+++ b/gwr-models/src/fabric/mod.rs
@@ -8,12 +8,18 @@
 //! ingress/egress ports will be populated.
 
 use std::cmp::min;
-use std::fmt::Display;
+use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Display};
 
+use clap::ValueEnum;
 use gwr_engine::port::PortStateResult;
+use gwr_engine::sim_error;
 use gwr_engine::traits::{Routable, SimObject};
-use gwr_engine::types::SimResult;
+use gwr_engine::types::{SimError, SimResult};
 use gwr_track::entity::GetEntity;
+use rand::{Rng, SeedableRng};
+use rand_xoshiro::SplitMix64;
+use serde::{Deserialize, Serialize};
 
 pub trait Fabric<T>: GetEntity + Display
 where
@@ -22,11 +28,32 @@ where
     fn connect_port_egress_i(&self, i: usize, port_state: PortStateResult<T>) -> SimResult;
     fn port_ingress_i(&self, i: usize) -> PortStateResult<T>;
     fn col_row_port_to_fabric_port_index(&self, col: usize, row: usize, port: usize) -> usize;
+    fn fabric_port_index_to_col_row_port(&self, fabric_port_index: usize) -> (usize, usize, usize);
+    fn destination_port_map(&self) -> &HashMap<u64, Vec<usize>>;
+    fn port_selection(&self) -> FabricPortSelection;
 }
 
 pub enum RoutingAlgoritm {
     ColumnFirst,
     RowFirst,
+}
+
+#[derive(ValueEnum, Clone, Copy, Default, Debug, Serialize, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FabricPortSelection {
+    #[default]
+    DestinationAddressHash,
+    SourceIdModulo,
+}
+
+impl fmt::Display for FabricPortSelection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            FabricPortSelection::DestinationAddressHash => "destination-address-hash",
+            FabricPortSelection::SourceIdModulo => "source-id-modulo",
+        };
+        f.write_str(s)
+    }
 }
 
 /// Configuration structure for a fabric
@@ -62,6 +89,13 @@ pub struct FabricConfig {
 
     /// Indices of populated ingress/egress ports
     fabric_port_indices: Vec<usize>,
+
+    /// Mapping from protocol destinations, such as device IDs, to fabric
+    /// egress port indices.
+    destination_port_map: HashMap<u64, Vec<usize>>,
+
+    /// Policy used when a destination maps to multiple egress ports.
+    port_selection: FabricPortSelection,
 }
 
 #[must_use]
@@ -141,9 +175,25 @@ fn create_populated_indices(
     fabric_indices
 }
 
+fn validate_destination_port_map(
+    destination_port_map: &HashMap<u64, Vec<usize>>,
+    fabric_port_indices: &[usize],
+) -> Result<(), SimError> {
+    let fabric_port_indices: HashSet<usize> = fabric_port_indices.iter().copied().collect();
+    for (destination, ports) in destination_port_map {
+        for port in ports {
+            if !fabric_port_indices.contains(port) {
+                return sim_error!(
+                    "Destination port map references unpopulated fabric port {port} for destination {destination}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 impl FabricConfig {
     #[expect(clippy::too_many_arguments)]
-    #[must_use]
     pub fn new(
         num_columns: usize,
         num_rows: usize,
@@ -154,14 +204,16 @@ impl FabricConfig {
         rx_buffer_bytes: usize,
         tx_buffer_bytes: usize,
         port_bits_per_tick: usize,
-    ) -> Self {
+        destination_port_map: HashMap<u64, Vec<usize>>,
+    ) -> Result<Self, SimError> {
         let fabric_port_indices = create_populated_indices(
             num_columns,
             num_rows,
             num_ports_per_node,
             ports_per_node_limit,
         );
-        Self {
+        validate_destination_port_map(&destination_port_map, &fabric_port_indices)?;
+        Ok(Self {
             num_columns,
             num_rows,
             num_ports_per_node,
@@ -172,7 +224,15 @@ impl FabricConfig {
             tx_buffer_bytes,
             port_bits_per_tick,
             fabric_port_indices,
-        }
+            destination_port_map,
+            port_selection: FabricPortSelection::default(),
+        })
+    }
+
+    #[must_use]
+    pub fn with_port_selection(mut self, port_selection: FabricPortSelection) -> Self {
+        self.port_selection = port_selection;
+        self
     }
 
     /// Returns the maximum number of ports in the fabric
@@ -265,6 +325,48 @@ impl FabricConfig {
     pub fn port_bits_per_tick(&self) -> usize {
         self.port_bits_per_tick
     }
+
+    #[must_use]
+    pub fn destination_port_map(&self) -> &HashMap<u64, Vec<usize>> {
+        &self.destination_port_map
+    }
+
+    #[must_use]
+    pub fn port_selection(&self) -> FabricPortSelection {
+        self.port_selection
+    }
+
+    pub fn resolve_destination_port<T>(&self, object: &T) -> Result<usize, SimError>
+    where
+        T: Routable,
+    {
+        let destination = object.dst_device().0;
+        let ports = self.destination_port_map.get(&destination).ok_or_else(|| {
+            SimError(format!(
+                "No fabric egress port mapped for destination {destination}"
+            ))
+        })?;
+
+        match ports.as_slice() {
+            [] => Err(SimError(format!(
+                "No fabric egress port mapped for destination {destination}"
+            ))),
+            [port] => Ok(*port),
+            _ => {
+                let selector = match self.port_selection {
+                    FabricPortSelection::DestinationAddressHash => splitmix64(object.dst_addr()),
+                    FabricPortSelection::SourceIdModulo => object.src_device().0,
+                };
+                Ok(ports[(selector as usize) % ports.len()])
+            }
+        }
+    }
+}
+
+#[must_use]
+fn splitmix64(seed: u64) -> u64 {
+    let mut rng = SplitMix64::seed_from_u64(seed);
+    rng.next_u64()
 }
 
 pub mod functional;
@@ -273,7 +375,8 @@ pub mod routed;
 
 #[test]
 fn port_index() {
-    let config: FabricConfig = FabricConfig::new(3, 4, 2, None, 1, 1, 1, 1, 1);
+    let config: FabricConfig =
+        FabricConfig::new(3, 4, 2, None, 1, 1, 1, 1, 1, HashMap::new()).unwrap();
 
     assert_eq!(config.col_row_port_to_fabric_port_index(0, 0, 0), 0);
     assert_eq!(config.fabric_port_index_to_col_row_port(0), (0, 0, 0));
@@ -295,4 +398,172 @@ fn port_index() {
 
     assert_eq!(config.col_row_port_to_fabric_port_index(2, 1, 1), 19);
     assert_eq!(config.fabric_port_index_to_col_row_port(19), (2, 1, 1));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use gwr_engine::traits::Routable;
+    use gwr_engine::types::{AccessType, DeviceId};
+
+    use super::{FabricConfig, FabricPortSelection, splitmix64};
+
+    const MULTI_ROUTE_PORTS: [usize; 3] = [10, 11, 12];
+
+    struct TestRoutable {
+        dst_device: DeviceId,
+        src_device: DeviceId,
+        dst_addr: u64,
+        src_addr: u64,
+    }
+
+    impl Routable for TestRoutable {
+        fn dst_addr(&self) -> u64 {
+            self.dst_addr
+        }
+
+        fn src_addr(&self) -> u64 {
+            self.src_addr
+        }
+
+        fn dst_device(&self) -> DeviceId {
+            self.dst_device
+        }
+
+        fn src_device(&self) -> DeviceId {
+            self.src_device
+        }
+
+        fn access_type(&self) -> AccessType {
+            AccessType::Control
+        }
+    }
+
+    fn config_with_map(selection: FabricPortSelection) -> FabricConfig {
+        FabricConfig::new(
+            4,
+            1,
+            4,
+            None,
+            1,
+            1,
+            1,
+            1,
+            1,
+            HashMap::from([(7, MULTI_ROUTE_PORTS.to_vec())]),
+        )
+        .unwrap()
+        .with_port_selection(selection)
+    }
+
+    #[test]
+    fn resolves_single_destination_port() {
+        let config =
+            FabricConfig::new(2, 2, 1, None, 1, 1, 1, 1, 1, HashMap::from([(7, vec![3])])).unwrap();
+        let packet = TestRoutable {
+            dst_device: DeviceId(7),
+            src_device: DeviceId(1),
+            dst_addr: 2,
+            src_addr: 1,
+        };
+
+        assert_eq!(config.resolve_destination_port(&packet).unwrap(), 3);
+    }
+
+    #[test]
+    fn errors_for_missing_destination_port() {
+        let config = config_with_map(FabricPortSelection::DestinationAddressHash);
+        let packet = TestRoutable {
+            dst_device: DeviceId(8),
+            src_device: DeviceId(1),
+            dst_addr: 2,
+            src_addr: 1,
+        };
+
+        assert!(
+            format!("{}", config.resolve_destination_port(&packet).unwrap_err())
+                .contains("No fabric egress port mapped for destination 8")
+        );
+    }
+
+    #[test]
+    fn errors_for_empty_destination_port_map() {
+        let config = FabricConfig::new(2, 1, 1, None, 1, 1, 1, 1, 1, HashMap::new()).unwrap();
+        let packet = TestRoutable {
+            dst_device: DeviceId(0),
+            src_device: DeviceId(1),
+            dst_addr: 2,
+            src_addr: 1,
+        };
+
+        assert!(
+            format!("{}", config.resolve_destination_port(&packet).unwrap_err())
+                .contains("No fabric egress port mapped for destination 0")
+        );
+    }
+
+    #[test]
+    fn rejects_destination_port_map_with_out_of_range_port() {
+        let error =
+            match FabricConfig::new(2, 1, 1, None, 1, 1, 1, 1, 1, HashMap::from([(7, vec![2])])) {
+                Ok(_) => panic!("expected invalid destination port map to return an error"),
+                Err(error) => error,
+            };
+
+        assert!(error.to_string().contains(
+            "Destination port map references unpopulated fabric port 2 for destination 7"
+        ));
+    }
+
+    #[test]
+    fn rejects_destination_port_map_with_unpopulated_port() {
+        let error = match FabricConfig::new(
+            2,
+            2,
+            2,
+            Some(3),
+            1,
+            1,
+            1,
+            1,
+            1,
+            HashMap::from([(7, vec![1])]),
+        ) {
+            Ok(_) => panic!("expected invalid destination port map to return an error"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains(
+            "Destination port map references unpopulated fabric port 1 for destination 7"
+        ));
+    }
+
+    #[test]
+    fn resolves_multi_route_by_destination_address_hash() {
+        let config = config_with_map(FabricPortSelection::DestinationAddressHash);
+        let packet = TestRoutable {
+            dst_device: DeviceId(7),
+            src_device: DeviceId(4),
+            dst_addr: 5,
+            src_addr: 4,
+        };
+        let expected = MULTI_ROUTE_PORTS[(splitmix64(5) as usize) % MULTI_ROUTE_PORTS.len()];
+
+        assert_eq!(config.resolve_destination_port(&packet).unwrap(), expected);
+    }
+
+    #[test]
+    fn resolves_multi_route_by_source_id_modulo() {
+        let config = config_with_map(FabricPortSelection::SourceIdModulo);
+        let packet = TestRoutable {
+            dst_device: DeviceId(7),
+            src_device: DeviceId(4),
+            dst_addr: 5,
+            src_addr: 4,
+        };
+        let expected = MULTI_ROUTE_PORTS[(packet.src_device.0 as usize) % MULTI_ROUTE_PORTS.len()];
+
+        assert_eq!(config.resolve_destination_port(&packet).unwrap(), expected);
+    }
 }

--- a/gwr-models/src/fabric/node.rs
+++ b/gwr-models/src/fabric/node.rs
@@ -137,7 +137,7 @@ where
     /// As a result it is necessary to remap indices from the computed egress
     /// port to the router port. This depends on the index of this router.
     fn route(&self, object: &T) -> Result<usize, SimError> {
-        let dest_fabric_port = object.destination() as usize;
+        let dest_fabric_port = self.config.resolve_destination_port(object)?;
         let (dest_col, dest_row, dest_port) = self
             .config
             .fabric_port_index_to_col_row_port(dest_fabric_port);

--- a/gwr-models/src/fabric/routed.rs
+++ b/gwr-models/src/fabric/routed.rs
@@ -19,6 +19,7 @@
 //! `col_row_port_to_fabric_port_index()` function in the configuration
 //! structure to get the index of the port you want to connect to.
 
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use async_trait::async_trait;
@@ -35,7 +36,7 @@ use gwr_track::entity::Entity;
 use gwr_track::tracker::aka::{Aka, populate_aka_from_string};
 
 use crate::fabric::node::{FabricNode, FabricRoutingAlgorithm};
-use crate::fabric::{Fabric, FabricConfig};
+use crate::fabric::{Fabric, FabricConfig, FabricPortSelection};
 
 #[derive(EntityGet, EntityDisplay, Runnable)]
 pub struct RoutedFabric<T>
@@ -324,5 +325,18 @@ where
     fn col_row_port_to_fabric_port_index(&self, col: usize, row: usize, port: usize) -> usize {
         self.config
             .col_row_port_to_fabric_port_index(col, row, port)
+    }
+
+    fn fabric_port_index_to_col_row_port(&self, fabric_port_index: usize) -> (usize, usize, usize) {
+        self.config
+            .fabric_port_index_to_col_row_port(fabric_port_index)
+    }
+
+    fn destination_port_map(&self) -> &HashMap<u64, Vec<usize>> {
+        self.config.destination_port_map()
+    }
+
+    fn port_selection(&self) -> FabricPortSelection {
+        self.config.port_selection()
     }
 }

--- a/gwr-models/src/memory/memory_access.rs
+++ b/gwr-models/src/memory/memory_access.rs
@@ -5,13 +5,12 @@ use std::rc::Rc;
 
 use gwr_engine::sim_error;
 use gwr_engine::traits::{Routable, SimObject, TotalBytes};
-use gwr_engine::types::{AccessType, SimError};
+use gwr_engine::types::{AccessType, DeviceId, SimError};
 use gwr_track::entity::Entity;
 use gwr_track::id::Unique;
 use gwr_track::{Id, create_id, track_create_object};
 
 use crate::memory::CacheHintType;
-use crate::memory::memory_map::DeviceId;
 use crate::memory::traits::{AccessMemory, ReadMemory};
 
 #[derive(Clone, Debug)]
@@ -60,22 +59,6 @@ impl Unique for MemoryAccess {
 }
 
 impl AccessMemory for MemoryAccess {
-    fn dst_addr(&self) -> u64 {
-        self.dst_addr
-    }
-
-    fn src_addr(&self) -> u64 {
-        self.src_addr
-    }
-
-    fn dst_device(&self) -> DeviceId {
-        self.dst_device
-    }
-
-    fn src_device(&self) -> DeviceId {
-        self.src_device
-    }
-
     fn cache_hint(&self) -> CacheHintType {
         CacheHintType::Allocate
     }
@@ -111,9 +94,17 @@ impl AccessMemory for MemoryAccess {
 }
 
 impl Routable for MemoryAccess {
-    fn destination(&self) -> u64 {
-        // The device ID is used for routing
-        self.dst_device.0
+    fn dst_addr(&self) -> u64 {
+        self.dst_addr
+    }
+    fn src_addr(&self) -> u64 {
+        self.src_addr
+    }
+    fn dst_device(&self) -> DeviceId {
+        self.dst_device
+    }
+    fn src_device(&self) -> DeviceId {
+        self.src_device
     }
     fn access_type(&self) -> AccessType {
         self.access_type

--- a/gwr-models/src/memory/memory_map.rs
+++ b/gwr-models/src/memory/memory_map.rs
@@ -3,10 +3,7 @@
 use std::collections::BTreeMap;
 
 use gwr_engine::sim_error;
-use gwr_engine::types::SimError;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct DeviceId(pub u64);
+use gwr_engine::types::{DeviceId, SimError};
 
 #[derive(Clone, Debug)]
 pub struct MemoryRegion {
@@ -93,7 +90,9 @@ impl MemoryMap {
 
 #[cfg(test)]
 mod tests {
-    use crate::memory::memory_map::{DeviceId, MemoryMap};
+    use gwr_engine::types::DeviceId;
+
+    use crate::memory::memory_map::MemoryMap;
 
     fn setup_map() -> MemoryMap {
         let mut memory_map = MemoryMap::new();

--- a/gwr-models/src/memory/traits.rs
+++ b/gwr-models/src/memory/traits.rs
@@ -4,7 +4,6 @@ use gwr_engine::traits::{Routable, TotalBytes};
 use gwr_engine::types::SimError;
 
 use crate::memory::CacheHintType;
-use crate::memory::memory_map::DeviceId;
 
 pub trait ReadMemory {
     fn read(&self) -> Vec<u8>;
@@ -15,18 +14,6 @@ pub trait AccessMemory
 where
     Self: Routable + TotalBytes,
 {
-    /// Return the destination address of this access
-    fn dst_addr(&self) -> u64;
-
-    /// Return the source address of this access
-    fn src_addr(&self) -> u64;
-
-    /// Return the destination device of this access
-    fn dst_device(&self) -> DeviceId;
-
-    /// Return the source device of this access
-    fn src_device(&self) -> DeviceId;
-
     /// Return the size of the access in bytes
     fn access_size_bytes(&self) -> usize;
 

--- a/gwr-models/src/processing_element/load_store_unit.rs
+++ b/gwr-models/src/processing_element/load_store_unit.rs
@@ -26,8 +26,8 @@ use gwr_engine::executor::Spawner;
 use gwr_engine::port::{InPort, OutPort, PortStateResult};
 use gwr_engine::sim_error;
 use gwr_engine::time::clock::{Clock, phase};
-use gwr_engine::traits::{Event, Runnable};
-use gwr_engine::types::{AccessType, SimError, SimResult};
+use gwr_engine::traits::{Event, Routable, Runnable};
+use gwr_engine::types::{AccessType, DeviceId, SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
 use gwr_resources::Resource;
 use gwr_resources::base::ResourceGuard;
@@ -36,8 +36,7 @@ use gwr_track::entity::{Entity, EntityGroup};
 use gwr_track::tracker::aka::Aka;
 
 use crate::memory::memory_access::MemoryAccess;
-use crate::memory::memory_map::{DeviceId, MemoryMap};
-use crate::memory::traits::AccessMemory;
+use crate::memory::memory_map::MemoryMap;
 use crate::processing_element::{ActivityLanes, ProcessingElementConfig};
 
 /// Each active request slot manages the request from the Processing Element

--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -31,7 +31,7 @@ use gwr_engine::executor::Spawner;
 use gwr_engine::port::PortStateResult;
 use gwr_engine::time::clock::{Clock, phase};
 use gwr_engine::traits::Runnable;
-use gwr_engine::types::{AccessType, SimError, SimResult};
+use gwr_engine::types::{AccessType, DeviceId, SimError, SimResult};
 use gwr_model_builder::{EntityDisplay, EntityGet};
 use gwr_track::debug;
 use gwr_track::entity::{Entity, EntityGroup, EntityLane};
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::log_stats;
 use crate::memory::memory_access::MemoryAccess;
-use crate::memory::memory_map::{DeviceId, MemoryMap};
+use crate::memory::memory_map::MemoryMap;
 use crate::processing_element::dispatch::Dispatch;
 use crate::processing_element::flop_monitor::FlopMonitor;
 use crate::processing_element::load_store_unit::LoadStoreUnit;

--- a/gwr-models/src/test_helpers.rs
+++ b/gwr-models/src/test_helpers.rs
@@ -5,12 +5,12 @@ use std::rc::Rc;
 
 #[doc(hidden)]
 pub use gwr_components::build_component_harness;
-use gwr_engine::types::AccessType;
+use gwr_engine::types::{AccessType, DeviceId};
 use gwr_track::entity::Entity;
 
 use crate::memory::CacheHintType;
 use crate::memory::memory_access::MemoryAccess;
-use crate::memory::memory_map::{DeviceId, MemoryMap};
+use crate::memory::memory_map::MemoryMap;
 use crate::memory::traits::AccessMemory;
 
 /// Builds a simulation test harness for models that implement `AccessMemory`.
@@ -298,7 +298,6 @@ pub struct MemoryTxn {
     src_addr: Option<u64>,
     bytes: Option<usize>,
     total_bytes: Option<usize>,
-    destination: Option<u64>,
     dst_device: Option<DeviceId>,
     src_device: Option<DeviceId>,
     cache_hint: Option<CacheHintType>,
@@ -313,7 +312,6 @@ impl MemoryTxn {
             src_addr: None,
             bytes: None,
             total_bytes: None,
-            destination: None,
             dst_device: None,
             src_device: None,
             cache_hint: None,
@@ -365,12 +363,6 @@ impl MemoryTxn {
     #[must_use]
     pub fn with_total_bytes(mut self, total_bytes: usize) -> Self {
         self.total_bytes = Some(total_bytes);
-        self
-    }
-
-    #[must_use]
-    pub fn with_destination(mut self, destination: u64) -> Self {
-        self.destination = Some(destination);
         self
     }
 
@@ -436,13 +428,6 @@ where
                 "{check_id}: total byte count mismatch for actual {actual:?}",
             );
         }
-        if let Some(destination) = self.destination {
-            assert_eq!(
-                actual.destination(),
-                destination,
-                "{check_id}: destination mismatch for actual {actual:?}",
-            );
-        }
         if let Some(dst_device) = self.dst_device {
             assert_eq!(
                 actual.dst_device(),
@@ -476,7 +461,6 @@ where
             .with_src_addr(self.src_addr())
             .with_bytes(self.access_size_bytes())
             .with_total_bytes(self.total_bytes())
-            .with_destination(self.destination())
             .with_dst_device(self.dst_device())
             .with_src_device(self.src_device())
             .with_cache_hint(self.cache_hint())

--- a/gwr-models/tests/fabric.rs
+++ b/gwr-models/tests/fabric.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -10,7 +11,7 @@ use gwr_engine::engine::Engine;
 use gwr_engine::run_simulation;
 use gwr_engine::test_helpers::start_test;
 use gwr_engine::traits::TotalBytes;
-use gwr_engine::types::AccessType;
+use gwr_engine::types::{AccessType, DeviceId};
 use gwr_models::build_model_harness;
 use gwr_models::ethernet_frame::{EthernetFrame, SRC_MAC_BYTES, u64_to_mac};
 use gwr_models::fabric::functional::FunctionalFabric;
@@ -18,7 +19,6 @@ use gwr_models::fabric::node::FabricRoutingAlgorithm;
 use gwr_models::fabric::routed::RoutedFabric;
 use gwr_models::fabric::{Fabric, FabricConfig};
 use gwr_models::memory::memory_access::MemoryAccess;
-use gwr_models::memory::memory_map::DeviceId;
 use gwr_models::test_helpers::MemoryTxn;
 
 trait ToDest {
@@ -120,8 +120,16 @@ fn default_config() -> Rc<FabricConfig> {
         rx_buffer_bytes,
         tx_buffer_bytes,
         port_bits_per_tick,
-    );
+        identity_destination_port_map(num_columns * num_rows * num_ports_per_node),
+    )
+    .unwrap();
     Rc::new(config)
+}
+
+fn identity_destination_port_map(num_ports: usize) -> HashMap<u64, Vec<usize>> {
+    (0..num_ports)
+        .map(|port_idx| (port_idx as u64, vec![port_idx]))
+        .collect()
 }
 
 #[test]
@@ -245,7 +253,21 @@ mod routed_fabric_harness {
         let mut engine = start_test(file!());
         let clock = engine.clock_ghz(1.0);
         let top = engine.top();
-        let config = Rc::new(FabricConfig::new(2, 2, 1, None, 2, 1, 1024, 1024, 128));
+        let config = Rc::new(
+            FabricConfig::new(
+                2,
+                2,
+                1,
+                None,
+                2,
+                1,
+                1024,
+                1024,
+                128,
+                identity_destination_port_map(4),
+            )
+            .unwrap(),
+        );
         let fabric = RoutedFabric::new_and_register(
             &engine,
             &clock,
@@ -300,7 +322,6 @@ mod routed_fabric_harness {
                 MemoryTxn::read_req(addr_a)
                     .with_src_addr(ingress_a_idx as u64)
                     .with_bytes(access_size_bytes)
-                    .with_destination(egress_a_idx as u64)
                     .with_dst_device(DeviceId(egress_a_idx as u64))
                     .with_src_device(DeviceId(ingress_a_idx as u64)),
             ),
@@ -309,7 +330,6 @@ mod routed_fabric_harness {
                 MemoryTxn::read_req(addr_b)
                     .with_src_addr(ingress_b_idx as u64)
                     .with_bytes(access_size_bytes)
-                    .with_destination(egress_b_idx as u64)
                     .with_dst_device(DeviceId(egress_b_idx as u64))
                     .with_src_device(DeviceId(ingress_b_idx as u64)),
             ),
@@ -320,7 +340,7 @@ mod routed_fabric_harness {
 #[test]
 #[should_panic(expected = "Cannot create fabric with less than 2 ports")]
 fn invalid_functional_fabric() {
-    let config = Rc::new(FabricConfig::new(1, 1, 1, None, 1, 1, 1, 1, 1));
+    let config = Rc::new(FabricConfig::new(1, 1, 1, None, 1, 1, 1, 1, 1, HashMap::new()).unwrap());
     let mut engine = start_test(file!());
     let clock = engine.clock_ghz(1.0);
     let top = engine.top();
@@ -331,7 +351,7 @@ fn invalid_functional_fabric() {
 
 #[test]
 fn invalid_functional_fabric_rx_buffer_bytes() {
-    let config = Rc::new(FabricConfig::new(1, 1, 2, None, 1, 1, 0, 1, 1));
+    let config = Rc::new(FabricConfig::new(1, 1, 2, None, 1, 1, 0, 1, 1, HashMap::new()).unwrap());
     let mut engine = start_test(file!());
     let clock = engine.clock_ghz(1.0);
     let top = engine.top();
@@ -350,7 +370,7 @@ fn invalid_functional_fabric_rx_buffer_bytes() {
 
 #[test]
 fn invalid_functional_fabric_tx_buffer_bytes() {
-    let config = Rc::new(FabricConfig::new(1, 1, 2, None, 1, 1, 1, 0, 1));
+    let config = Rc::new(FabricConfig::new(1, 1, 2, None, 1, 1, 1, 0, 1, HashMap::new()).unwrap());
     let mut engine = start_test(file!());
     let clock = engine.clock_ghz(1.0);
     let top = engine.top();
@@ -370,7 +390,7 @@ fn invalid_functional_fabric_tx_buffer_bytes() {
 #[test]
 #[should_panic(expected = "Cannot create fabric with less than 2 ports")]
 fn invalid_routed_fabric() {
-    let config = Rc::new(FabricConfig::new(1, 1, 1, None, 1, 1, 1, 1, 1));
+    let config = Rc::new(FabricConfig::new(1, 1, 1, None, 1, 1, 1, 1, 1, HashMap::new()).unwrap());
     let mut engine = start_test(file!());
     let clock = engine.clock_ghz(1.0);
     let top = engine.top();

--- a/gwr-models/tests/fabric_node.rs
+++ b/gwr-models/tests/fabric_node.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Graphcore Ltd. All rights reserved.
 
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use gwr_components::{connect_dummy_rx, connect_dummy_tx};
@@ -11,6 +12,8 @@ use gwr_models::fabric::FabricConfig;
 use gwr_models::fabric::node::{FabricNode, FabricRoutingAlgorithm};
 use gwr_track::entity::Entity;
 
+// Create a fabric config. Note that it does not support any routing because
+// no port map is constructed.
 fn default_config() -> Rc<FabricConfig> {
     let num_columns = 3;
     let num_rows = 4;
@@ -31,7 +34,9 @@ fn default_config() -> Rc<FabricConfig> {
         rx_buffer_bytes,
         tx_buffer_bytes,
         port_bits_per_tick,
-    );
+        HashMap::new(),
+    )
+    .unwrap();
     Rc::new(config)
 }
 

--- a/gwr-models/tests/ring_node.rs
+++ b/gwr-models/tests/ring_node.rs
@@ -24,7 +24,7 @@ where
 {
     fn route(&self, obj: &T) -> Result<usize, SimError> {
         // If the dest matches then exit via IO port, otherwise use ring port
-        let dest = obj.destination();
+        let dest = obj.dst_addr();
         Ok(if self.0 == dest { IO_INDEX } else { RING_INDEX })
     }
 }

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-platform"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,9 +23,9 @@ async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.21.0" }
+gwr-models = { path = "../gwr-models", version = "0.22.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 regex.workspace = true

--- a/gwr-platform/src/bin/gen-fabric.rs
+++ b/gwr-platform/src/bin/gen-fabric.rs
@@ -13,6 +13,9 @@ use gwr_platform::builder::{
     DEFAULT_PE_COMPARES_PER_TICK, DEFAULT_PE_LSU_ACCESS_BYTES, DEFAULT_PE_MULS_PER_TICK,
     DEFAULT_PE_NUM_ACTIVE_REQUESTS, DEFAULT_PE_OVERHEAD_SIZE_BYTES, DEFAULT_PE_SRAM_BYTES,
 };
+use gwr_platform::connection_id::{
+    cache_endpoint_id, fabric_port_endpoint_id, mem_endpoint_id, pe_endpoint_id,
+};
 use gwr_platform::types::{
     CacheConfigSection, CacheSection, ConnectSection, FabricKind, FabricSection,
     MemoryDeviceSection, MemoryKind, MemoryMapSection, MemorySection, PlatformConfig,
@@ -195,6 +198,7 @@ fn build_fabrics(args: &Args) -> Vec<FabricSection> {
         tx_buffer_bytes: Some(DEFAULT_FABRIC_TX_BUFFER_BYTES),
         port_bits_per_tick: Some(DEFAULT_FABRIC_PORT_BITS_PER_TICK),
         routing: Some(args.fabric_routing),
+        port_selection: None,
     }]
 }
 
@@ -273,16 +277,16 @@ fn build_connections(args: &Args) -> Result<Vec<ConnectSection>, String> {
     let mut connections = Vec::new();
 
     for (column, row) in PeIdGen::new(args)? {
-        let mut entities = vec![format!("pe.{}", create_name("pe", column, row))];
+        let mut entities = vec![pe_endpoint_id(create_name("pe", column, row))];
 
         if args.l1_kib != 0 {
-            entities.push(format!("cache.{}", create_name("l1", column, row)));
+            entities.push(cache_endpoint_id(create_name("l1", column, row)));
         }
         if args.l2_kib != 0 {
-            entities.push(format!("cache.{}", create_name("l2", column, row)));
+            entities.push(cache_endpoint_id(create_name("l2", column, row)));
         }
 
-        entities.push(format!("fabric.{FABRIC_NAME}@({column},{row})"));
+        entities.push(fabric_port_endpoint_id(FABRIC_NAME, column, row, 0));
 
         for pair in entities.windows(2) {
             connections.push(ConnectSection {
@@ -294,8 +298,8 @@ fn build_connections(args: &Args) -> Result<Vec<ConnectSection>, String> {
     for (i, (column, row)) in HbmIdGen::new(args)?.enumerate() {
         connections.push(ConnectSection {
             connect: vec![
-                format!("mem.hbm{i}"),
-                format!("fabric.{FABRIC_NAME}@({column},{row})"),
+                mem_endpoint_id(format!("hbm{i}")),
+                fabric_port_endpoint_id(FABRIC_NAME, column, row, 0),
             ],
         });
     }

--- a/gwr-platform/src/bin/validate-platform.rs
+++ b/gwr-platform/src/bin/validate-platform.rs
@@ -18,6 +18,10 @@ struct Args {
     /// Print the constructed platform after validation.
     #[arg(long, default_value_t = false)]
     print_platform: bool,
+
+    /// Print derived fabric port maps after validation.
+    #[arg(long, default_value_t = false)]
+    print_fabric_port_maps: bool,
 }
 
 fn main() -> Result<()> {
@@ -38,6 +42,10 @@ fn main() -> Result<()> {
 
     if args.print_platform {
         println!("{platform}");
+    }
+
+    if args.print_fabric_port_maps {
+        print!("{}", platform.fabric_port_map_description());
     }
 
     Ok(())

--- a/gwr-platform/src/builder.rs
+++ b/gwr-platform/src/builder.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Graphcore Ltd. All rights reserved.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::BuildHasher;
 use std::rc::Rc;
 
@@ -10,7 +10,7 @@ use gwr_engine::types::SimError;
 use gwr_models::fabric::functional::FunctionalFabric;
 use gwr_models::fabric::node::FabricRoutingAlgorithm;
 use gwr_models::fabric::routed::RoutedFabric;
-use gwr_models::fabric::{Fabric, FabricConfig};
+use gwr_models::fabric::{Fabric, FabricConfig, FabricPortSelection};
 use gwr_models::memory::cache::{Cache, CacheConfig};
 use gwr_models::memory::memory_access::MemoryAccess;
 use gwr_models::memory::memory_map::MemoryMap;
@@ -18,8 +18,72 @@ use gwr_models::memory::{Memory, MemoryConfig};
 use gwr_models::processing_element::{ProcessingElement, ProcessingElementConfig};
 use gwr_track::entity::{Entity, GetEntity};
 
-use crate::types::{FabricKind, MemoryMapSection, PlatformConfig, ProcessingElementConfigSection};
+use crate::connection_id::{CachePortId, ConnectionEndpointId, parse_connection_endpoint_id};
+use crate::types::{
+    FabricKind, FabricSection, MemoryMapSection, PlatformConfig, ProcessingElementConfigSection,
+};
 use crate::{Caches, DeviceIds, Fabrics, Memories, NameToIdxMap, ProcessingElements};
+
+pub const DEFAULT_HBM_DELAY_TICKS: usize = 10;
+pub const DEFAULT_HBM_BW_BYTES_PER_CYCLE: usize = 32;
+pub const DEFAULT_HBM_SIZE_BYTES: usize = 1024 * 1024 * 1024;
+
+pub fn build_memories(
+    engine: &Engine,
+    clock: &Clock,
+    parent: &Rc<Entity>,
+    cfg: &PlatformConfig,
+) -> Result<(Memories, NameToIdxMap), SimError> {
+    let mut memories = Vec::new();
+    if let Some(memories_section) = &cfg.memories {
+        for memory_section in memories_section {
+            let base_address = memory_section.base_address;
+            let capacity_bytes = memory_section.capacity_bytes as usize;
+            let bw_bytes_per_cycle = memory_section
+                .bw_bytes_per_cycle
+                .unwrap_or(DEFAULT_HBM_BW_BYTES_PER_CYCLE);
+            let delay_ticks = memory_section
+                .delay_ticks
+                .unwrap_or(DEFAULT_HBM_DELAY_TICKS);
+            let config = MemoryConfig::new(
+                base_address,
+                capacity_bytes,
+                bw_bytes_per_cycle,
+                delay_ticks,
+            );
+            memories.push(Memory::new_and_register(
+                engine,
+                clock,
+                parent,
+                memory_section.name.as_str(),
+                config,
+            )?);
+        }
+    }
+
+    let mut memories_idx_by_id = HashMap::new();
+    for (i, memory) in memories.iter().enumerate() {
+        let name = memory.entity().name.to_string();
+        memories_idx_by_id.insert(name, i);
+    }
+
+    Ok((memories, memories_idx_by_id))
+}
+
+pub fn build_memory_maps(
+    cfg: &PlatformConfig,
+    memories: &Memories,
+    memories_idx_by_id: &NameToIdxMap,
+    device_ids: &DeviceIds,
+) -> Result<HashMap<String, Rc<MemoryMap>>, SimError> {
+    let mut memory_maps = HashMap::new();
+    for memory_map in &cfg.memory_maps {
+        let built = build_memory_map(memory_map, memories, memories_idx_by_id, device_ids)?;
+        memory_maps.insert(memory_map.name.clone(), Rc::new(built));
+    }
+
+    Ok(memory_maps)
+}
 
 pub fn build_memory_map(
     cfg: &MemoryMapSection,
@@ -45,21 +109,6 @@ pub fn build_memory_map(
     Ok(memory_map)
 }
 
-pub fn build_memory_maps(
-    cfg: &PlatformConfig,
-    memories: &Memories,
-    memories_idx_by_id: &NameToIdxMap,
-    device_ids: &DeviceIds,
-) -> Result<HashMap<String, Rc<MemoryMap>>, SimError> {
-    let mut memory_maps = HashMap::new();
-    for memory_map in &cfg.memory_maps {
-        let built = build_memory_map(memory_map, memories, memories_idx_by_id, device_ids)?;
-        memory_maps.insert(memory_map.name.clone(), Rc::new(built));
-    }
-
-    Ok(memory_maps)
-}
-
 pub const DEFAULT_PE_NUM_ACTIVE_REQUESTS: usize = 8;
 pub const DEFAULT_PE_LSU_ACCESS_BYTES: usize = 32;
 pub const DEFAULT_PE_SRAM_BYTES: u64 = 1024 * 1024;
@@ -67,35 +116,6 @@ pub const DEFAULT_PE_ADDS_PER_TICK: f64 = 16.0;
 pub const DEFAULT_PE_MULS_PER_TICK: f64 = 4.0;
 pub const DEFAULT_PE_COMPARES_PER_TICK: f64 = DEFAULT_PE_ADDS_PER_TICK;
 pub const DEFAULT_PE_OVERHEAD_SIZE_BYTES: usize = 8;
-
-fn build_pe_config(
-    cfg: &ProcessingElementConfigSection,
-) -> Result<ProcessingElementConfig, SimError> {
-    let num_active_requests = cfg
-        .num_active_requests
-        .unwrap_or(DEFAULT_PE_NUM_ACTIVE_REQUESTS);
-    let lsu_access_bytes = cfg.lsu_access_bytes.unwrap_or(DEFAULT_PE_LSU_ACCESS_BYTES);
-    let overhead_size_bytes = cfg
-        .overhead_size_bytes
-        .unwrap_or(DEFAULT_PE_OVERHEAD_SIZE_BYTES);
-    let sram_bytes = cfg.sram_bytes.unwrap_or(DEFAULT_PE_SRAM_BYTES) as usize;
-
-    let adds_per_tick = cfg.adds_per_tick.unwrap_or(DEFAULT_PE_ADDS_PER_TICK);
-    let muls_per_tick = cfg.muls_per_tick.unwrap_or(DEFAULT_PE_MULS_PER_TICK);
-    let compares_per_tick = cfg
-        .compares_per_tick
-        .unwrap_or(DEFAULT_PE_COMPARES_PER_TICK);
-
-    Ok(ProcessingElementConfig {
-        num_active_requests,
-        lsu_access_bytes,
-        overhead_size_bytes,
-        sram_bytes,
-        adds_per_tick,
-        muls_per_tick,
-        compares_per_tick,
-    })
-}
 
 pub fn build_pes<S: BuildHasher>(
     engine: &Engine,
@@ -134,6 +154,35 @@ pub fn build_pes<S: BuildHasher>(
         pes_idx_by_id.insert(name, i);
     }
     Ok((processing_elements, pes_idx_by_id))
+}
+
+fn build_pe_config(
+    cfg: &ProcessingElementConfigSection,
+) -> Result<ProcessingElementConfig, SimError> {
+    let num_active_requests = cfg
+        .num_active_requests
+        .unwrap_or(DEFAULT_PE_NUM_ACTIVE_REQUESTS);
+    let lsu_access_bytes = cfg.lsu_access_bytes.unwrap_or(DEFAULT_PE_LSU_ACCESS_BYTES);
+    let overhead_size_bytes = cfg
+        .overhead_size_bytes
+        .unwrap_or(DEFAULT_PE_OVERHEAD_SIZE_BYTES);
+    let sram_bytes = cfg.sram_bytes.unwrap_or(DEFAULT_PE_SRAM_BYTES) as usize;
+
+    let adds_per_tick = cfg.adds_per_tick.unwrap_or(DEFAULT_PE_ADDS_PER_TICK);
+    let muls_per_tick = cfg.muls_per_tick.unwrap_or(DEFAULT_PE_MULS_PER_TICK);
+    let compares_per_tick = cfg
+        .compares_per_tick
+        .unwrap_or(DEFAULT_PE_COMPARES_PER_TICK);
+
+    Ok(ProcessingElementConfig {
+        num_active_requests,
+        lsu_access_bytes,
+        overhead_size_bytes,
+        sram_bytes,
+        adds_per_tick,
+        muls_per_tick,
+        compares_per_tick,
+    })
 }
 
 pub const DEFAULT_CACHE_LINE_SIZE_BYTES: usize = 32;
@@ -205,49 +254,73 @@ pub const DEFAULT_FABRIC_RX_BUFFER_BYTES: usize = 256;
 pub const DEFAULT_FABRIC_TX_BUFFER_BYTES: usize = 256;
 pub const DEFAULT_FABRIC_PORT_BITS_PER_TICK: usize = 32 * 8; // 32 bytes per cycle
 pub const DEFAULT_FABRIC_ROUTING: FabricRoutingAlgorithm = FabricRoutingAlgorithm::ColumnFirst;
+pub const DEFAULT_FABRIC_PORT_SELECTION: FabricPortSelection =
+    FabricPortSelection::DestinationAddressHash;
+
+pub type FabricDestinationPortMap = HashMap<u64, Vec<usize>>;
+pub type FabricDestinationPortMaps = HashMap<String, FabricDestinationPortMap>;
+
+pub fn build_fabric_destination_port_maps(
+    cfg: &PlatformConfig,
+    device_ids: &DeviceIds,
+) -> Result<FabricDestinationPortMaps, SimError> {
+    let topology = FabricTopology::new(cfg)?;
+    let mut maps = FabricDestinationPortMaps::new();
+
+    if let Some(fabrics) = &cfg.fabrics {
+        for fabric in fabrics {
+            let mut destination_port_map: FabricDestinationPortMap = HashMap::new();
+            let Some(config) = topology.fabric_configs.get(&fabric.name) else {
+                continue;
+            };
+
+            let mut shortest_distance_by_device = HashMap::new();
+            for port_idx in config.port_indices() {
+                for (device_id, distance) in
+                    topology.device_distances_from_port(&fabric.name, *port_idx, device_ids)
+                {
+                    let shortest = shortest_distance_by_device
+                        .entry(device_id)
+                        .or_insert(distance);
+                    if distance < *shortest {
+                        *shortest = distance;
+                        destination_port_map.insert(device_id, vec![*port_idx]);
+                    } else if distance == *shortest {
+                        destination_port_map
+                            .entry(device_id)
+                            .or_default()
+                            .push(*port_idx);
+                    }
+                }
+            }
+
+            for ports in destination_port_map.values_mut() {
+                ports.sort_unstable();
+                ports.dedup();
+            }
+            maps.insert(fabric.name.clone(), destination_port_map);
+        }
+    }
+
+    Ok(maps)
+}
 
 pub fn build_fabrics(
     engine: &Engine,
     clock: &Clock,
     parent: &Rc<Entity>,
     cfg: &PlatformConfig,
+    fabric_destination_port_maps: &FabricDestinationPortMaps,
 ) -> Result<(Fabrics, NameToIdxMap), SimError> {
     let mut fabrics = Vec::new();
     if let Some(fabric_sections) = &cfg.fabrics {
         for fabric_section in fabric_sections {
-            let fabric_columns = fabric_section.columns;
-            let fabric_rows = fabric_section.rows;
-            let fabric_ports_per_node = fabric_section
-                .fabric_ports_per_node
-                .unwrap_or(DEFAULT_FABRIC_PORTS_PER_NODE);
-            let ticks_per_hop = fabric_section
-                .ticks_per_hop
-                .unwrap_or(DEFAULT_FABRIC_TICKS_PER_HOP);
-            let ticks_overhead = fabric_section
-                .ticks_overhead
-                .unwrap_or(DEFAULT_FABRIC_TICKS_OVERHEAD);
-            let rx_buffer_bytes = fabric_section
-                .rx_buffer_bytes
-                .unwrap_or(DEFAULT_FABRIC_RX_BUFFER_BYTES);
-            let tx_buffer_bytes = fabric_section
-                .tx_buffer_bytes
-                .unwrap_or(DEFAULT_FABRIC_TX_BUFFER_BYTES);
-            let port_bits_per_tick = fabric_section
-                .port_bits_per_tick
-                .unwrap_or(DEFAULT_FABRIC_PORT_BITS_PER_TICK);
             let fabric_algorithm = fabric_section.routing.unwrap_or(DEFAULT_FABRIC_ROUTING);
-
-            let config = Rc::new(FabricConfig::new(
-                fabric_columns,
-                fabric_rows,
-                fabric_ports_per_node,
-                None,
-                ticks_per_hop,
-                ticks_overhead,
-                rx_buffer_bytes,
-                tx_buffer_bytes,
-                port_bits_per_tick,
-            ));
+            let destination_port_map = fabric_destination_port_maps
+                .get(&fabric_section.name)
+                .cloned()
+                .unwrap_or_default();
+            let config = Rc::new(build_fabric_config(fabric_section, destination_port_map)?);
 
             let fabric: Rc<dyn Fabric<MemoryAccess>> = match fabric_section.kind {
                 FabricKind::Functional => FunctionalFabric::new_and_register(
@@ -279,58 +352,261 @@ pub fn build_fabrics(
     Ok((fabrics, fabrics_idx_by_id))
 }
 
-pub const DEFAULT_HBM_DELAY_TICKS: usize = 10;
-pub const DEFAULT_HBM_BW_BYTES_PER_CYCLE: usize = 32;
-pub const DEFAULT_HBM_SIZE_BYTES: usize = 1024 * 1024 * 1024;
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum ResolvedEndpoint {
+    Pe(String),
+    CacheDev(String),
+    CacheMem(String),
+    Mem(String),
+    FabricPort { fabric: String, port_idx: usize },
+}
 
-pub fn build_memories(
-    engine: &Engine,
-    clock: &Clock,
-    parent: &Rc<Entity>,
-    cfg: &PlatformConfig,
-) -> Result<(Memories, NameToIdxMap), SimError> {
-    let mut memories = Vec::new();
-    if let Some(memories_section) = &cfg.memories {
-        for memory_section in memories_section {
-            let base_address = memory_section.base_address;
-            let capacity_bytes = memory_section.capacity_bytes as usize;
-            let bw_bytes_per_cycle = memory_section
-                .bw_bytes_per_cycle
-                .unwrap_or(DEFAULT_HBM_BW_BYTES_PER_CYCLE);
-            let delay_ticks = memory_section
-                .delay_ticks
-                .unwrap_or(DEFAULT_HBM_DELAY_TICKS);
-            let config = MemoryConfig::new(
-                base_address,
-                capacity_bytes,
-                bw_bytes_per_cycle,
-                delay_ticks,
-            );
-            memories.push(Memory::new_and_register(
-                engine,
-                clock,
-                parent,
-                memory_section.name.as_str(),
-                config,
-            )?);
+struct FabricTopology {
+    edges: HashMap<ResolvedEndpoint, HashSet<ResolvedEndpoint>>,
+    fabric_configs: HashMap<String, FabricConfig>,
+}
+
+impl FabricTopology {
+    fn new(cfg: &PlatformConfig) -> Result<Self, SimError> {
+        let mut topology = Self {
+            edges: HashMap::new(),
+            fabric_configs: build_empty_fabric_configs(cfg)?,
+        };
+        topology.add_cache_passthroughs(cfg);
+        topology.add_connection_edges(cfg)?;
+        Ok(topology)
+    }
+
+    fn add_edge(&mut self, a: ResolvedEndpoint, b: ResolvedEndpoint) {
+        self.edges.entry(a.clone()).or_default().insert(b.clone());
+        self.edges.entry(b).or_default().insert(a);
+    }
+
+    fn add_cache_passthroughs(&mut self, cfg: &PlatformConfig) {
+        if let Some(caches) = &cfg.caches {
+            for cache in caches {
+                self.add_edge(
+                    ResolvedEndpoint::CacheDev(cache.name.clone()),
+                    ResolvedEndpoint::CacheMem(cache.name.clone()),
+                );
+            }
         }
     }
 
-    let mut memories_idx_by_id = HashMap::new();
-    for (i, memory) in memories.iter().enumerate() {
-        let name = memory.entity().name.to_string();
-        memories_idx_by_id.insert(name, i);
+    fn add_connection_edges(&mut self, cfg: &PlatformConfig) -> Result<(), SimError> {
+        if let Some(connections) = &cfg.connections {
+            for c in connections {
+                if c.connect.len() != 2 {
+                    return Err(SimError(format!(
+                        "Invalid 'connect' with {} entries (only 2 expected)",
+                        c.connect.len()
+                    )));
+                }
+                let (a, b) = self.parse_topology_connection(&c.connect[0], &c.connect[1])?;
+                self.add_edge(a, b);
+            }
+        }
+        Ok(())
     }
 
-    Ok((memories, memories_idx_by_id))
+    fn device_distances_from_port(
+        &self,
+        target_fabric: &str,
+        start_port_idx: usize,
+        device_ids: &DeviceIds,
+    ) -> HashMap<u64, usize> {
+        let mut found = HashMap::new();
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        let start = ResolvedEndpoint::FabricPort {
+            fabric: target_fabric.to_string(),
+            port_idx: start_port_idx,
+        };
+        visited.insert(start.clone());
+        queue.push_back((start, 0));
+
+        while let Some((node, distance)) = queue.pop_front() {
+            match &node {
+                ResolvedEndpoint::Pe(name) | ResolvedEndpoint::Mem(name) => {
+                    if let Some(device_id) = device_ids.get(name) {
+                        found.entry(device_id.0).or_insert(distance);
+                    }
+                }
+                _ => {}
+            }
+
+            if let Some(neighbors) = self.edges.get(&node) {
+                for neighbor in neighbors {
+                    if visited.insert(neighbor.clone()) {
+                        queue.push_back((neighbor.clone(), distance + 1));
+                    }
+                }
+            }
+
+            if let ResolvedEndpoint::FabricPort { fabric, .. } = &node
+                && fabric != target_fabric
+                && let Some(config) = self.fabric_configs.get(fabric)
+            {
+                for port_idx in config.port_indices() {
+                    let neighbor = ResolvedEndpoint::FabricPort {
+                        fabric: fabric.clone(),
+                        port_idx: *port_idx,
+                    };
+                    if visited.insert(neighbor.clone()) {
+                        queue.push_back((neighbor, distance + 1));
+                    }
+                }
+            }
+        }
+
+        found
+    }
+
+    fn parse_topology_connection(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> Result<(ResolvedEndpoint, ResolvedEndpoint), SimError> {
+        let from_raw = parse_connection_endpoint_id(from)?;
+        let to_raw = parse_connection_endpoint_id(to)?;
+        Ok((
+            self.resolve_topology_node(&from_raw, &to_raw, true)?,
+            self.resolve_topology_node(&to_raw, &from_raw, false)?,
+        ))
+    }
+
+    fn resolve_topology_node(
+        &self,
+        node: &ConnectionEndpointId,
+        other: &ConnectionEndpointId,
+        is_from: bool,
+    ) -> Result<ResolvedEndpoint, SimError> {
+        match node {
+            ConnectionEndpointId::Pe { name } => Ok(ResolvedEndpoint::Pe(name.clone())),
+            ConnectionEndpointId::Mem { name } => Ok(ResolvedEndpoint::Mem(name.clone())),
+            ConnectionEndpointId::FabricPort {
+                fabric,
+                column,
+                row,
+                port,
+            } => Ok(ResolvedEndpoint::FabricPort {
+                fabric: fabric.clone(),
+                port_idx: self.fabric_port_endpoint_to_index(fabric, *column, *row, *port)?,
+            }),
+            ConnectionEndpointId::Cache { name, port } => match port {
+                Some(CachePortId::Dev) => Ok(ResolvedEndpoint::CacheDev(name.clone())),
+                Some(CachePortId::Mem) => Ok(ResolvedEndpoint::CacheMem(name.clone())),
+                None => match other {
+                    ConnectionEndpointId::Pe { .. } => Ok(ResolvedEndpoint::CacheDev(name.clone())),
+                    ConnectionEndpointId::Cache { .. } if is_from => {
+                        Ok(ResolvedEndpoint::CacheMem(name.clone()))
+                    }
+                    ConnectionEndpointId::Cache { .. } => {
+                        Ok(ResolvedEndpoint::CacheDev(name.clone()))
+                    }
+                    ConnectionEndpointId::Mem { .. } | ConnectionEndpointId::FabricPort { .. } => {
+                        Ok(ResolvedEndpoint::CacheMem(name.clone()))
+                    }
+                },
+            },
+        }
+    }
+
+    fn fabric_port_endpoint_to_index(
+        &self,
+        fabric: &str,
+        column: usize,
+        row: usize,
+        port: usize,
+    ) -> Result<usize, SimError> {
+        let config = self
+            .fabric_configs
+            .get(fabric)
+            .ok_or_else(|| SimError(format!("Unknown fabric '{fabric}'")))?;
+        if column >= config.num_columns() {
+            return Err(SimError(format!(
+                "Fabric '{fabric}' column {column} is out of range"
+            )));
+        }
+        if row >= config.num_rows() {
+            return Err(SimError(format!(
+                "Fabric '{fabric}' row {row} is out of range"
+            )));
+        }
+
+        if port >= config.node_num_ingress_egress_ports(column, row) {
+            return Err(SimError(format!(
+                "Fabric '{fabric}' port ({column},{row},{port}) is not populated"
+            )));
+        }
+        Ok(config.col_row_port_to_fabric_port_index(column, row, port))
+    }
+}
+
+fn build_empty_fabric_configs(
+    cfg: &PlatformConfig,
+) -> Result<HashMap<String, FabricConfig>, SimError> {
+    // These configs are topology-only: the destination port maps have not been
+    // derived yet, so they are built empty and used only for fabric geometry.
+    let mut fabric_configs = HashMap::new();
+    if let Some(fabrics) = &cfg.fabrics {
+        for fabric in fabrics {
+            let config = build_fabric_config(fabric, HashMap::new())?;
+            fabric_configs.insert(fabric.name.clone(), config);
+        }
+    }
+    Ok(fabric_configs)
+}
+
+fn build_fabric_config(
+    fabric_section: &FabricSection,
+    destination_port_map: FabricDestinationPortMap,
+) -> Result<FabricConfig, SimError> {
+    let fabric_columns = fabric_section.columns;
+    let fabric_rows = fabric_section.rows;
+    let fabric_ports_per_node = fabric_section
+        .fabric_ports_per_node
+        .unwrap_or(DEFAULT_FABRIC_PORTS_PER_NODE);
+    let ticks_per_hop = fabric_section
+        .ticks_per_hop
+        .unwrap_or(DEFAULT_FABRIC_TICKS_PER_HOP);
+    let ticks_overhead = fabric_section
+        .ticks_overhead
+        .unwrap_or(DEFAULT_FABRIC_TICKS_OVERHEAD);
+    let rx_buffer_bytes = fabric_section
+        .rx_buffer_bytes
+        .unwrap_or(DEFAULT_FABRIC_RX_BUFFER_BYTES);
+    let tx_buffer_bytes = fabric_section
+        .tx_buffer_bytes
+        .unwrap_or(DEFAULT_FABRIC_TX_BUFFER_BYTES);
+    let port_bits_per_tick = fabric_section
+        .port_bits_per_tick
+        .unwrap_or(DEFAULT_FABRIC_PORT_BITS_PER_TICK);
+    let port_selection = fabric_section
+        .port_selection
+        .unwrap_or(DEFAULT_FABRIC_PORT_SELECTION);
+
+    Ok(FabricConfig::new(
+        fabric_columns,
+        fabric_rows,
+        fabric_ports_per_node,
+        None,
+        ticks_per_hop,
+        ticks_overhead,
+        rx_buffer_bytes,
+        tx_buffer_bytes,
+        port_bits_per_tick,
+        destination_port_map,
+    )?
+    .with_port_selection(port_selection))
 }
 
 #[cfg(test)]
 mod tests {
     use gwr_engine::test_helpers::start_test;
-    use gwr_models::memory::memory_map::DeviceId;
+    use gwr_engine::types::DeviceId;
 
-    use super::{build_memories, build_memory_maps};
+    use super::{build_fabric_destination_port_maps, build_memories, build_memory_maps};
     use crate::DeviceIds;
     use crate::types::{
         MemoryDeviceSection, MemoryKind, MemoryMapSection, MemorySection, PlatformConfig,
@@ -373,5 +649,299 @@ mod tests {
         assert_eq!(memory_map.lookup(0x4000), Some((DeviceId(7), 0)));
         assert_eq!(memory_map.lookup(0x5fff), Some((DeviceId(7), 0x1fff)));
         assert_eq!(memory_map.lookup(0x6000), None);
+    }
+
+    #[test]
+    fn derives_fabric_port_maps_from_direct_connections() {
+        let cfg: PlatformConfig = serde_yaml::from_str(
+            "
+memory_maps:
+  - name: mm0
+    devices:
+      - name: hbm0
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config: {}
+fabrics:
+  - name: fabric0
+    kind: functional
+    columns: 2
+    rows: 1
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 1024
+connections:
+  - connect:
+    - pe.pe0
+    - fabric.fabric0@(0,0)
+  - connect:
+    - mem.hbm0
+    - fabric.fabric0@(1,0)
+",
+        )
+        .expect("platform yaml should parse");
+        let device_ids = DeviceIds::from([
+            ("pe0".to_string(), DeviceId(0)),
+            ("hbm0".to_string(), DeviceId(1)),
+        ]);
+
+        let maps = build_fabric_destination_port_maps(&cfg, &device_ids)
+            .expect("fabric maps should build");
+        let fabric_map = maps.get("fabric0").expect("fabric map should exist");
+
+        assert_eq!(fabric_map.get(&0), Some(&vec![0]));
+        assert_eq!(fabric_map.get(&1), Some(&vec![1]));
+    }
+
+    #[test]
+    fn derives_fabric_port_maps_through_cache() {
+        let cfg: PlatformConfig = serde_yaml::from_str(
+            "
+memory_maps:
+  - name: mm0
+    devices:
+      - name: hbm0
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config: {}
+caches:
+  - name: l1
+    config: {}
+fabrics:
+  - name: fabric0
+    kind: functional
+    columns: 2
+    rows: 1
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 1024
+connections:
+  - connect:
+    - pe.pe0
+    - cache.l1
+  - connect:
+    - cache.l1
+    - fabric.fabric0@(0,0)
+  - connect:
+    - mem.hbm0
+    - fabric.fabric0@(1,0)
+",
+        )
+        .expect("platform yaml should parse");
+        let device_ids = DeviceIds::from([
+            ("pe0".to_string(), DeviceId(0)),
+            ("hbm0".to_string(), DeviceId(1)),
+        ]);
+
+        let maps = build_fabric_destination_port_maps(&cfg, &device_ids)
+            .expect("fabric maps should build");
+        let fabric_map = maps.get("fabric0").expect("fabric map should exist");
+
+        assert_eq!(fabric_map.get(&0), Some(&vec![0]));
+        assert_eq!(fabric_map.get(&1), Some(&vec![1]));
+    }
+
+    #[test]
+    fn derives_multiple_candidate_ports_for_same_device() {
+        let cfg: PlatformConfig = serde_yaml::from_str(
+            "
+memory_maps:
+  - name: mm0
+    devices:
+      - name: hbm0
+fabrics:
+  - name: fabric0
+    kind: functional
+    columns: 2
+    rows: 1
+    fabric_ports_per_node: 2
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 1024
+connections:
+  - connect:
+    - mem.hbm0
+    - fabric.fabric0@(1,0)
+  - connect:
+    - mem.hbm0
+    - fabric.fabric0@(1,0).1
+",
+        )
+        .expect("platform yaml should parse");
+        let device_ids = DeviceIds::from([("hbm0".to_string(), DeviceId(7))]);
+
+        let maps = build_fabric_destination_port_maps(&cfg, &device_ids)
+            .expect("fabric maps should build");
+        let fabric_map = maps.get("fabric0").expect("fabric map should exist");
+
+        assert_eq!(fabric_map.get(&7), Some(&vec![2, 3]));
+    }
+
+    #[test]
+    fn derives_fabric_port_maps_through_single_fabric_link() {
+        let cfg: PlatformConfig = serde_yaml::from_str(
+            "
+memory_maps:
+  - name: mm0
+    devices: []
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config: {}
+  - name: pe1
+    memory_map: mm0
+    config: {}
+fabrics:
+  - name: fabric0
+    kind: functional
+    columns: 2
+    rows: 1
+  - name: fabric1
+    kind: functional
+    columns: 2
+    rows: 1
+connections:
+  - connect:
+    - pe.pe0
+    - fabric.fabric0@(0,0)
+  - connect:
+    - pe.pe1
+    - fabric.fabric1@(0,0)
+  - connect:
+    - fabric.fabric0@(1,0)
+    - fabric.fabric1@(1,0)
+",
+        )
+        .expect("platform yaml should parse");
+        let device_ids = DeviceIds::from([
+            ("pe0".to_string(), DeviceId(0)),
+            ("pe1".to_string(), DeviceId(1)),
+        ]);
+
+        let maps = build_fabric_destination_port_maps(&cfg, &device_ids)
+            .expect("fabric maps should build");
+        let fabric0_map = maps.get("fabric0").expect("fabric0 map should exist");
+        let fabric1_map = maps.get("fabric1").expect("fabric1 map should exist");
+
+        assert_eq!(fabric0_map.get(&0), Some(&vec![0]));
+        assert_eq!(fabric0_map.get(&1), Some(&vec![1]));
+        assert_eq!(fabric1_map.get(&0), Some(&vec![1]));
+        assert_eq!(fabric1_map.get(&1), Some(&vec![0]));
+    }
+
+    #[test]
+    fn derives_fabric_port_maps_through_two_fabric_links() {
+        let cfg: PlatformConfig = serde_yaml::from_str(
+            "
+memory_maps:
+  - name: mm0
+    devices: []
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config: {}
+  - name: pe1
+    memory_map: mm0
+    config: {}
+fabrics:
+  - name: fabric0
+    kind: functional
+    columns: 3
+    rows: 1
+  - name: fabric1
+    kind: functional
+    columns: 3
+    rows: 1
+connections:
+  - connect:
+    - pe.pe0
+    - fabric.fabric0@(0,0)
+  - connect:
+    - fabric.fabric0@(1,0)
+    - fabric.fabric1@(1,0)
+  - connect:
+    - fabric.fabric0@(2,0)
+    - fabric.fabric1@(0,0)
+  - connect:
+    - pe.pe1
+    - fabric.fabric1@(2,0)
+",
+        )
+        .expect("platform yaml should parse");
+        let device_ids = DeviceIds::from([
+            ("pe0".to_string(), DeviceId(0)),
+            ("pe1".to_string(), DeviceId(1)),
+        ]);
+
+        let maps = build_fabric_destination_port_maps(&cfg, &device_ids)
+            .expect("fabric maps should build");
+        let fabric0_map = maps.get("fabric0").expect("fabric0 map should exist");
+        let fabric1_map = maps.get("fabric1").expect("fabric1 map should exist");
+
+        assert_eq!(fabric0_map.get(&0), Some(&vec![0]));
+        assert_eq!(fabric0_map.get(&1), Some(&vec![1, 2]));
+        assert_eq!(fabric1_map.get(&0), Some(&vec![0, 1]));
+        assert_eq!(fabric1_map.get(&1), Some(&vec![2]));
+    }
+
+    #[test]
+    fn derives_only_shortest_fabric_port_maps_through_cycle() {
+        let cfg: PlatformConfig = serde_yaml::from_str(
+            "
+memory_maps:
+  - name: mm0
+    devices: []
+processing_elements:
+  - name: pe1
+    memory_map: mm0
+    config: {}
+fabrics:
+  - name: fabric0
+    kind: functional
+    columns: 3
+    rows: 1
+  - name: fabric1
+    kind: functional
+    columns: 3
+    rows: 1
+  - name: fabric2
+    kind: functional
+    columns: 3
+    rows: 1
+connections:
+  - connect:
+    - pe.pe1
+    - fabric.fabric1@(0,0)
+  - connect:
+    - fabric.fabric0@(1,0)
+    - fabric.fabric1@(1,0)
+  - connect:
+    - fabric.fabric1@(2,0)
+    - fabric.fabric2@(1,0)
+  - connect:
+    - fabric.fabric2@(2,0)
+    - fabric.fabric0@(2,0)
+",
+        )
+        .expect("platform yaml should parse");
+        let device_ids = DeviceIds::from([("pe1".to_string(), DeviceId(1))]);
+
+        let maps = build_fabric_destination_port_maps(&cfg, &device_ids)
+            .expect("fabric maps should build");
+        let fabric0_map = maps.get("fabric0").expect("fabric0 map should exist");
+        let fabric1_map = maps.get("fabric1").expect("fabric1 map should exist");
+        let fabric2_map = maps.get("fabric2").expect("fabric2 map should exist");
+
+        assert_eq!(fabric0_map.get(&1), Some(&vec![1]));
+        assert_eq!(fabric1_map.get(&1), Some(&vec![0]));
+        assert_eq!(fabric2_map.get(&1), Some(&vec![1]));
     }
 }

--- a/gwr-platform/src/connect.rs
+++ b/gwr-platform/src/connect.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 Graphcore Ltd. All rights reserved.
 
 use std::rc::Rc;
-use std::str::Split;
-use std::sync::LazyLock;
 
 use gwr_engine::sim_error;
 use gwr_engine::types::{SimError, SimResult};
@@ -13,9 +11,9 @@ use gwr_models::memory::memory_access::MemoryAccess;
 use gwr_models::processing_element::ProcessingElement;
 use gwr_track::debug;
 use gwr_track::entity::GetEntity;
-use regex::Regex;
 
 use crate::Platform;
+use crate::connection_id::{CachePortId, ConnectionEndpointId, parse_connection_endpoint_id};
 use crate::types::PlatformConfig;
 
 pub enum PortId<'a> {
@@ -24,7 +22,7 @@ pub enum PortId<'a> {
     },
     Cache {
         cache: &'a Rc<Cache<MemoryAccess>>,
-        port: Option<&'a str>,
+        port: Option<CachePortId>,
     },
     Mem {
         memory: &'a Rc<Memory<MemoryAccess>>,
@@ -35,79 +33,37 @@ pub enum PortId<'a> {
     },
 }
 
-/// Parse a Fabric port ID of the form:
-///   fabric.name@(col,row)[.port]
-fn parse_fabric_port_id<'a>(platform: &'a Platform, s: &'a str) -> Result<PortId<'a>, SimError> {
-    static FABRIC_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"^fabric\.([A-Za-z0-9_]+)@\((\d+),(\d+)\)(?:\.(.*))?$").unwrap()
-    });
-
-    if let Some(caps) = FABRIC_RE.captures(s) {
-        let name = &caps[1];
-        let col = caps[2].parse().map_err(|e| SimError(format!("{e}")))?;
-        let row = caps[3].parse().map_err(|e| SimError(format!("{e}")))?;
-
-        // Assume a default port index 0 if not provided
-        let port_num = match caps.get(4) {
-            Some(m) => m.as_str(),
-            None => "0",
-        };
-        let port = port_num.parse().map_err(|e| SimError(format!("{e}")))?;
-
-        let fabric = platform.fabric(name)?;
-        let port_idx = fabric.col_row_port_to_fabric_port_index(col, row, port);
-        Ok(PortId::FabricTile { fabric, port_idx })
-    } else {
-        sim_error!("Unable to parse Fabric port '{s}'")
-    }
+pub fn parse_port_id<'a>(platform: &'a Platform, s: &str) -> Result<PortId<'a>, SimError> {
+    let endpoint = parse_connection_endpoint_id(s)?;
+    resolve_port_id(platform, &endpoint)
 }
 
-pub fn parse_port_id<'a>(
+fn resolve_port_id<'a>(
     platform: &'a Platform,
-    s: &'a str,
-) -> Result<(PortId<'a>, Split<'a, char>), SimError> {
-    let mut parts = s.split('.');
-    let kind = parts
-        .next()
-        .ok_or_else(|| SimError(format!("Failed to parse kind in '{s}'")))?;
-
-    if kind == "fabric" {
-        return Ok((parse_fabric_port_id(platform, s)?, parts));
-    }
-
-    // Parse ports IDs of the form: kind.name[.port]
-    let name = parts
-        .next()
-        .ok_or_else(|| SimError(format!("Failed to parse name in '{s}'")))?;
-    let port = parts.next();
-    if parts.next().is_some() {
-        return sim_error!("Failed to parse '{s}' - extra tokens");
-    }
-
-    Ok((
-        match kind {
-            "pe" => {
-                let pe = match port {
-                    Some(_) => return sim_error!("Cannot specify a port for PE"),
-                    None => platform.pe(name)?,
-                };
-                PortId::Pe { pe }
-            }
-            "cache" => {
-                let cache = platform.cache(name)?;
-                PortId::Cache { cache, port }
-            }
-            "mem" => {
-                let memory = match port {
-                    Some(_) => return sim_error!("Cannot specify a port for Memory"),
-                    None => platform.memory(name)?,
-                };
-                PortId::Mem { memory }
-            }
-            _ => return sim_error!("Failed to parse '{s}' - unsupported kind"),
+    endpoint: &ConnectionEndpointId,
+) -> Result<PortId<'a>, SimError> {
+    Ok(match endpoint {
+        ConnectionEndpointId::Pe { name } => PortId::Pe {
+            pe: platform.pe(name)?,
         },
-        parts,
-    ))
+        ConnectionEndpointId::Cache { name, port } => PortId::Cache {
+            cache: platform.cache(name)?,
+            port: port.clone(),
+        },
+        ConnectionEndpointId::Mem { name } => PortId::Mem {
+            memory: platform.memory(name)?,
+        },
+        ConnectionEndpointId::FabricPort {
+            fabric,
+            column,
+            row,
+            port,
+        } => {
+            let fabric = platform.fabric(fabric)?;
+            let port_idx = fabric.col_row_port_to_fabric_port_index(*column, *row, *port);
+            PortId::FabricTile { fabric, port_idx }
+        }
+    })
 }
 
 pub fn connect_ports(platform: &Platform, cfg: &PlatformConfig) -> SimResult {
@@ -120,8 +76,8 @@ pub fn connect_ports(platform: &Platform, cfg: &PlatformConfig) -> SimResult {
                 );
             }
 
-            let (from, _) = parse_port_id(platform, &c.connect[0])?;
-            let (to, _) = parse_port_id(platform, &c.connect[1])?;
+            let from = parse_port_id(platform, &c.connect[0])?;
+            let to = parse_port_id(platform, &c.connect[1])?;
             connect_port(platform, &from, &to)?;
         }
     }
@@ -131,7 +87,7 @@ pub fn connect_ports(platform: &Platform, cfg: &PlatformConfig) -> SimResult {
 fn connect_port(platform: &Platform, from: &PortId, to: &PortId) -> SimResult {
     match from {
         PortId::Pe { pe } => connect_pe_to(platform, pe, to),
-        PortId::Cache { cache, port } => connect_cache_to(platform, cache, *port, to),
+        PortId::Cache { cache, port } => connect_cache_to(platform, cache, port.as_ref(), to),
         PortId::FabricTile { fabric, port_idx } => {
             connect_fabric_to(platform, fabric, *port_idx, to)
         }
@@ -144,7 +100,7 @@ fn connect_pe_to(platform: &Platform, pe: &Rc<ProcessingElement>, to: &PortId) -
         PortId::Pe { .. } => {
             sim_error!("Cannot connect a PE directly to a PE")
         }
-        PortId::Cache { cache, port } => connect_pe_to_cache(platform, pe, cache, *port),
+        PortId::Cache { cache, port } => connect_pe_to_cache(platform, pe, cache, port.as_ref()),
         PortId::FabricTile { fabric, port_idx } => {
             connect_pe_to_fabric(platform, pe, fabric, *port_idx)
         }
@@ -155,7 +111,7 @@ fn connect_pe_to(platform: &Platform, pe: &Rc<ProcessingElement>, to: &PortId) -
 fn connect_cache_to(
     platform: &Platform,
     cache: &Rc<Cache<MemoryAccess>>,
-    cache_port: Option<&str>,
+    cache_port: Option<&CachePortId>,
     to: &PortId,
 ) -> SimResult {
     match to {
@@ -163,7 +119,7 @@ fn connect_cache_to(
         PortId::Cache {
             cache: to_cache,
             port,
-        } => connect_cache_to_cache(platform, cache, cache_port, to_cache, *port),
+        } => connect_cache_to_cache(platform, cache, cache_port, to_cache, port.as_ref()),
         PortId::FabricTile { fabric, port_idx } => {
             connect_cache_to_fabric(platform, cache, cache_port, fabric, *port_idx)
         }
@@ -180,7 +136,7 @@ fn connect_fabric_to(
     match to {
         PortId::Pe { pe } => connect_pe_to_fabric(platform, pe, fabric, fabric_port_idx),
         PortId::Cache { cache, port } => {
-            connect_cache_to_fabric(platform, cache, *port, fabric, fabric_port_idx)
+            connect_cache_to_fabric(platform, cache, port.as_ref(), fabric, fabric_port_idx)
         }
         PortId::FabricTile {
             fabric: to_fabric,
@@ -199,7 +155,9 @@ fn connect_memory_to(
 ) -> SimResult {
     match to {
         PortId::Pe { pe } => connect_pe_to_memory(platform, pe, memory),
-        PortId::Cache { cache, port } => connect_cache_to_memory(platform, cache, *port, memory),
+        PortId::Cache { cache, port } => {
+            connect_cache_to_memory(platform, cache, port.as_ref(), memory)
+        }
         PortId::FabricTile { fabric, port_idx } => {
             connect_memory_to_fabric(platform, memory, fabric, *port_idx)
         }
@@ -213,10 +171,10 @@ fn connect_pe_to_cache(
     platform: &Platform,
     pe: &Rc<ProcessingElement>,
     cache: &Rc<Cache<MemoryAccess>>,
-    cache_port: Option<&str>,
+    cache_port: Option<&CachePortId>,
 ) -> SimResult {
     if let Some(cache_port) = cache_port
-        && cache_port != "dev"
+        && cache_port != &CachePortId::Dev
     {
         return sim_error!("PEs can only connect to the 'dev' port on the Cache");
     }
@@ -250,12 +208,12 @@ fn connect_pe_to_memory(
 fn connect_cache_to_fabric(
     platform: &Platform,
     cache: &Rc<Cache<MemoryAccess>>,
-    cache_port: Option<&str>,
+    cache_port: Option<&CachePortId>,
     fabric: &Rc<dyn Fabric<MemoryAccess>>,
     fabric_port_idx: usize,
 ) -> SimResult {
     if let Some(cache_port) = cache_port
-        && cache_port != "mem"
+        && cache_port != &CachePortId::Mem
     {
         return sim_error!("Cache should connect the 'mem' port to a Fabric");
     }
@@ -268,11 +226,11 @@ fn connect_cache_to_fabric(
 fn connect_cache_to_memory(
     platform: &Platform,
     cache: &Rc<Cache<MemoryAccess>>,
-    cache_port: Option<&str>,
+    cache_port: Option<&CachePortId>,
     memory: &Rc<Memory<MemoryAccess>>,
 ) -> SimResult {
     if let Some(cache_port) = cache_port
-        && cache_port != "mem"
+        && cache_port != &CachePortId::Mem
     {
         return sim_error!("Cache should connect the 'mem' port to a Memory");
     }
@@ -285,12 +243,12 @@ fn connect_cache_to_memory(
 fn connect_cache_to_cache(
     platform: &Platform,
     from_cache: &Rc<Cache<MemoryAccess>>,
-    from_port: Option<&str>,
+    from_port: Option<&CachePortId>,
     to_cache: &Rc<Cache<MemoryAccess>>,
-    to_port: Option<&str>,
+    to_port: Option<&CachePortId>,
 ) -> SimResult {
     if let Some(from_port) = from_port
-        && from_port != "mem"
+        && from_port != &CachePortId::Mem
     {
         return sim_error!(
             "When connecting Cache to Cache, connect 'mem' to 'dev' (or simply don't specify ports)"
@@ -298,7 +256,7 @@ fn connect_cache_to_cache(
     }
 
     if let Some(to_port) = to_port
-        && to_port != "dev"
+        && to_port != &CachePortId::Dev
     {
         return sim_error!(
             "When connecting Cache to Cache, connect 'mem' to 'dev' (or simply don't specify ports)"

--- a/gwr-platform/src/connection_id.rs
+++ b/gwr-platform/src/connection_id.rs
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+//! Helpers for parsing and formatting platform connection endpoint IDs.
+//!
+//! Endpoint IDs use the same textual forms accepted in platform YAML
+//! `connections` entries:
+//! - `pe.<name>`
+//! - `cache.<name>[.dev|.mem]`
+//! - `mem.<name>`
+//! - `fabric.<name>@(<column>,<row>)[.<port>]`
+//!
+//! Fabric endpoints omit `.0` when formatted because port 0 is the default.
+
+use std::fmt;
+use std::sync::LazyLock;
+
+use gwr_engine::types::SimError;
+use regex::Regex;
+
+/// Identifies one of the cache's external connection ports.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CachePortId {
+    /// Device-facing cache port.
+    Dev,
+
+    /// Memory-facing cache port.
+    Mem,
+}
+
+impl CachePortId {
+    /// Returns the endpoint suffix used for this cache port.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Mem => "mem",
+        }
+    }
+}
+
+impl fmt::Display for CachePortId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Parsed platform connection endpoint.
+///
+/// The display form round-trips through [`parse_connection_endpoint_id`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConnectionEndpointId {
+    /// Processing element endpoint, formatted as `pe.<name>`.
+    Pe {
+        /// Processing element name.
+        name: String,
+    },
+
+    /// Cache endpoint, formatted as `cache.<name>[.dev|.mem]`.
+    Cache {
+        /// Cache name.
+        name: String,
+
+        /// Optional explicit cache port. When omitted, connection builders
+        /// infer the side from the other endpoint.
+        port: Option<CachePortId>,
+    },
+
+    /// Memory endpoint, formatted as `mem.<name>`.
+    Mem {
+        /// Memory name.
+        name: String,
+    },
+
+    /// Fabric tile port endpoint, formatted as
+    /// `fabric.<name>@(<column>,<row>)[.<port>]`.
+    FabricPort {
+        /// Fabric name.
+        fabric: String,
+
+        /// Fabric column coordinate.
+        column: usize,
+
+        /// Fabric row coordinate.
+        row: usize,
+
+        /// Ingress/egress port number on the tile. Port 0 is omitted when
+        /// formatted.
+        port: usize,
+    },
+}
+
+impl fmt::Display for ConnectionEndpointId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pe { name } => write!(f, "pe.{name}"),
+            Self::Cache { name, port } => {
+                write!(f, "cache.{name}")?;
+                if let Some(port) = port {
+                    write!(f, ".{port}")?;
+                }
+                Ok(())
+            }
+            Self::Mem { name } => write!(f, "mem.{name}"),
+            Self::FabricPort {
+                fabric,
+                column,
+                row,
+                port,
+            } => {
+                write!(f, "fabric.{fabric}@({column},{row})")?;
+                if *port != 0 {
+                    write!(f, ".{port}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Parses a platform connection endpoint ID.
+///
+/// Supported forms are `pe.<name>`, `cache.<name>[.dev|.mem]`,
+/// `mem.<name>`, and `fabric.<name>@(<column>,<row>)[.<port>]`. Fabric ports
+/// default to port 0 when the suffix is omitted.
+pub fn parse_connection_endpoint_id(s: &str) -> Result<ConnectionEndpointId, SimError> {
+    if s.starts_with("fabric.") {
+        return parse_fabric_port_id(s);
+    }
+
+    let mut parts = s.split('.');
+    let kind = parts
+        .next()
+        .ok_or_else(|| SimError(format!("Failed to parse kind in '{s}'")))?;
+    let name = parts
+        .next()
+        .ok_or_else(|| SimError(format!("Failed to parse name in '{s}'")))?;
+    let port = parts.next();
+    if parts.next().is_some() {
+        return Err(SimError(format!("Failed to parse '{s}' - extra tokens")));
+    }
+
+    match kind {
+        "pe" => {
+            if port.is_some() {
+                return Err(SimError("Cannot specify a port for PE".to_string()));
+            }
+            Ok(ConnectionEndpointId::Pe {
+                name: name.to_string(),
+            })
+        }
+        "cache" => Ok(ConnectionEndpointId::Cache {
+            name: name.to_string(),
+            port: port.map(parse_cache_port_id).transpose()?,
+        }),
+        "mem" => {
+            if port.is_some() {
+                return Err(SimError("Cannot specify a port for Memory".to_string()));
+            }
+            Ok(ConnectionEndpointId::Mem {
+                name: name.to_string(),
+            })
+        }
+        _ => Err(SimError(format!(
+            "Failed to parse '{s}' - unsupported kind"
+        ))),
+    }
+}
+
+fn parse_cache_port_id(s: &str) -> Result<CachePortId, SimError> {
+    match s {
+        "dev" => Ok(CachePortId::Dev),
+        "mem" => Ok(CachePortId::Mem),
+        other => Err(SimError(format!("Unsupported Cache port '{other}'"))),
+    }
+}
+
+fn parse_fabric_port_id(s: &str) -> Result<ConnectionEndpointId, SimError> {
+    static FABRIC_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^fabric\.([A-Za-z0-9_]+)@\((\d+),(\d+)\)(?:\.(.*))?$").unwrap()
+    });
+
+    let caps = FABRIC_RE
+        .captures(s)
+        .ok_or_else(|| SimError(format!("Unable to parse Fabric port '{s}'")))?;
+    let fabric = caps[1].to_string();
+    let column = caps[2].parse().map_err(|e| SimError(format!("{e}")))?;
+    let row = caps[3].parse().map_err(|e| SimError(format!("{e}")))?;
+    let port = caps
+        .get(4)
+        .map_or("0", |m| m.as_str())
+        .parse()
+        .map_err(|e| SimError(format!("{e}")))?;
+
+    Ok(ConnectionEndpointId::FabricPort {
+        fabric,
+        column,
+        row,
+        port,
+    })
+}
+
+/// Formats a processing element endpoint ID.
+pub fn pe_endpoint_id(name: impl Into<String>) -> String {
+    ConnectionEndpointId::Pe { name: name.into() }.to_string()
+}
+
+/// Formats a cache endpoint ID without an explicit cache port.
+///
+/// Portless cache endpoints let the connection builder infer `dev` or `mem`
+/// from the other endpoint.
+pub fn cache_endpoint_id(name: impl Into<String>) -> String {
+    ConnectionEndpointId::Cache {
+        name: name.into(),
+        port: None,
+    }
+    .to_string()
+}
+
+/// Formats a memory endpoint ID.
+pub fn mem_endpoint_id(name: impl Into<String>) -> String {
+    ConnectionEndpointId::Mem { name: name.into() }.to_string()
+}
+
+/// Formats a fabric tile port endpoint ID.
+///
+/// Port 0 is treated as the default and is omitted from the formatted string.
+pub fn fabric_port_endpoint_id(
+    fabric: impl Into<String>,
+    column: usize,
+    row: usize,
+    port: usize,
+) -> String {
+    ConnectionEndpointId::FabricPort {
+        fabric: fabric.into(),
+        column,
+        row,
+        port,
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CachePortId, ConnectionEndpointId, fabric_port_endpoint_id, parse_connection_endpoint_id,
+    };
+
+    #[test]
+    fn parses_and_formats_fabric_port_ids() {
+        let endpoint = parse_connection_endpoint_id("fabric.fabric0@(2,3).1")
+            .expect("fabric endpoint should parse");
+
+        assert_eq!(
+            endpoint,
+            ConnectionEndpointId::FabricPort {
+                fabric: "fabric0".to_string(),
+                column: 2,
+                row: 3,
+                port: 1,
+            }
+        );
+        assert_eq!(endpoint.to_string(), "fabric.fabric0@(2,3).1");
+        assert_eq!(
+            fabric_port_endpoint_id("fabric0", 2, 3, 0),
+            "fabric.fabric0@(2,3)"
+        );
+    }
+
+    #[test]
+    fn parses_and_formats_cache_port_ids() {
+        let endpoint =
+            parse_connection_endpoint_id("cache.l1.mem").expect("cache endpoint should parse");
+
+        assert_eq!(
+            endpoint,
+            ConnectionEndpointId::Cache {
+                name: "l1".to_string(),
+                port: Some(CachePortId::Mem),
+            }
+        );
+        assert_eq!(endpoint.to_string(), "cache.l1.mem");
+    }
+}

--- a/gwr-platform/src/lib.rs
+++ b/gwr-platform/src/lib.rs
@@ -10,13 +10,12 @@ use std::rc::Rc;
 use gwr_engine::engine::Engine;
 use gwr_engine::sim_error;
 use gwr_engine::time::clock::Clock;
-use gwr_engine::types::SimError;
+use gwr_engine::types::{DeviceId, SimError};
 use gwr_model_builder::EntityGet;
 use gwr_models::fabric::Fabric;
 use gwr_models::log_stats;
 use gwr_models::memory::cache::{Cache, CacheStatsDisplay};
 use gwr_models::memory::memory_access::MemoryAccess;
-use gwr_models::memory::memory_map::DeviceId;
 use gwr_models::memory::{Memory, MemoryStatsDisplay};
 use gwr_models::processing_element::dispatch::Dispatch;
 use gwr_models::processing_element::{
@@ -24,12 +23,17 @@ use gwr_models::processing_element::{
 };
 use gwr_track::entity::{Entity, GetEntity};
 
-use crate::builder::{build_caches, build_fabrics, build_memories, build_memory_maps, build_pes};
+use crate::builder::{
+    build_caches, build_fabric_destination_port_maps, build_fabrics, build_memories,
+    build_memory_maps, build_pes,
+};
 use crate::connect::connect_ports;
+use crate::connection_id::fabric_port_endpoint_id;
 use crate::types::PlatformConfig;
 
 pub mod builder;
 mod connect;
+pub mod connection_id;
 pub mod types;
 pub mod yaml;
 
@@ -51,6 +55,7 @@ pub struct Platform {
     fabrics_idx_by_id: NameToIdxMap,
     memories: Memories,
     memories_idx_by_id: NameToIdxMap,
+    device_names_by_id: HashMap<u64, String>,
 }
 
 impl fmt::Debug for Platform {
@@ -91,7 +96,13 @@ impl Platform {
         let (processing_elements, pes_idx_by_id) =
             build_pes(engine, clock, top, cfg, &memory_maps, &device_ids)?;
         let (caches, caches_idx_by_id) = build_caches(engine, clock, top, cfg)?;
-        let (fabrics, fabrics_idx_by_id) = build_fabrics(engine, clock, top, cfg)?;
+        let fabric_destination_port_maps = build_fabric_destination_port_maps(cfg, &device_ids)?;
+        let (fabrics, fabrics_idx_by_id) =
+            build_fabrics(engine, clock, top, cfg, &fabric_destination_port_maps)?;
+        let device_names_by_id = device_ids
+            .iter()
+            .map(|(name, device_id)| (device_id.0, name.clone()))
+            .collect();
 
         let parent = engine.top();
         let entity = Rc::new(Entity::new(parent, "platform"));
@@ -105,6 +116,7 @@ impl Platform {
             fabrics_idx_by_id,
             memories,
             memories_idx_by_id,
+            device_names_by_id,
         };
         connect_ports(&platform, cfg)?;
         Ok(platform)
@@ -205,6 +217,44 @@ impl Platform {
         for pe in &self.processing_elements {
             pe.dump_stats(time_now_ns);
         }
+    }
+
+    #[must_use]
+    pub fn fabric_port_map_description(&self) -> String {
+        let mut out = String::new();
+        for fabric in &self.fabrics {
+            use std::fmt::Write as _;
+
+            let _ = writeln!(
+                out,
+                "Fabric {} port_selection: {}",
+                fabric.entity().name,
+                fabric.port_selection()
+            );
+            let mut entries: Vec<_> = fabric.destination_port_map().iter().collect();
+            entries.sort_by_key(|(device_id, _)| **device_id);
+            for (device_id, ports) in entries {
+                let device_name = self
+                    .device_names_by_id
+                    .get(device_id)
+                    .map_or("<unknown>", String::as_str);
+                let port_strings: Vec<String> = ports
+                    .iter()
+                    .map(|port_idx| {
+                        let (col, row, port) = fabric.fabric_port_index_to_col_row_port(*port_idx);
+                        let endpoint =
+                            fabric_port_endpoint_id(fabric.entity().name.as_str(), col, row, port);
+                        format!("{port_idx}={endpoint} ({col},{row}).{port}")
+                    })
+                    .collect();
+                let _ = writeln!(
+                    out,
+                    "  device {device_id} ({device_name}) -> {}",
+                    port_strings.join(", ")
+                );
+            }
+        }
+        out
     }
 
     fn dump_memory_totals(&self, time_now_ns: f64) {

--- a/gwr-platform/src/types.rs
+++ b/gwr-platform/src/types.rs
@@ -2,6 +2,7 @@
 
 use byte_unit::Byte;
 use clap::ValueEnum;
+use gwr_models::fabric::FabricPortSelection;
 use gwr_models::fabric::node::FabricRoutingAlgorithm;
 use serde::{Deserialize, Serialize, de};
 use serde_yaml::Value;
@@ -159,6 +160,7 @@ pub struct FabricSection {
     pub tx_buffer_bytes: Option<usize>,
     pub port_bits_per_tick: Option<usize>,
     pub routing: Option<FabricRoutingAlgorithm>,
+    pub port_selection: Option<FabricPortSelection>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/gwr-platform/src/yaml.rs
+++ b/gwr-platform/src/yaml.rs
@@ -201,6 +201,13 @@ fn emit_fabrics(platform: &PlatformConfig) -> Result<Option<String>, Box<dyn std
                 2,
             )?;
         }
+        if let Some(port_selection) = fabric.port_selection {
+            emit_line(
+                &mut out,
+                format_args!("port_selection: {}", serializable_to_str(&port_selection)?),
+                2,
+            )?;
+        }
     }
     Ok(Some(out))
 }

--- a/gwr-platform/tests/simple_platforms.rs
+++ b/gwr-platform/tests/simple_platforms.rs
@@ -96,34 +96,37 @@ impl Dispatch for TestDispatcher {
     }
 }
 
+fn build_dispatcher_for_pe_tasks(tasks_by_pe_addrs: &[(&str, &[u64])]) -> Rc<dyn Dispatch> {
+    let mut tasks = HashMap::new();
+    let mut tasks_by_pe = HashMap::new();
+    let mut next_task_idx = 0;
+
+    for (pe_name, addrs) in tasks_by_pe_addrs {
+        let mut queue = VecDeque::new();
+        for addr in *addrs {
+            let task_idx = next_task_idx;
+            next_task_idx += 1;
+            tasks.insert(
+                task_idx,
+                Task::MemoryTask {
+                    config: MemoryTaskConfig {
+                        id: format!("{pe_name}_task{task_idx}"),
+                        op: MemoryOp::Load,
+                        addr: *addr,
+                        num_bytes: 128,
+                    },
+                },
+            );
+            queue.push_back(task_idx);
+        }
+        tasks_by_pe.insert((*pe_name).to_string(), queue);
+    }
+
+    Rc::new(TestDispatcher::new(tasks, tasks_by_pe))
+}
+
 fn build_dispatcher() -> Rc<dyn Dispatch> {
-    Rc::new(TestDispatcher::new(
-        HashMap::from([
-            (
-                0,
-                Task::MemoryTask {
-                    config: MemoryTaskConfig {
-                        id: "task0".to_string(),
-                        op: MemoryOp::Load,
-                        addr: 0x1_0000_0000,
-                        num_bytes: 128,
-                    },
-                },
-            ),
-            (
-                1,
-                Task::MemoryTask {
-                    config: MemoryTaskConfig {
-                        id: "task1".to_string(),
-                        op: MemoryOp::Load,
-                        addr: 0x1_0000_0000,
-                        num_bytes: 128,
-                    },
-                },
-            ),
-        ]),
-        HashMap::from([("pe0".to_string(), VecDeque::from([0, 1]))]),
-    ))
+    build_dispatcher_for_pe_tasks(&[("pe0", &[0x1_0000_0000, 0x1_0000_0000])])
 }
 
 macro_rules! pe_mem_config {
@@ -178,6 +181,72 @@ fn run_pe_mem(num_active_requests: usize) -> (Engine, Clock) {
     (engine, clock)
 }
 
+fn run_pe_fabric_mem(num_active_requests: usize) -> (Engine, Clock) {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let platform = Platform::from_string(
+        &engine,
+        &clock,
+        format!(
+            "
+memory_maps:
+  - name: mm0
+    devices:
+      - name: hbm0
+
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config:
+      num_active_requests: {num_active_requests}
+      lsu_access_bytes: 32
+
+fabrics:
+  - name: fabric0
+    kind: functional
+    columns: 2
+    rows: 1
+    fabric_ports_per_node: 1
+    ticks_per_hop: 1
+    ticks_overhead: 1
+    port_bits_per_tick: 4096
+
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0x1_0000_0000
+    capacity_bytes: 16GiB
+    delay_ticks: 10
+
+connections:
+  - connect:
+    - pe.pe0
+    - fabric.fabric0@(0,0)
+  - connect:
+    - mem.hbm0
+    - fabric.fabric0@(1,0)
+"
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    assert_eq!(platform.num_pes(), 1);
+    assert_eq!(platform.num_memories(), 1);
+    assert_eq!(platform.num_fabrics(), 1);
+    assert_eq!(platform.num_caches(), 0);
+    let port_map_dump = platform.fabric_port_map_description();
+    assert!(port_map_dump.contains("Fabric fabric0 port_selection: destination-address-hash"));
+    assert!(port_map_dump.contains("device 0 (pe0) -> 0=fabric.fabric0@(0,0) (0,0).0"));
+    assert!(port_map_dump.contains("device 1 (hbm0) -> 1=fabric.fabric0@(1,0) (1,0).0"));
+
+    let dispatcher = build_dispatcher();
+    platform.attach_dispatcher(&dispatcher);
+
+    run_simulation!(engine);
+    (engine, clock)
+}
+
 #[test]
 fn simple_pe_mem_one_request() {
     let (_, clock) = run_pe_mem(1);
@@ -195,6 +264,13 @@ fn simple_pe_mem_two_requests() {
     // the LSU supports two outstanding requests. So, the first two access take
     // 11ns, but the remainder take 10ns because they overlap.
     assert_eq!(clock.time_now_ns(), 41.0);
+}
+
+#[test]
+fn simple_pe_fabric_mem_routes_by_device_id() {
+    let (_, clock) = run_pe_fabric_mem(1);
+
+    assert!(clock.time_now_ns() > 80.0);
 }
 
 #[test]

--- a/gwr-protocols/Cargo.toml
+++ b/gwr-protocols/Cargo.toml
@@ -23,5 +23,5 @@ paste.workspace = true
 
 [dev-dependencies]
 gwr-components = { path = "../gwr-components", version = "0.11.0" }
-gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.14.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }

--- a/gwr-resources/Cargo.toml
+++ b/gwr-resources/Cargo.toml
@@ -19,7 +19,7 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.14.0" }
 
 [dev-dependencies]
 gwr-track = { path = "../gwr-track", version = "0.13.0" }

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -27,10 +27,10 @@ publish.workspace = true
 async-trait.workspace = true
 byte-unit.workspace = true
 clap.workspace = true
-gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
+gwr-engine = { path = "../gwr-engine", version = "0.14.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.21.0" }
-gwr-platform = { path = "../gwr-platform", version = "0.6.0" }
+gwr-models = { path = "../gwr-models", version = "0.22.0" }
+gwr-platform = { path = "../gwr-platform", version = "0.7.0" }
 gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/licenses.html
+++ b/licenses.html
@@ -8408,14 +8408,14 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-developer-guide 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-doc-builder 0.2.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-docpp 0.1.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.13.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.14.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-model-builder 0.2.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.21.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.22.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx-sys 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-perfetto 0.3.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-perfetto-sys 2.0.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.6.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-platform 0.7.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-protocols 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.9.0</a></li>


### PR DESCRIPTION
Introduce explicit source/destination address and device routing APIs,
derive fabric destination port maps from platform connections, and use
those maps in functional and routed fabrics. Add endpoint parsing helpers
for platform connections, expose fabric port-map diagnostics, and update
YAML generation/validation to cover the new routing metadata.

Add focused tests for device-based fabric routing, endpoint parsing,
port-map derivation, and Routable source/destination behavior.
