### PR TITLE
feat(gwr-models): add custom compute op support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-models"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/examples/sim-fabric/Cargo.toml
+++ b/examples/sim-fabric/Cargo.toml
@@ -24,7 +24,7 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.20.0" }
+gwr-models = { path = "../../gwr-models", version = "0.21.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-pipe/Cargo.toml
+++ b/examples/sim-pipe/Cargo.toml
@@ -24,7 +24,7 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.20.0" }
+gwr-models = { path = "../../gwr-models", version = "0.21.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/examples/sim-ring/Cargo.toml
+++ b/examples/sim-ring/Cargo.toml
@@ -23,7 +23,7 @@ clap.workspace = true
 gwr-components = { path = "../../gwr-components", version = "0.11.0" }
 gwr-engine = { path = "../../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../../gwr-models", version = "0.20.0" }
+gwr-models = { path = "../../gwr-models", version = "0.21.0" }
 gwr-track = { path = "../../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true
 log.workspace = true

--- a/gwr-models/Cargo.toml
+++ b/gwr-models/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-models"
-version = "0.20.0"
+version = "0.21.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -36,6 +36,7 @@ use gwr_model_builder::{EntityDisplay, EntityGet};
 use gwr_track::debug;
 use gwr_track::entity::{Entity, EntityGroup, EntityLane};
 use gwr_track::tracker::aka::Aka;
+use serde::{Deserialize, Serialize};
 
 use crate::log_stats;
 use crate::memory::memory_access::MemoryAccess;
@@ -59,10 +60,14 @@ pub enum MachineOp {
     Mul,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MachineOpCounts {
+    #[serde(default)]
     pub adds: usize,
+    #[serde(default)]
     pub compares: usize,
+    #[serde(default)]
     pub muls: usize,
 }
 
@@ -166,6 +171,10 @@ impl ComputeCapabilities {
     }
 
     pub fn cycles_for_ops(&self, num_ops: usize, op: MachineOp) -> Result<usize, SimError> {
+        if num_ops == 0 {
+            return Ok(0);
+        }
+
         let ops_per_tick = self.ops_per_tick(op);
         if !ops_per_tick.is_finite() || ops_per_tick <= 0.0 {
             return Err(SimError(format!(
@@ -536,7 +545,8 @@ async fn handle_compute_task(
         config
             .op
             .create_partitions(&config.inputs, &config.outputs, num_partitions)?;
-    let group = activity_lanes.create_group(&format!("{} operation", config.id));
+    let activity_name = config.activity_name();
+    let group = activity_lanes.create_group(&format!("{activity_name} operation"));
 
     for partition in partitions {
         for (idx, view) in partition.inputs.iter().enumerate() {
@@ -548,7 +558,7 @@ async fn handle_compute_task(
                 tensor_view_num_bytes(view),
                 tensor_view_base_addr(view)?,
                 &activity_lanes.lsu_read,
-                &format!("{} tensor {idx} read", config.id),
+                &format!("{activity_name} tensor {idx} read"),
                 &group,
             )
             .await?;
@@ -575,7 +585,7 @@ async fn handle_compute_task(
 
             let _activity = ActivityLanes::begin_in_group(
                 &activity_lanes.compute,
-                &format!("{} compute", config.id),
+                &format!("{activity_name} compute"),
                 &group,
             );
             clock.wait_ticks(compute_ticks as u64).await;
@@ -591,7 +601,7 @@ async fn handle_compute_task(
                 tensor_view_num_bytes(view),
                 tensor_view_base_addr(view)?,
                 &activity_lanes.lsu_write,
-                &format!("{} tensor {idx} write", config.id),
+                &format!("{activity_name} tensor {idx} write"),
                 &group,
             )
             .await?;

--- a/gwr-models/src/processing_element/operators/custom.rs
+++ b/gwr-models/src/processing_element/operators/custom.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+//! A custom operator with caller-provided machine operation counts.
+
+use std::rc::Rc;
+
+use gwr_engine::types::{SimError, SimResult};
+use serde::{Deserialize, Serialize};
+
+use super::{Operator, Tensor, TensorPartition, TensorView};
+use crate::processing_element::{ComputeCapabilities, MachineOp, MachineOpCounts};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperatorCustom {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub machine_ops: MachineOpCounts,
+}
+
+impl Operator for OperatorCustom {
+    fn validate_tensors(
+        &self,
+        _inputs: &[Option<Tensor>],
+        _outputs: &[Option<Tensor>],
+    ) -> SimResult {
+        Ok(())
+    }
+
+    fn compute_delay_ticks(
+        &self,
+        compute_capabilities: &Rc<ComputeCapabilities>,
+        _inputs: &[Option<TensorView>],
+        _outputs: &[Option<TensorView>],
+    ) -> Result<usize, SimError> {
+        Ok(
+            compute_capabilities.cycles_for_ops(self.machine_ops.adds, MachineOp::Add)?
+                + compute_capabilities.cycles_for_ops(self.machine_ops.muls, MachineOp::Mul)?
+                + compute_capabilities
+                    .cycles_for_ops(self.machine_ops.compares, MachineOp::Compare)?,
+        )
+    }
+
+    fn compute_machine_ops(
+        &self,
+        _inputs: &[Option<TensorView>],
+        _outputs: &[Option<TensorView>],
+    ) -> Result<MachineOpCounts, SimError> {
+        Ok(self.machine_ops)
+    }
+
+    fn partition_views(
+        &self,
+        input_views: &[Option<TensorView>],
+        output_views: &[Option<TensorView>],
+        _num_partitions: usize,
+    ) -> Result<Vec<TensorPartition>, SimError> {
+        Ok(vec![TensorPartition {
+            inputs: input_views.to_vec(),
+            outputs: output_views.to_vec(),
+        }])
+    }
+}

--- a/gwr-models/src/processing_element/operators/mod.rs
+++ b/gwr-models/src/processing_element/operators/mod.rs
@@ -556,5 +556,6 @@ pub fn apply_dim_partitions(
 }
 
 pub mod add;
+pub mod custom;
 pub mod gemm;
 pub mod maxpool;

--- a/gwr-models/src/processing_element/task.rs
+++ b/gwr-models/src/processing_element/task.rs
@@ -7,6 +7,7 @@ use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::processing_element::operators::add::OperatorAdd;
+use crate::processing_element::operators::custom::OperatorCustom;
 use crate::processing_element::operators::gemm::OperatorGemm;
 use crate::processing_element::operators::maxpool::OperatorMaxPool;
 use crate::processing_element::operators::{Operator, TensorPartition, TensorView};
@@ -21,12 +22,23 @@ pub struct ComputeTaskConfig {
     pub outputs: Vec<Option<TensorView>>,
 }
 
+impl ComputeTaskConfig {
+    #[must_use]
+    pub fn activity_name(&self) -> &str {
+        match &self.op {
+            ComputeOp::Custom(operator) => operator.name.as_deref().unwrap_or(&self.id),
+            _ => &self.id,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ComputeOp {
     Add,
     Gemm,
     MaxPool(OperatorMaxPool),
+    Custom(OperatorCustom),
 }
 
 impl Serialize for ComputeOp {
@@ -42,17 +54,23 @@ impl Serialize for ComputeOp {
                 map.serialize_entry("maxpool", operator)?;
                 map.end()
             }
+            Self::Custom(operator) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("custom", operator)?;
+                map.end()
+            }
         }
     }
 }
 
 impl ComputeOp {
     #[must_use]
-    pub fn trace_name(&self) -> &'static str {
+    pub fn trace_name(&self) -> &str {
         match self {
             ComputeOp::Add => "add",
             ComputeOp::Gemm => "gemm",
             ComputeOp::MaxPool(_) => "maxpool",
+            ComputeOp::Custom(operator) => operator.name.as_deref().unwrap_or("custom"),
         }
     }
 
@@ -72,6 +90,9 @@ impl ComputeOp {
             ComputeOp::MaxPool(operator) => {
                 operator.compute_delay_ticks(compute_capabilities, input_views, output_views)
             }
+            ComputeOp::Custom(operator) => {
+                operator.compute_delay_ticks(compute_capabilities, input_views, output_views)
+            }
         }
     }
 
@@ -84,6 +105,7 @@ impl ComputeOp {
             ComputeOp::Add => OperatorAdd {}.compute_flops(input_views, output_views),
             ComputeOp::Gemm => OperatorGemm {}.compute_flops(input_views, output_views),
             ComputeOp::MaxPool(operator) => operator.compute_flops(input_views, output_views),
+            ComputeOp::Custom(operator) => operator.compute_flops(input_views, output_views),
         }
     }
 
@@ -96,6 +118,7 @@ impl ComputeOp {
             ComputeOp::Add => OperatorAdd {}.compute_machine_ops(input_views, output_views),
             ComputeOp::Gemm => OperatorGemm {}.compute_machine_ops(input_views, output_views),
             ComputeOp::MaxPool(operator) => operator.compute_machine_ops(input_views, output_views),
+            ComputeOp::Custom(operator) => operator.compute_machine_ops(input_views, output_views),
         }
     }
 
@@ -113,6 +136,9 @@ impl ComputeOp {
                 OperatorGemm {}.partition_views(input_views, output_views, num_partitions)
             }
             ComputeOp::MaxPool(operator) => {
+                operator.partition_views(input_views, output_views, num_partitions)
+            }
+            ComputeOp::Custom(operator) => {
                 operator.partition_views(input_views, output_views, num_partitions)
             }
         }

--- a/gwr-platform/Cargo.toml
+++ b/gwr-platform/Cargo.toml
@@ -25,7 +25,7 @@ clap.workspace = true
 gwr-build = { path = "../gwr-build", version = "0.1.0" }
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.20.0" }
+gwr-models = { path = "../gwr-models", version = "0.21.0" }
 gwr-track = { path = "../gwr-track", version = "0.13.0" }
 log.workspace = true
 regex.workspace = true

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -29,7 +29,7 @@ byte-unit.workspace = true
 clap.workspace = true
 gwr-engine = { path = "../gwr-engine", version = "0.13.0" }
 gwr-model-builder = { path = "../gwr-model-builder", version = "0.2.0" }
-gwr-models = { path = "../gwr-models", version = "0.20.0" }
+gwr-models = { path = "../gwr-models", version = "0.21.0" }
 gwr-platform = { path = "../gwr-platform", version = "0.6.0" }
 gwr-track = { path = "../gwr-track", features = ["perfetto"], version = "0.13.0" }
 indicatif.workspace = true

--- a/gwr-timetable/src/bin/gen-timetable.rs
+++ b/gwr-timetable/src/bin/gen-timetable.rs
@@ -93,6 +93,7 @@ fn op_index(compute_op: &ComputeOp) -> usize {
         ComputeOp::Add => 0,
         ComputeOp::Gemm => 1,
         ComputeOp::MaxPool(_) => 2,
+        ComputeOp::Custom(_) => unreachable!("custom ops are not generated"),
     }
 }
 
@@ -101,6 +102,7 @@ fn op_name(compute_op: &ComputeOp) -> &'static str {
         ComputeOp::Add => "add",
         ComputeOp::Gemm => "gemm",
         ComputeOp::MaxPool(_) => "maxpool",
+        ComputeOp::Custom(_) => "custom",
     }
 }
 
@@ -122,6 +124,7 @@ fn create_op(
                 create_maxpool_op(tensor, direction, expand_ratio).map_err(boxed_error)?;
             Ok(ComputeOp::MaxPool(operator))
         }
+        ComputeOp::Custom(_) => Err(error_from_str("custom ops are not generated")),
     }
 }
 
@@ -471,6 +474,9 @@ fn validate_generated_node(
         ComputeOp::MaxPool(operator) => operator
             .validate_tensors(inputs, outputs)
             .map_err(boxed_error),
+        ComputeOp::Custom(operator) => operator
+            .validate_tensors(inputs, outputs)
+            .map_err(boxed_error),
     }
 }
 
@@ -496,6 +502,10 @@ fn create_partitions_for_op(
         )
         .map_err(boxed_error),
         ComputeOp::MaxPool(operator) => {
+            partition_tensors(operator, input_tensors, output_tensors, num_partitions)
+                .map_err(boxed_error)
+        }
+        ComputeOp::Custom(operator) => {
             partition_tensors(operator, input_tensors, output_tensors, num_partitions)
                 .map_err(boxed_error)
         }
@@ -707,6 +717,7 @@ impl Generator {
                 Ok(inputs)
             }
             ComputeOp::MaxPool(_) => Ok(vec![Some(input_tensor.clone())]),
+            ComputeOp::Custom(_) => Err(error_from_str("custom ops are not generated")),
         }
     }
 
@@ -885,6 +896,7 @@ impl Generator {
             ComputeOp::MaxPool(operator) => operator
                 .create_inputs(outputs, self.args.expand_ratio, &mut self.rng)
                 .map_err(boxed_error),
+            ComputeOp::Custom(_) => Err(error_from_str("custom ops are not generated")),
         }
     }
 
@@ -903,6 +915,7 @@ impl Generator {
             ComputeOp::MaxPool(operator) => operator
                 .create_outputs(inputs, self.args.expand_ratio, &mut self.rng)
                 .map_err(boxed_error),
+            ComputeOp::Custom(_) => Err(error_from_str("custom ops are not generated")),
         }
     }
 
@@ -1022,6 +1035,7 @@ impl Generator {
             ComputeOp::Add => true,
             ComputeOp::Gemm => point.tensor.shape().num_dims() >= 2,
             ComputeOp::MaxPool(_) => point.tensor.shape().num_dims() >= 3,
+            ComputeOp::Custom(_) => false,
         }
     }
 
@@ -1045,6 +1059,7 @@ impl Generator {
             ComputeOp::Add => self.args.weight_add,
             ComputeOp::Gemm => self.args.weight_gemm,
             ComputeOp::MaxPool(_) => self.args.weight_maxpool,
+            ComputeOp::Custom(_) => 0.0,
         }
     }
 

--- a/gwr-timetable/tests/custom_compute.rs
+++ b/gwr-timetable/tests/custom_compute.rs
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::fs;
+use std::process::Command;
+use std::rc::Rc;
+
+use gwr_engine::engine::Engine;
+use gwr_engine::test_helpers::start_test;
+use gwr_models::processing_element::MachineOpCounts;
+use gwr_models::processing_element::dispatch::Dispatch;
+use gwr_models::processing_element::operators::HasShape;
+use gwr_models::processing_element::task::{ComputeOp, Task};
+use gwr_platform::Platform;
+use gwr_timetable::Timetable;
+use gwr_timetable::timetable_file::{NodeSection, TimetableFile};
+use tempfile::tempdir;
+
+const PLATFORM_YAML: &str = "
+memory_maps:
+  - name: default
+    devices:
+      - name: hbm0
+
+processing_elements:
+  - name: pe0
+    memory_map: default
+    config:
+      lsu_access_bytes: 32
+      sram_bytes: 64KiB
+
+caches:
+  - name: l1_0
+    config:
+      bw_bytes_per_cycle: 32
+      line_size_bytes: 32
+      delay_ticks: 4
+
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0x1_0000_0000
+    capacity_bytes: 0x1000_0000
+
+connections:
+  - connect:
+      - pe.pe0
+      - cache.l1_0.dev
+  - connect:
+      - cache.l1_0.mem
+      - mem.hbm0
+";
+
+const CUSTOM_TIMETABLE_YAML: &str = "
+nodes:
+  - id: input0
+    kind: tensor
+    config:
+      addr: 0x1_0000_0000
+      dtype: fp32
+      shape: [2, 3]
+
+  - id: input1
+    kind: tensor
+    config:
+      addr: 0x1_0000_0400
+      dtype: fp16
+      shape: [4]
+
+  - id: custom0
+    kind: compute
+    op:
+      custom:
+        name: fft_stage
+        machine_ops:
+          adds: 10
+          muls: 20
+          compares: 30
+    pe: pe0
+    input_views:
+      -
+      -
+    output_views:
+      -
+      -
+
+  - id: output0
+    kind: tensor
+    config:
+      addr: 0x1_0000_0800
+      dtype: fp32
+      shape: [1]
+
+  - id: output1
+    kind: tensor
+    config:
+      addr: 0x1_0000_0c00
+      dtype: int64
+      shape: [2, 2]
+
+edges:
+  - from: input0
+    to: custom0.0
+    kind: data
+
+  - from: input1
+    to: custom0.1
+    kind: data
+
+  - from: custom0.0
+    to: output0
+    kind: data
+
+  - from: custom0.1
+    to: output1
+    kind: data
+";
+
+fn create_timetable(yaml: &str) -> Timetable {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let platform = Rc::new(Platform::from_string(&engine, &clock, PLATFORM_YAML).unwrap());
+    let timetable_file = TimetableFile::from_string(yaml).unwrap();
+
+    Timetable::new(engine.top(), timetable_file, &platform).unwrap()
+}
+
+#[test]
+fn custom_compute_accepts_multiple_inputs_and_outputs() {
+    let timetable = create_timetable(CUSTOM_TIMETABLE_YAML);
+    let task = timetable.task_by_id(2).unwrap();
+
+    let Task::ComputeTask { config } = task else {
+        panic!("custom node did not produce a compute task");
+    };
+
+    assert_eq!(config.id, "custom0");
+    assert_eq!(config.inputs.len(), 2);
+    assert_eq!(config.outputs.len(), 2);
+    assert_eq!(
+        config.inputs[0].as_ref().unwrap().shape().get_dims(),
+        &vec![2, 3]
+    );
+    assert_eq!(
+        config.inputs[1].as_ref().unwrap().shape().get_dims(),
+        &vec![4]
+    );
+    assert_eq!(
+        config.outputs[0].as_ref().unwrap().shape().get_dims(),
+        &vec![1]
+    );
+    assert_eq!(
+        config.outputs[1].as_ref().unwrap().shape().get_dims(),
+        &vec![2, 2]
+    );
+
+    let ComputeOp::Custom(operator) = config.op else {
+        panic!("expected custom compute op");
+    };
+    assert_eq!(operator.name.as_deref(), Some("fft_stage"));
+    assert_eq!(
+        operator.machine_ops,
+        MachineOpCounts {
+            adds: 10,
+            muls: 20,
+            compares: 30,
+        }
+    );
+}
+
+#[test]
+fn custom_compute_serializes_name() {
+    let timetable_file = TimetableFile::from_string(CUSTOM_TIMETABLE_YAML).unwrap();
+    let yaml = serde_yaml::to_string(&timetable_file).unwrap();
+
+    assert!(
+        yaml.contains("name: fft_stage"),
+        "serialized timetable:\n{yaml}"
+    );
+}
+
+#[test]
+fn custom_compute_defaults_missing_machine_op_counts() {
+    let timetable_file = TimetableFile::from_string(
+        "
+nodes:
+  - id: custom0
+    kind: compute
+    op:
+      custom:
+        machine_ops:
+          muls: 7
+    pe: pe0
+    input_views: []
+    output_views: []
+
+edges: []
+",
+    )
+    .unwrap();
+
+    let NodeSection::Compute { op, .. } = &timetable_file.nodes[0] else {
+        panic!("expected compute node");
+    };
+    let ComputeOp::Custom(operator) = op else {
+        panic!("expected custom compute op");
+    };
+    assert_eq!(operator.name, None);
+    assert_eq!(
+        operator.machine_ops,
+        MachineOpCounts {
+            adds: 0,
+            muls: 7,
+            compares: 0,
+        }
+    );
+}
+
+#[test]
+fn custom_compute_name_is_used_in_activity_trace() {
+    let (test_tracker, tracker) = gwr_track::test_init!(1000);
+    let mut engine = Engine::new(&tracker);
+    let clock = engine.default_clock();
+    let platform = Rc::new(Platform::from_string(&engine, &clock, PLATFORM_YAML).unwrap());
+    let timetable_file = TimetableFile::from_string(CUSTOM_TIMETABLE_YAML).unwrap();
+    let timetable = Rc::new(Timetable::new(engine.top(), timetable_file, &platform).unwrap());
+    let dispatcher: Rc<dyn Dispatch> = timetable.clone();
+    platform.attach_dispatcher(&dispatcher);
+
+    engine.run().unwrap();
+    timetable.check_tasks_complete().unwrap();
+
+    let events = test_tracker.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("created group")
+                && event.contains("pe0::fft_stage operation")),
+        "missing named custom operation group in {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.contains("activity begin fft_stage compute")),
+        "missing named custom compute activity in {events:#?}"
+    );
+}
+
+#[test]
+fn custom_compute_rejects_unknown_fields() {
+    let err = TimetableFile::from_string(
+        "
+nodes:
+  - id: custom0
+    kind: compute
+    op:
+      custom:
+        machine_ops:
+          adds: 1
+        latency: 2
+    pe: pe0
+    input_views: []
+    output_views: []
+
+edges: []
+",
+    )
+    .unwrap_err();
+
+    assert!(format!("{err}").contains("unknown field `latency`"));
+}
+
+#[test]
+fn dump_stats_reports_custom_machine_ops() {
+    let dir = tempdir().unwrap();
+    let timetable_path = dir.path().join("timetable.yaml");
+    fs::write(&timetable_path, CUSTOM_TIMETABLE_YAML).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_gwr-timetable"))
+        .arg("--platform")
+        .arg("../gwr-platform/examples/simple_pe_cache_mem.yaml")
+        .arg("--timetable")
+        .arg(&timetable_path)
+        .arg("--stdout")
+        .arg("--dump-stats")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "gwr-timetable failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("machine ops 60 total, 10 add, 20 mul, 30 compare"),
+        "stdout:\n{stdout}"
+    );
+}

--- a/gwr-timetable/tests/gen_timetable.rs
+++ b/gwr-timetable/tests/gen_timetable.rs
@@ -104,6 +104,7 @@ fn generator_emits_multi_output_maxpool() {
 
         match op {
             ComputeOp::Add | ComputeOp::Gemm => {}
+            ComputeOp::Custom(_) => panic!("gen-timetable should not generate custom ops"),
             ComputeOp::MaxPool(_) => {
                 saw_maxpool = true;
                 assert!((1..=2).contains(&output_views.len()));

--- a/licenses.html
+++ b/licenses.html
@@ -8410,7 +8410,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-docpp 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-engine 0.13.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-model-builder 0.2.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.20.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-models 0.21.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-onnx-sys 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-perfetto 0.3.0</a></li>


### PR DESCRIPTION
Add a custom compute operator with caller-provided machine operation counts,
wire it into timetable parsing/serialization, and report its machine ops in
stats.
