### PR TITLE
fix(gwr-models): preserve packed tensor byte ranges

### DIFF
--- a/gwr-models/src/processing_element/mod.rs
+++ b/gwr-models/src/processing_element/mod.rs
@@ -504,16 +504,16 @@ async fn handle_task(
     }
 }
 
-fn tensor_view_num_bytes(view: &TensorView) -> usize {
-    view.num_bytes()
-}
-
-fn tensor_view_base_addr(view: &TensorView) -> Result<u64, SimError> {
-    let base_addr = view.tensor().addr();
-    let element_offset = view.element_offset()?;
-    let dtype = view.tensor().dtype();
-    let byte_offset = (dtype.num_bits() * element_offset).div_ceil(8) as u64;
-    Ok(base_addr + byte_offset)
+fn tensor_view_access(view: &TensorView) -> Result<(u64, usize), SimError> {
+    let byte_range = view.byte_range()?;
+    let byte_offset = u64::try_from(byte_range.start)
+        .map_err(|error| SimError(format!("Tensor view byte offset: {error}")))?;
+    let address = view
+        .tensor()
+        .addr()
+        .checked_add(byte_offset)
+        .ok_or_else(|| SimError("Tensor view address overflows".to_string()))?;
+    Ok((address, byte_range.end - byte_range.start))
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -533,7 +533,7 @@ async fn handle_compute_task(
         .iter()
         .chain(config.outputs.iter())
         .filter_map(|view| view.as_ref())
-        .map(tensor_view_num_bytes)
+        .map(TensorView::num_bytes)
         .sum();
 
     let num_partitions = total_num_bytes
@@ -552,10 +552,11 @@ async fn handle_compute_task(
             let Some(view) = view else {
                 continue;
             };
+            let (address, num_bytes) = tensor_view_access(view)?;
             lsu.do_access(
                 AccessType::ReadRequest,
-                tensor_view_num_bytes(view),
-                tensor_view_base_addr(view)?,
+                num_bytes,
+                address,
                 &activity_lanes.lsu_read,
                 &format!("{activity_name} tensor {idx} read"),
                 &group,
@@ -595,10 +596,11 @@ async fn handle_compute_task(
             let Some(view) = view else {
                 continue;
             };
+            let (address, num_bytes) = tensor_view_access(view)?;
             lsu.do_access(
                 AccessType::WriteNonPostedRequest,
-                tensor_view_num_bytes(view),
-                tensor_view_base_addr(view)?,
+                num_bytes,
+                address,
                 &activity_lanes.lsu_write,
                 &format!("{activity_name} tensor {idx} write"),
                 &group,
@@ -651,6 +653,25 @@ async fn handle_memory_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::processing_element::operators::Tensor;
+    use crate::processing_element::operators::dtype::DataType;
+
+    #[test]
+    fn tensor_view_access_includes_each_partially_touched_byte() {
+        let tensor = Tensor::new(&[4], &DataType::Int4, 0x1000);
+        let view = TensorView::new(tensor, &[2], &[1]);
+
+        assert_eq!(tensor_view_access(&view).unwrap(), (0x1000, 2));
+    }
+
+    #[test]
+    fn tensor_view_access_is_empty_for_zero_element_view() {
+        let tensor = Tensor::new(&[4], &DataType::Int4, 0x1000);
+        let view = TensorView::new(tensor, &[0], &[1]);
+
+        assert_eq!(view.byte_range().unwrap(), 0..0);
+        assert_eq!(tensor_view_access(&view).unwrap(), (0x1000, 0));
+    }
 
     #[test]
     fn cycles_for_ops_uses_ceil_for_fractional_throughput() {

--- a/gwr-models/src/processing_element/operators/mod.rs
+++ b/gwr-models/src/processing_element/operators/mod.rs
@@ -318,6 +318,28 @@ impl TensorView {
         (num_bits * num_elements).div_ceil(8)
     }
 
+    /// Return the physical byte range touched by this view, relative to the
+    /// tensor's base address.
+    pub fn byte_range(&self) -> Result<std::ops::Range<usize>, SimError> {
+        let bits_per_element = self.tensor.dtype().num_bits();
+        let start_bit = self
+            .element_offset()?
+            .checked_mul(bits_per_element)
+            .ok_or_else(|| SimError("Tensor view start offset overflows".to_string()))?;
+        let num_bits = self
+            .num_elements()
+            .checked_mul(bits_per_element)
+            .ok_or_else(|| SimError("Tensor view size overflows".to_string()))?;
+        let start_byte = start_bit / 8;
+        if num_bits == 0 {
+            return Ok(start_byte..start_byte);
+        }
+        let end_bit = start_bit
+            .checked_add(num_bits)
+            .ok_or_else(|| SimError("Tensor view end offset overflows".to_string()))?;
+        Ok(start_byte..end_bit.div_ceil(8))
+    }
+
     /// Return the offset of the first element (in number of elements)
     pub fn element_offset(&self) -> Result<usize, SimError> {
         let shape = &self.tensor.shape.0;


### PR DESCRIPTION
Related to #334.

## Intent

Calculate compute-task LSU addresses and sizes from both the starting bit
offset and total bit length of each packed tensor view. Round the start toward
the lower byte address and the end toward the higher byte address so partially
occupied boundary bytes are included.

Report byte-range or base-address overflow before dispatch.

## Stack

This is part 2 of 7 in the decomposition of #334.

1. [#337](https://github.com/graphcore-research/gwr/pull/337) — `refactor(gwr-models,sim-restaurant): standardise simulation errors`
2. [#338](https://github.com/graphcore-research/gwr/pull/338) — `fix(gwr-models): preserve packed tensor byte ranges` **← current**
3. [#339](https://github.com/graphcore-research/gwr/pull/339) — `fix(gwr-timetable): preserve packed tensor byte ranges`
4. [#340](https://github.com/graphcore-research/gwr/pull/340) — `fix(gwr-timetable): derive scheduling dependencies from data edges`
5. [#341](https://github.com/graphcore-research/gwr/pull/341) — `feat(gwr-platform): support standalone platform validation`
6. [#342](https://github.com/graphcore-research/gwr/pull/342) — `feat(gwr-timetable)!: support standalone timetable validation`
7. [#343](https://github.com/graphcore-research/gwr/pull/343) — `feat(gwr-visualisation): add static timetable visualisation tool`

- Base branch: `pr-visualisation-decomposed-01-simulation-errors`
- Head branch: `pr-visualisation-decomposed-02-model-packed-byte-ranges`
- Predecessor: [#337](https://github.com/graphcore-research/gwr/pull/337)
- Successor: [#339](https://github.com/graphcore-research/gwr/pull/339)

## Verification

- Amended commit: `ef904046ab6432dfb0edf66f143e8eb3029ec47c`
- Cumulative Git tree: `c529f81e3db45d5d7ee2654222f6e4179990f932`
- The amended snapshot passes the all-features build, test, and benchmark
  compilation, the all-files `prek` suite, and `cog verify`.
- The decomposition report remains an unchanged historical record and does not
  include this post-review amendment.
