### PR TITLE
fix(gwr-timetable): derive scheduling dependencies from data edges

### DIFF
--- a/gwr-timetable/src/lib.rs
+++ b/gwr-timetable/src/lib.rs
@@ -37,7 +37,7 @@ use types::Node;
 
 use crate::mermaid::{MermaidNodeStatus, render_mermaid_from_parts};
 use crate::timetable_file::{
-    EdgeSection, MemoryConfigSection, TensorConfigSection, TensorViewSection,
+    EdgeKind, EdgeSection, MemoryConfigSection, TensorConfigSection, TensorViewSection,
     checked_dtype_byte_range,
 };
 
@@ -132,6 +132,8 @@ pub struct Timetable {
     platform: Rc<Platform>,
     nodes: Vec<Node>,
     edges: Vec<EdgeSection>,
+    predecessors: Vec<Vec<usize>>,
+    successors: Vec<Vec<usize>>,
     node_pe_indices: Vec<Option<usize>>,
     completed_node_indices: RefCell<HashSet<usize>>,
     active_node_indices: RefCell<HashSet<usize>>,
@@ -231,6 +233,9 @@ impl Timetable {
             node_pe_indices.push(pe_idx);
         }
 
+        let mut predecessors = vec![Vec::new(); nodes.len()];
+        let mut successors = vec![Vec::new(); nodes.len()];
+
         // Wire up the new node inputs/outputs to build the graph connectivity
         for edge_section in &timetable_file.edges {
             // Note: we have validated the edges so we can just unwrap()
@@ -238,6 +243,13 @@ impl Timetable {
             let from_node_idx = node_idx_by_id.get(from_node_id).unwrap();
             let (to_node_id, to_edge_idx) = edge_section.to_node_and_edge()?;
             let to_node_idx = node_idx_by_id.get(to_node_id).unwrap();
+
+            if !matches!(&edge_section.kind, EdgeKind::Data) {
+                continue;
+            }
+
+            predecessors[*to_node_idx].push(*from_node_idx);
+            successors[*from_node_idx].push(*to_node_idx);
 
             update_edge_indices(*from_node_idx, to_edge_idx, &mut nodes[*to_node_idx].inputs)
                 .map_err(|err| {
@@ -267,6 +279,8 @@ impl Timetable {
             platform: platform.clone(),
             completed_node_indices: RefCell::new(HashSet::new()),
             active_node_indices: RefCell::new(HashSet::new()),
+            predecessors,
+            successors,
             nodes_per_pe,
             ready_nodes_per_pe: RefCell::new(HashMap::new()),
             remaining_nodes_per_pe: RefCell::new(HashMap::new()),
@@ -410,6 +424,13 @@ impl Timetable {
             );
         }
 
+        if !load_node.outputs.is_empty() {
+            return sim_error!(
+                "{} data edges connect from Load node '{id}'",
+                load_node.outputs.len()
+            );
+        }
+
         let Some(config) = self.get_tensor_node_config(load_node) else {
             return sim_error!("Load node '{id}' not connected from Tensor node",);
         };
@@ -442,10 +463,8 @@ impl Timetable {
             return false;
         }
 
-        let tensor_node = &self.nodes[tensor_idx];
-
         // Look for an input node that is not complete
-        for idx in tensor_node.inputs.iter().flatten() {
+        for idx in &self.predecessors[tensor_idx] {
             if !completed_node_indices.contains(idx) {
                 return false;
             }
@@ -480,10 +499,8 @@ impl Timetable {
                 }
 
                 remaining_nodes += 1;
-                let unresolved_inputs = self.nodes[*node_idx]
-                    .inputs
+                let unresolved_inputs = self.predecessors[*node_idx]
                     .iter()
-                    .flatten()
                     .filter(|input_idx| !completed_node_indices.contains(input_idx))
                     .count();
                 unresolved_input_counts[*node_idx] = unresolved_inputs;
@@ -529,7 +546,7 @@ impl Timetable {
     }
 
     fn mark_successors_updated(&self, node_idx: usize) {
-        for output_node_idx in self.nodes[node_idx].outputs.iter().flatten() {
+        for output_node_idx in &self.successors[node_idx] {
             self.mark_dependency_completed(*output_node_idx);
         }
     }
@@ -798,7 +815,6 @@ impl Dispatch for Timetable {
             return Ok(());
         }
 
-        let node = &self.nodes[node_idx];
         if let Some(pe_idx) = self.node_pe_indices[node_idx] {
             self.ready_nodes_per_pe
                 .borrow_mut()
@@ -819,24 +835,14 @@ impl Dispatch for Timetable {
         self.completed_node_indices.borrow_mut().insert(node_idx);
         self.mark_successors_updated(node_idx);
 
-        match node.node_section {
-            NodeSection::Compute { .. } => {
-                for tensor_node_idx in node.outputs.iter().flatten() {
-                    if self.update_complete_tensor(*tensor_node_idx) {
-                        self.mark_successors_updated(*tensor_node_idx);
-                    }
-                }
+        for tensor_node_idx in &self.successors[node_idx] {
+            if matches!(
+                self.nodes[*tensor_node_idx].node_section,
+                NodeSection::Tensor { .. }
+            ) && self.update_complete_tensor(*tensor_node_idx)
+            {
+                self.mark_successors_updated(*tensor_node_idx);
             }
-            NodeSection::Memory { op, .. } => {
-                if let MemoryOp::Store = op {
-                    // Only stores are completing their output tensors
-                    let tensor_node_idx = node.get_output_tensor_node_idx().unwrap();
-                    if self.update_complete_tensor(tensor_node_idx) {
-                        self.mark_successors_updated(tensor_node_idx);
-                    }
-                }
-            }
-            NodeSection::Tensor { .. } => {}
         }
 
         self.ready_nodes_changed.notify();

--- a/gwr-timetable/tests/errors.rs
+++ b/gwr-timetable/tests/errors.rs
@@ -93,6 +93,65 @@ fn timetable_file() {
 }
 
 #[test]
+fn control_edges_are_ignored_by_scheduler() {
+    let (top, platform, mut timetable_file) = create_default_timetable_file();
+    timetable_file.edges.push(EdgeSection {
+        from: "load0".to_string(),
+        to: "load1".to_string(),
+        kind: EdgeKind::Control,
+    });
+
+    let timetable = Timetable::new(&top, timetable_file, &platform).unwrap();
+    assert_eq!(timetable.ready_task_indices("pe0").unwrap().1, vec![1, 2]);
+
+    timetable.set_task_completed(1).unwrap();
+    assert_eq!(timetable.ready_task_indices("pe0").unwrap().1, vec![2]);
+}
+
+#[test]
+fn control_edges_ignore_data_port_suffixes() {
+    let (top, platform, mut timetable_file) = create_default_timetable_file();
+    timetable_file.edges.push(EdgeSection {
+        from: "load0.99".to_string(),
+        to: "load1.99".to_string(),
+        kind: EdgeKind::Control,
+    });
+
+    Timetable::new(&top, timetable_file, &platform).unwrap();
+}
+
+#[test]
+fn control_edges_through_tensors_are_ignored_by_scheduler() {
+    let (top, platform, mut timetable_file) = create_default_timetable_file();
+    timetable_file.nodes.push(NodeSection::Tensor {
+        id: "gate".to_string(),
+        config: TensorConfigSection {
+            addr: 0,
+            dtype: DataType::Fp32,
+            shape: vec![1],
+        },
+    });
+    timetable_file.edges.extend([
+        EdgeSection {
+            from: "load0".to_string(),
+            to: "gate".to_string(),
+            kind: EdgeKind::Control,
+        },
+        EdgeSection {
+            from: "gate".to_string(),
+            to: "load1".to_string(),
+            kind: EdgeKind::Control,
+        },
+    ]);
+
+    let timetable = Timetable::new(&top, timetable_file, &platform).unwrap();
+    assert_eq!(timetable.ready_task_indices("pe0").unwrap().1, vec![1, 2]);
+
+    timetable.set_task_completed(1).unwrap();
+    assert_eq!(timetable.ready_task_indices("pe0").unwrap().1, vec![2]);
+}
+
+#[test]
 fn timetable_rejects_unknown_top_level_field() {
     let err = TimetableFile::from_string(
         "
@@ -188,6 +247,33 @@ fn load_not_connected_to_tensor() {
 }
 
 #[test]
+fn load_with_data_output_is_rejected() {
+    let (top, platform, _) = create_default_timetable_file();
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0, dtype: fp32, shape: [1] }
+  - id: load
+    kind: memory
+    op: load
+    config: {}
+  - id: output
+    kind: tensor
+    config: { addr: 4, dtype: fp32, shape: [1] }
+edges:
+  - { from: input, to: load, kind: data }
+  - { from: load, to: output, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = Timetable::new(&top, timetable_file, &platform).unwrap_err();
+    assert!(format!("{err}").contains("1 data edges connect from Load node 'load'"));
+}
+
+#[test]
 fn store_not_connected_to_tensor() {
     let (top, platform, mut timetable_file) = create_default_timetable_file();
     timetable_file.nodes.push(NodeSection::Memory {
@@ -250,7 +336,7 @@ fn store_outside_tensor() {
     timetable_file.edges.push(EdgeSection {
         from: "load0".to_string(),
         to: "store0".to_string(),
-        kind: EdgeKind::Data,
+        kind: EdgeKind::Control,
     });
     timetable_file.edges.push(EdgeSection {
         from: "store0".to_string(),


### PR DESCRIPTION
Related to #334.

## Intent

Build scheduler predecessor and successor lists from data edges independently
of the port-indexed tensor connections used to construct task views.

Reject data outputs from Load nodes because dispatch cannot produce them.

## Stack

This is part 4 of 7 in the decomposition of #334.

1. [#337](https://github.com/graphcore-research/gwr/pull/337) — `refactor(gwr-models,sim-restaurant): standardise simulation errors`
2. [#338](https://github.com/graphcore-research/gwr/pull/338) — `fix(gwr-models): preserve packed tensor byte ranges`
3. [#339](https://github.com/graphcore-research/gwr/pull/339) — `fix(gwr-timetable): preserve packed tensor byte ranges`
4. [#340](https://github.com/graphcore-research/gwr/pull/340) — `fix(gwr-timetable): derive scheduling dependencies from data edges` **← current**
5. [#341](https://github.com/graphcore-research/gwr/pull/341) — `feat(gwr-platform): support standalone platform validation`
6. [#342](https://github.com/graphcore-research/gwr/pull/342) — `feat(gwr-timetable)!: support standalone timetable validation`
7. [#343](https://github.com/graphcore-research/gwr/pull/343) — `feat(gwr-visualisation): add static timetable visualisation tool`

- Base branch: `pr-visualisation-decomposed-03-timetable-packed-byte-ranges`
- Head branch: `pr-visualisation-decomposed-04-data-edge-scheduling`
- Predecessor: [#339](https://github.com/graphcore-research/gwr/pull/339)
- Successor: [#341](https://github.com/graphcore-research/gwr/pull/341)

## Verification

- Patch SHA-256: `17076d757d4d24df90687c63ea3b30d5921de4e75492a1341c91c4174a53ae30` (unchanged from the decomposition report)
- Rebased commit: `ecd6c7f247e49609e65b9e035e0d93bcd00b2fff`
- Cumulative Git tree: `c9d9e88a5f136d69b20256ad4cbdc6984d7f6e8a`
- This rebased cumulative snapshot passes the build, test, benchmark, `prek`,
  and `cog` verification matrix.
- The decomposition reports remain unchanged historical artifacts and do not
  include the post-review amendments to #338 and #339.
