### PR TITLE
fix: correct RoutingAlgoritm to RoutingAlgorithm enum name

### DIFF
--- a/gwr-models/src/fabric/mod.rs
+++ b/gwr-models/src/fabric/mod.rs
@@ -24,7 +24,7 @@ where
     fn col_row_port_to_fabric_port_index(&self, col: usize, row: usize, port: usize) -> usize;
 }
 
-pub enum RoutingAlgoritm {
+pub enum RoutingAlgorithm {
     ColumnFirst,
     RowFirst,
 }


### PR DESCRIPTION
## Description
Fixes a typo in the enum name `RoutingAlgoritm` → `RoutingAlgorithm` in `gwr-models/src/fabric/mod.rs`.

## Changes
- Rename `pub enum RoutingAlgoritm` to `pub enum RoutingAlgorithm` (line 27)

Fixes #326.