### PR TITLE
refactor(gwr-models,sim-restaurant): standardise simulation errors

### DIFF
--- a/examples/sim-restaurant/src/bin/sim-restaurant.rs
+++ b/examples/sim-restaurant/src/bin/sim-restaurant.rs
@@ -5,6 +5,7 @@
 //! See `lib.rs` for details.
 
 use clap::{CommandFactory, Parser};
+use gwr_engine::sim_error;
 use gwr_engine::types::SimError;
 use gwr_track::builder::{TrackerArgs, setup_trackers};
 use gwr_track::tracker::dev_null_tracker;
@@ -50,22 +51,18 @@ impl CliArgs {
         let max_kitchen_staff = long_arg_name(&command, "max_kitchen_staff");
 
         if self.min_till_staff > self.max_till_staff {
-            return Err(SimError(format!(
-                "`{min_till_staff}` must be <= `{max_till_staff}`"
-            )));
+            return sim_error!("`{min_till_staff}` must be <= `{max_till_staff}`");
         }
         if self.min_kitchen_staff > self.max_kitchen_staff {
-            return Err(SimError(format!(
-                "`{min_kitchen_staff}` must be <= `{max_kitchen_staff}`"
-            )));
+            return sim_error!("`{min_kitchen_staff}` must be <= `{max_kitchen_staff}`");
         }
         if self.tracking_requested()
             && (self.min_till_staff != self.max_till_staff
                 || self.min_kitchen_staff != self.max_kitchen_staff)
         {
-            return Err(SimError(format!(
+            return sim_error!(
                 "tracking output requires exactly one staffing configuration; set `{min_till_staff}` equal to `{max_till_staff}` and `{min_kitchen_staff}` equal to `{max_kitchen_staff}`"
-            )));
+            );
         }
         RestaurantConfig::from(self.sim.clone()).validate()
     }

--- a/examples/sim-restaurant/src/config.rs
+++ b/examples/sim-restaurant/src/config.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Graphcore Ltd. All rights reserved.
 
 use clap::{Args, Command};
+use gwr_engine::sim_error;
 use gwr_engine::types::SimError;
 
 use crate::time_of_day::TimeOfDay;
@@ -146,17 +147,13 @@ impl RestaurantConfig {
         let closing_time = long_arg_name(&command, "closing_time");
 
         if !(0.0..=1.0).contains(&self.join_base_probability) {
-            return Err(SimError(format!(
-                "`{join_base_probability}` must be in the range 0..=1"
-            )));
+            return sim_error!("`{join_base_probability}` must be in the range 0..=1");
         }
         if self.opening_time >= self.closing_time {
-            return Err(SimError(format!(
-                "`{opening_time}` must be earlier than `{closing_time}`"
-            )));
+            return sim_error!("`{opening_time}` must be earlier than `{closing_time}`");
         }
         if self.day_ticks == 0 {
-            return Err(SimError("day length must be greater than zero".to_string()));
+            return sim_error!("day length must be greater than zero");
         }
         Ok(())
     }

--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -29,6 +29,7 @@ use async_trait::async_trait;
 use gwr_engine::engine::Engine;
 use gwr_engine::executor::Spawner;
 use gwr_engine::port::PortStateResult;
+use gwr_engine::sim_error;
 use gwr_engine::time::clock::{Clock, phase};
 use gwr_engine::traits::Runnable;
 use gwr_engine::types::{AccessType, SimError, SimResult};
@@ -177,9 +178,7 @@ impl ComputeCapabilities {
 
         let ops_per_tick = self.ops_per_tick(op);
         if !ops_per_tick.is_finite() || ops_per_tick <= 0.0 {
-            return Err(SimError(format!(
-                "invalid compute throughput {ops_per_tick} ops/tick"
-            )));
+            return sim_error!("invalid compute throughput {ops_per_tick} ops/tick");
         }
 
         Ok(((num_ops as f64) / ops_per_tick).ceil() as usize)


### PR DESCRIPTION
Related to #334.

## Intent

Use the shared simulation-error helper for validation failures so model and
example code follow the same error-construction convention.

Existing error text and control flow is unchanged.

## Stack

This is part 1 of 7 in the decomposition of #334.

1. [#337](https://github.com/graphcore-research/gwr/pull/337) — `refactor(gwr-models,sim-restaurant): standardise simulation errors` **← current**
2. [#338](https://github.com/graphcore-research/gwr/pull/338) — `fix(gwr-models): preserve packed tensor byte ranges`
3. [#339](https://github.com/graphcore-research/gwr/pull/339) — `fix(gwr-timetable): preserve packed tensor byte ranges`
4. [#340](https://github.com/graphcore-research/gwr/pull/340) — `fix(gwr-timetable): derive scheduling dependencies from data edges`
5. [#341](https://github.com/graphcore-research/gwr/pull/341) — `feat(gwr-platform): support standalone platform validation`
6. [#342](https://github.com/graphcore-research/gwr/pull/342) — `feat(gwr-timetable)!: support standalone timetable validation`
7. [#343](https://github.com/graphcore-research/gwr/pull/343) — `feat(gwr-visualisation): add static timetable visualisation tool`

- Base branch: `main`
- Head branch: `pr-visualisation-decomposed-01-simulation-errors`
- Predecessor: `main`
- Successor: [#338](https://github.com/graphcore-research/gwr/pull/338)

## Verification

- Patch SHA-256: `db5d3aa62c24c5562cf4346f1e88ecb854ad5c335fd3cf2f1b64ec8f1548e6c0`
- Cumulative Git tree: `434d63f8652acbbfee3bddaac8062096f6da16f0`
- The decomposition report's build, test, benchmark, `prek`, and `cog`
  verification passed for this cumulative snapshot.
