### PR TITLE
fix(gwr-timetable): preserve packed tensor byte ranges

### DIFF
--- a/gwr-timetable/src/lib.rs
+++ b/gwr-timetable/src/lib.rs
@@ -37,7 +37,8 @@ use types::Node;
 
 use crate::mermaid::{MermaidNodeStatus, render_mermaid_from_parts};
 use crate::timetable_file::{
-    EdgeSection, MemoryConfigSection, TensorConfigSection, TensorViewSection, dtype_num_bytes,
+    EdgeSection, MemoryConfigSection, TensorConfigSection, TensorViewSection,
+    checked_dtype_byte_range,
 };
 
 fn validate_access_in_range(
@@ -546,16 +547,29 @@ impl Timetable {
         &self,
         memory_node: &Node,
         config: &MemoryConfigSection,
-    ) -> (u64, usize) {
-        // Note we assume that the graph has been validated so that we can simply unwrap
-        // the result
-        let tensor_config = self.get_tensor_node_config(memory_node).unwrap();
-        let offset_num_elements = tensor_view_offset(tensor_config, config.view.as_ref());
-        let view_num_elements = tensor_view_num_elements(tensor_config, config.view.as_ref());
-        let address =
-            tensor_config.addr + dtype_num_bytes(&tensor_config.dtype, offset_num_elements) as u64;
-        let num_bytes = dtype_num_bytes(&tensor_config.dtype, view_num_elements);
-        (address, num_bytes)
+    ) -> Result<(u64, usize), SimError> {
+        let node_id = memory_node.node_section.id();
+        let Some(tensor_config) = self.get_tensor_node_config(memory_node) else {
+            return sim_error!("Memory node '{node_id}' is not connected to a Tensor node");
+        };
+        let offset = u64::try_from(tensor_view_offset(tensor_config, config.view.as_ref()))
+            .map_err(|error| SimError(format!("Memory node '{node_id}' view offset: {error}")))?;
+        let num_elements = u64::try_from(tensor_view_num_elements(
+            tensor_config,
+            config.view.as_ref(),
+        ))
+        .map_err(|error| SimError(format!("Memory node '{node_id}' view size: {error}")))?;
+        let byte_range = checked_dtype_byte_range(&tensor_config.dtype, offset, num_elements)
+            .ok_or_else(|| {
+                SimError(format!("Memory node '{node_id}' view byte range overflows"))
+            })?;
+        let address = tensor_config
+            .addr
+            .checked_add(byte_range.start)
+            .ok_or_else(|| SimError(format!("Memory node '{node_id}' address overflows")))?;
+        let num_bytes = usize::try_from(byte_range.end - byte_range.start)
+            .map_err(|error| SimError(format!("Memory node '{node_id}' byte size: {error}")))?;
+        Ok((address, num_bytes))
     }
 
     pub fn get_input_output_tensors(&self, node_idx: usize) -> Result<InOutTensorViews, SimError> {
@@ -640,7 +654,7 @@ impl Timetable {
         for (idx, node) in self.nodes.iter().enumerate() {
             match &node.node_section {
                 NodeSection::Memory { op, config, .. } => {
-                    let (_, num_bytes) = self.memory_access_address_num_bytes(node, config);
+                    let (_, num_bytes) = self.memory_access_address_num_bytes(node, config)?;
                     match op {
                         MemoryOp::Load => total_load_bytes += num_bytes,
                         MemoryOp::Store => total_store_bytes += num_bytes,
@@ -754,7 +768,7 @@ impl Dispatch for Timetable {
                 Ok(build_compute_task(id, op.clone(), inputs, outputs))
             }
             NodeSection::Memory { id, op, config, .. } => {
-                let (address, num_bytes) = self.memory_access_address_num_bytes(node, config);
+                let (address, num_bytes) = self.memory_access_address_num_bytes(node, config)?;
                 Ok(build_memory_task(id, *op, address, num_bytes))
             }
             NodeSection::Tensor { .. } => {

--- a/gwr-timetable/src/timetable_file.rs
+++ b/gwr-timetable/src/timetable_file.rs
@@ -132,6 +132,35 @@ pub fn dtype_num_bytes(dtype: &DataType, num_elements: usize) -> usize {
     (dtype.num_bits() * num_elements).div_ceil(8)
 }
 
+/// Return the physical byte range touched by a contiguous view of
+/// `num_elements` elements starting at `element_offset`.
+#[must_use]
+pub fn checked_dtype_byte_range(
+    dtype: &DataType,
+    element_offset: u64,
+    num_elements: u64,
+) -> Option<std::ops::Range<u64>> {
+    let bits_per_element = u64::try_from(dtype.num_bits()).ok()?;
+    let start_bit = element_offset.checked_mul(bits_per_element)?;
+    let num_bits = num_elements.checked_mul(bits_per_element)?;
+    let start_byte = start_bit / 8;
+    if num_bits == 0 {
+        return Some(start_byte..start_byte);
+    }
+    let end_bit = start_bit.checked_add(num_bits)?;
+    Some(start_byte..end_bit.div_ceil(8))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_element_byte_range_is_empty_at_starting_byte() {
+        assert_eq!(checked_dtype_byte_range(&DataType::Int4, 1, 0), Some(0..0));
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TensorConfigSection {

--- a/gwr-timetable/tests/errors.rs
+++ b/gwr-timetable/tests/errors.rs
@@ -6,7 +6,7 @@ use std::vec;
 use gwr_engine::test_helpers::start_test;
 use gwr_models::processing_element::dispatch::Dispatch;
 use gwr_models::processing_element::operators::dtype::DataType;
-use gwr_models::processing_element::task::MemoryOp;
+use gwr_models::processing_element::task::{MemoryOp, Task};
 use gwr_platform::Platform;
 use gwr_timetable::Timetable;
 use gwr_timetable::timetable_file::{
@@ -288,6 +288,37 @@ fn invalid_to_edge_pe() {
 
     let err = Timetable::new(&top, timetable_file, &platform).unwrap_err();
     assert!(format!("{err}").contains("Edge contains invalid to Node ID 'node2'"));
+}
+
+#[test]
+fn sub_byte_memory_views_use_physical_byte_range() {
+    let (top, platform, _) = create_default_timetable_file();
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: tensor0
+    kind: tensor
+    config: { addr: 0x1000, dtype: int4, shape: [4] }
+  - id: load0
+    kind: memory
+    op: load
+    pe: pe0
+    config:
+      view:
+        offsets: [1]
+        shape: [2]
+edges:
+  - { from: tensor0, to: load0, kind: data }
+",
+    )
+    .unwrap();
+
+    let timetable = Timetable::new(&top, timetable_file, &platform).unwrap();
+    let Task::MemoryTask { config } = timetable.task_by_id(1).unwrap() else {
+        panic!("load0 should produce a memory task");
+    };
+    assert_eq!(config.addr, 0x1000);
+    assert_eq!(config.num_bytes, 2);
 }
 
 #[test]


### PR DESCRIPTION
Related to #334.

## Intent

Calculate memory-task addresses and sizes from both the starting bit offset
and total bit length of each packed tensor view. Round the start toward the
lower byte address and the end toward the higher byte address so partially
occupied boundary bytes are included.

Report byte-range or base-address overflow before dispatch.

## Stack

This is part 3 of 7 in the decomposition of #334.

1. [#337](https://github.com/graphcore-research/gwr/pull/337) — `refactor(gwr-models,sim-restaurant): standardise simulation errors`
2. [#338](https://github.com/graphcore-research/gwr/pull/338) — `fix(gwr-models): preserve packed tensor byte ranges`
3. [#339](https://github.com/graphcore-research/gwr/pull/339) — `fix(gwr-timetable): preserve packed tensor byte ranges` **← current**
4. [#340](https://github.com/graphcore-research/gwr/pull/340) — `fix(gwr-timetable): derive scheduling dependencies from data edges`
5. [#341](https://github.com/graphcore-research/gwr/pull/341) — `feat(gwr-platform): support standalone platform validation`
6. [#342](https://github.com/graphcore-research/gwr/pull/342) — `feat(gwr-timetable)!: support standalone timetable validation`
7. [#343](https://github.com/graphcore-research/gwr/pull/343) — `feat(gwr-visualisation): add static timetable visualisation tool`

- Base branch: `pr-visualisation-decomposed-02-model-packed-byte-ranges`
- Head branch: `pr-visualisation-decomposed-03-timetable-packed-byte-ranges`
- Predecessor: [#338](https://github.com/graphcore-research/gwr/pull/338)
- Successor: [#340](https://github.com/graphcore-research/gwr/pull/340)

## Verification

- Amended commit: `50aad0bebafc701fd97f55ec0b4d4ee8184a55ce`
- Cumulative Git tree: `e61d43e75acdde79231983cf1f81ef66312be676`
- The amended snapshot passes the all-features build, test, and benchmark
  compilation, the all-files `prek` suite, and `cog verify`.
- The decomposition report remains an unchanged historical record and does not
  include this post-review amendment.
