### PR TITLE
feat(gwr-platform): support standalone platform validation

### DIFF
--- a/gwr-platform/src/connect.rs
+++ b/gwr-platform/src/connect.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2026 Graphcore Ltd. All rights reserved.
 
 use std::rc::Rc;
-use std::str::Split;
 use std::sync::LazyLock;
 
 use gwr_engine::sim_error;
@@ -35,44 +34,61 @@ pub enum PortId<'a> {
     },
 }
 
+#[derive(Debug)]
+pub(crate) enum PortEndpoint<'a> {
+    Pe {
+        name: &'a str,
+    },
+    Cache {
+        name: &'a str,
+        port: Option<&'a str>,
+    },
+    Mem {
+        name: &'a str,
+    },
+    FabricTile {
+        name: &'a str,
+        col: usize,
+        row: usize,
+        port: usize,
+    },
+}
+
 /// Parse a Fabric port ID of the form:
 ///   fabric.name@(col,row)[.port]
-fn parse_fabric_port_id<'a>(platform: &'a Platform, s: &'a str) -> Result<PortId<'a>, SimError> {
+fn parse_fabric_endpoint(s: &str) -> Result<PortEndpoint<'_>, SimError> {
     static FABRIC_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"^fabric\.([A-Za-z0-9_]+)@\((\d+),(\d+)\)(?:\.(.*))?$").unwrap()
     });
 
     if let Some(caps) = FABRIC_RE.captures(s) {
-        let name = &caps[1];
+        let name = caps.get(1).unwrap().as_str();
         let col = caps[2].parse().map_err(|e| SimError(format!("{e}")))?;
         let row = caps[3].parse().map_err(|e| SimError(format!("{e}")))?;
+        let port = caps
+            .get(4)
+            .map_or(Ok(0), |port| port.as_str().parse())
+            .map_err(|e| SimError(format!("{e}")))?;
 
-        // Assume a default port index 0 if not provided
-        let port_num = match caps.get(4) {
-            Some(m) => m.as_str(),
-            None => "0",
-        };
-        let port = port_num.parse().map_err(|e| SimError(format!("{e}")))?;
-
-        let fabric = platform.fabric(name)?;
-        let port_idx = fabric.col_row_port_to_fabric_port_index(col, row, port);
-        Ok(PortId::FabricTile { fabric, port_idx })
+        Ok(PortEndpoint::FabricTile {
+            name,
+            col,
+            row,
+            port,
+        })
     } else {
         sim_error!("Unable to parse Fabric port '{s}'")
     }
 }
 
-pub fn parse_port_id<'a>(
-    platform: &'a Platform,
-    s: &'a str,
-) -> Result<(PortId<'a>, Split<'a, char>), SimError> {
+pub(crate) fn parse_port_endpoint(s: &str) -> Result<PortEndpoint<'_>, SimError> {
     let mut parts = s.split('.');
     let kind = parts
         .next()
         .ok_or_else(|| SimError(format!("Failed to parse kind in '{s}'")))?;
 
     if kind == "fabric" {
-        return Ok((parse_fabric_port_id(platform, s)?, parts));
+        return parse_fabric_endpoint(s);
     }
 
     // Parse ports IDs of the form: kind.name[.port]
@@ -84,30 +100,92 @@ pub fn parse_port_id<'a>(
         return sim_error!("Failed to parse '{s}' - extra tokens");
     }
 
-    Ok((
-        match kind {
-            "pe" => {
-                let pe = match port {
-                    Some(_) => return sim_error!("Cannot specify a port for PE"),
-                    None => platform.pe(name)?,
-                };
-                PortId::Pe { pe }
+    match kind {
+        "pe" => {
+            if port.is_some() {
+                return sim_error!("Cannot specify a port for PE");
             }
-            "cache" => {
-                let cache = platform.cache(name)?;
-                PortId::Cache { cache, port }
+            Ok(PortEndpoint::Pe { name })
+        }
+        "cache" => Ok(PortEndpoint::Cache { name, port }),
+        "mem" => {
+            if port.is_some() {
+                return sim_error!("Cannot specify a port for Memory");
             }
-            "mem" => {
-                let memory = match port {
-                    Some(_) => return sim_error!("Cannot specify a port for Memory"),
-                    None => platform.memory(name)?,
-                };
-                PortId::Mem { memory }
+            Ok(PortEndpoint::Mem { name })
+        }
+        _ => sim_error!("Failed to parse '{s}' - unsupported kind"),
+    }
+}
+
+fn resolve_port_endpoint<'a>(
+    platform: &'a Platform,
+    endpoint: &PortEndpoint<'a>,
+) -> Result<PortId<'a>, SimError> {
+    match endpoint {
+        PortEndpoint::Pe { name } => Ok(PortId::Pe {
+            pe: platform.pe(name)?,
+        }),
+        PortEndpoint::Cache { name, port } => Ok(PortId::Cache {
+            cache: platform.cache(name)?,
+            port: *port,
+        }),
+        PortEndpoint::Mem { name } => Ok(PortId::Mem {
+            memory: platform.memory(name)?,
+        }),
+        PortEndpoint::FabricTile {
+            name,
+            col,
+            row,
+            port,
+        } => {
+            let fabric = platform.fabric(name)?;
+            let port_idx = fabric.col_row_port_to_fabric_port_index(*col, *row, *port);
+            Ok(PortId::FabricTile { fabric, port_idx })
+        }
+    }
+}
+
+pub(crate) fn validate_port_endpoint_pair(
+    from: &PortEndpoint<'_>,
+    to: &PortEndpoint<'_>,
+) -> SimResult {
+    match (from, to) {
+        (PortEndpoint::Pe { .. }, PortEndpoint::Pe { .. }) => {
+            sim_error!("Cannot connect a PE directly to a PE")
+        }
+        (PortEndpoint::Mem { .. }, PortEndpoint::Mem { .. }) => {
+            sim_error!("Cannot connect a Memory directly to a Memory")
+        }
+        (PortEndpoint::Pe { .. }, PortEndpoint::Cache { port, .. })
+        | (PortEndpoint::Cache { port, .. }, PortEndpoint::Pe { .. }) => {
+            validate_cache_dev_port(*port)
+        }
+        (PortEndpoint::Cache { port, .. }, PortEndpoint::FabricTile { .. })
+        | (PortEndpoint::FabricTile { .. }, PortEndpoint::Cache { port, .. }) => {
+            validate_cache_mem_port(*port, "Cache should connect the 'mem' port to a Fabric")
+        }
+        (PortEndpoint::Cache { port, .. }, PortEndpoint::Mem { .. })
+        | (PortEndpoint::Mem { .. }, PortEndpoint::Cache { port, .. }) => {
+            validate_cache_mem_port(*port, "Cache should connect the 'mem' port to a Memory")
+        }
+        (
+            PortEndpoint::Cache {
+                port: from_port, ..
+            },
+            PortEndpoint::Cache { port: to_port, .. },
+        ) => {
+            if from_port.is_some_and(|port| port != "mem")
+                || to_port.is_some_and(|port| port != "dev")
+            {
+                return sim_error!(
+                    "When connecting Cache to Cache, connect 'mem' to 'dev' (or simply don't specify ports)"
+                );
             }
-            _ => return sim_error!("Failed to parse '{s}' - unsupported kind"),
-        },
-        parts,
-    ))
+            Ok(())
+        }
+        _ => Ok(()),
+    }
 }
 
 pub fn connect_ports(platform: &Platform, cfg: &PlatformConfig) -> SimResult {
@@ -120,8 +198,11 @@ pub fn connect_ports(platform: &Platform, cfg: &PlatformConfig) -> SimResult {
                 );
             }
 
-            let (from, _) = parse_port_id(platform, &c.connect[0])?;
-            let (to, _) = parse_port_id(platform, &c.connect[1])?;
+            let from_endpoint = parse_port_endpoint(&c.connect[0])?;
+            let to_endpoint = parse_port_endpoint(&c.connect[1])?;
+            validate_port_endpoint_pair(&from_endpoint, &to_endpoint)?;
+            let from = resolve_port_endpoint(platform, &from_endpoint)?;
+            let to = resolve_port_endpoint(platform, &to_endpoint)?;
             connect_port(platform, &from, &to)?;
         }
     }
@@ -215,11 +296,7 @@ fn connect_pe_to_cache(
     cache: &Rc<Cache<MemoryAccess>>,
     cache_port: Option<&str>,
 ) -> SimResult {
-    if let Some(cache_port) = cache_port
-        && cache_port != "dev"
-    {
-        return sim_error!("PEs can only connect to the 'dev' port on the Cache");
-    }
+    validate_cache_dev_port(cache_port)?;
 
     debug!(platform.entity() ; "Connect {} to {}.dev", pe, cache);
     pe.connect_port_tx(cache.port_dev_rx())?;
@@ -254,11 +331,10 @@ fn connect_cache_to_fabric(
     fabric: &Rc<dyn Fabric<MemoryAccess>>,
     fabric_port_idx: usize,
 ) -> SimResult {
-    if let Some(cache_port) = cache_port
-        && cache_port != "mem"
-    {
-        return sim_error!("Cache should connect the 'mem' port to a Fabric");
-    }
+    validate_cache_mem_port(
+        cache_port,
+        "Cache should connect the 'mem' port to a Fabric",
+    )?;
 
     debug!(platform.entity() ; "Connect {}.mem to {}.{}", cache, fabric, fabric_port_idx);
     cache.connect_port_mem_tx(fabric.port_ingress_i(fabric_port_idx))?;
@@ -271,11 +347,10 @@ fn connect_cache_to_memory(
     cache_port: Option<&str>,
     memory: &Rc<Memory<MemoryAccess>>,
 ) -> SimResult {
-    if let Some(cache_port) = cache_port
-        && cache_port != "mem"
-    {
-        return sim_error!("Cache should connect the 'mem' port to a Memory");
-    }
+    validate_cache_mem_port(
+        cache_port,
+        "Cache should connect the 'mem' port to a Memory",
+    )?;
 
     debug!(platform.entity() ; "Connect {}.mem to {}", cache, memory);
     cache.connect_port_mem_tx(memory.port_rx())?;
@@ -289,17 +364,7 @@ fn connect_cache_to_cache(
     to_cache: &Rc<Cache<MemoryAccess>>,
     to_port: Option<&str>,
 ) -> SimResult {
-    if let Some(from_port) = from_port
-        && from_port != "mem"
-    {
-        return sim_error!(
-            "When connecting Cache to Cache, connect 'mem' to 'dev' (or simply don't specify ports)"
-        );
-    }
-
-    if let Some(to_port) = to_port
-        && to_port != "dev"
-    {
+    if from_port.is_some_and(|port| port != "mem") || to_port.is_some_and(|port| port != "dev") {
         return sim_error!(
             "When connecting Cache to Cache, connect 'mem' to 'dev' (or simply don't specify ports)"
         );
@@ -331,4 +396,18 @@ fn connect_fabric_to_fabric(
     debug!(platform.entity() ; "Connect {}.{} to {}.{}", from_fabric, from_port_idx, to_fabric, to_port_idx);
     from_fabric.connect_port_egress_i(from_port_idx, to_fabric.port_ingress_i(to_port_idx))?;
     to_fabric.connect_port_egress_i(to_port_idx, from_fabric.port_ingress_i(from_port_idx))
+}
+
+fn validate_cache_dev_port(port: Option<&str>) -> SimResult {
+    if port.is_some_and(|port| port != "dev") {
+        return sim_error!("PEs can only connect to the 'dev' port on the Cache");
+    }
+    Ok(())
+}
+
+fn validate_cache_mem_port(port: Option<&str>, message: &str) -> SimResult {
+    if port.is_some_and(|port| port != "mem") {
+        return sim_error!("{message}");
+    }
+    Ok(())
 }

--- a/gwr-platform/src/lib.rs
+++ b/gwr-platform/src/lib.rs
@@ -31,6 +31,7 @@ use crate::types::PlatformConfig;
 pub mod builder;
 mod connect;
 pub mod types;
+mod validation;
 pub mod yaml;
 
 type ProcessingElements = Vec<Rc<ProcessingElement>>;
@@ -83,6 +84,7 @@ impl Platform {
     }
 
     fn build(engine: &Engine, clock: &Clock, cfg: &PlatformConfig) -> Result<Self, SimError> {
+        cfg.validate()?;
         let device_ids = assign_device_ids(cfg)?;
 
         let top = engine.top();

--- a/gwr-platform/src/validation.rs
+++ b/gwr-platform/src/validation.rs
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::collections::{HashMap, HashSet};
+
+use gwr_engine::sim_error;
+use gwr_engine::types::SimResult;
+
+use crate::builder::DEFAULT_FABRIC_PORTS_PER_NODE;
+use crate::connect::{PortEndpoint, parse_port_endpoint, validate_port_endpoint_pair};
+use crate::types::{FabricSection, MemorySection, PlatformConfig};
+
+impl PlatformConfig {
+    /// Validate platform properties that do not require building the simulator.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a physical memory range is invalid or if a memory
+    /// map or processing element references an unknown object.
+    pub fn validate(&self) -> SimResult {
+        validate_unique_names(self)?;
+        validate_memory_ranges(self.memories.as_deref().unwrap_or_default())?;
+        validate_references(self)?;
+        validate_connections(self)
+    }
+}
+
+fn validate_unique_names(platform: &PlatformConfig) -> SimResult {
+    let mut device_names = HashSet::new();
+    for pe in platform.processing_elements.iter().flatten() {
+        if !device_names.insert(pe.name.as_str()) {
+            return sim_error!("Duplicate device name {}", pe.name);
+        }
+    }
+    for memory in platform.memories.iter().flatten() {
+        if !device_names.insert(memory.name.as_str()) {
+            return sim_error!("Duplicate device name {}", memory.name);
+        }
+    }
+
+    validate_unique_section_names(
+        "memory map",
+        platform.memory_maps.iter().map(|map| &map.name),
+    )?;
+    validate_unique_section_names(
+        "cache",
+        platform.caches.iter().flatten().map(|cache| &cache.name),
+    )?;
+    validate_unique_section_names(
+        "fabric",
+        platform.fabrics.iter().flatten().map(|fabric| &fabric.name),
+    )
+}
+
+fn validate_unique_section_names<'a>(
+    section: &str,
+    names: impl Iterator<Item = &'a String>,
+) -> SimResult {
+    let mut seen = HashSet::new();
+    for name in names {
+        if !seen.insert(name.as_str()) {
+            return sim_error!("Duplicate {section} name {name}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_references(platform: &PlatformConfig) -> SimResult {
+    let memories = platform
+        .memories
+        .iter()
+        .flatten()
+        .map(|memory| (memory.name.as_str(), memory))
+        .collect::<HashMap<_, _>>();
+    for memory_map in &platform.memory_maps {
+        let mut devices = HashSet::new();
+        for device in &memory_map.devices {
+            let Some(memory) = memories.get(device.name.as_str()).copied() else {
+                return sim_error!(
+                    "Unknown memory '{}' in memory map '{}'",
+                    device.name,
+                    memory_map.name
+                );
+            };
+            if memory.capacity_bytes == 0 {
+                return sim_error!(
+                    "Memory '{}' in memory map '{}' has zero capacity",
+                    memory.name,
+                    memory_map.name
+                );
+            }
+            if !devices.insert(device.name.as_str()) {
+                return sim_error!(
+                    "Duplicate memory '{}' in memory map '{}'",
+                    device.name,
+                    memory_map.name
+                );
+            }
+        }
+    }
+
+    let memory_map_names = platform
+        .memory_maps
+        .iter()
+        .map(|memory_map| memory_map.name.as_str())
+        .collect::<HashSet<_>>();
+    for pe in platform.processing_elements.iter().flatten() {
+        if !memory_map_names.contains(pe.memory_map.as_str()) {
+            return sim_error!(
+                "Unknown memory map '{}' for processing element '{}'",
+                pe.memory_map,
+                pe.name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_connections(platform: &PlatformConfig) -> SimResult {
+    let pe_names = platform
+        .processing_elements
+        .iter()
+        .flatten()
+        .map(|pe| pe.name.as_str())
+        .collect::<HashSet<_>>();
+    let cache_names = platform
+        .caches
+        .iter()
+        .flatten()
+        .map(|cache| cache.name.as_str())
+        .collect::<HashSet<_>>();
+    let memory_names = platform
+        .memories
+        .iter()
+        .flatten()
+        .map(|memory| memory.name.as_str())
+        .collect::<HashSet<_>>();
+    let fabrics = platform
+        .fabrics
+        .iter()
+        .flatten()
+        .map(|fabric| (fabric.name.as_str(), fabric))
+        .collect::<HashMap<_, _>>();
+
+    let mut connected_ports = HashSet::new();
+    for connection in platform.connections.iter().flatten() {
+        if connection.connect.len() != 2 {
+            return sim_error!(
+                "Invalid 'connect' with {} entries (only 2 expected)",
+                connection.connect.len()
+            );
+        }
+        let from = parse_port_endpoint(&connection.connect[0])?;
+        let to = parse_port_endpoint(&connection.connect[1])?;
+        validate_port_endpoint(
+            &from,
+            &pe_names,
+            &cache_names,
+            &memory_names,
+            &fabrics,
+            &connection.connect[0],
+        )?;
+        validate_port_endpoint(
+            &to,
+            &pe_names,
+            &cache_names,
+            &memory_names,
+            &fabrics,
+            &connection.connect[1],
+        )?;
+        validate_port_endpoint_pair(&from, &to)?;
+        validate_ports_available(&from, &to, &mut connected_ports)?;
+    }
+    Ok(())
+}
+
+fn validate_ports_available(
+    from: &PortEndpoint<'_>,
+    to: &PortEndpoint<'_>,
+    connected_ports: &mut HashSet<String>,
+) -> SimResult {
+    for port in connection_ports(from, to) {
+        if !connected_ports.insert(port.clone()) {
+            return sim_error!("Port '{port}' is connected more than once");
+        }
+    }
+    Ok(())
+}
+
+fn connection_ports(from: &PortEndpoint<'_>, to: &PortEndpoint<'_>) -> Vec<String> {
+    vec![
+        endpoint_port(from, to, true),
+        endpoint_port(to, from, false),
+    ]
+}
+
+fn endpoint_port(endpoint: &PortEndpoint<'_>, other: &PortEndpoint<'_>, is_from: bool) -> String {
+    match endpoint {
+        PortEndpoint::Pe { name } => format!("pe.{name}"),
+        PortEndpoint::Mem { name } => format!("mem.{name}"),
+        PortEndpoint::FabricTile {
+            name,
+            col,
+            row,
+            port,
+        } => format!("fabric.{name}@({col},{row}).{port}"),
+        PortEndpoint::Cache { name, port } => {
+            let port = cache_connection_port(*port, other, is_from);
+            format!("cache.{name}.{port}")
+        }
+    }
+}
+
+fn cache_connection_port(
+    port: Option<&str>,
+    other: &PortEndpoint<'_>,
+    is_from: bool,
+) -> &'static str {
+    if let Some("dev") = port {
+        return "dev";
+    }
+    if let Some("mem") = port {
+        return "mem";
+    }
+    match other {
+        PortEndpoint::Pe { .. } => "dev",
+        PortEndpoint::Cache { .. } if is_from => "mem",
+        PortEndpoint::Cache { .. } => "dev",
+        PortEndpoint::Mem { .. } | PortEndpoint::FabricTile { .. } => "mem",
+    }
+}
+
+fn validate_port_endpoint(
+    endpoint: &PortEndpoint<'_>,
+    pe_names: &HashSet<&str>,
+    cache_names: &HashSet<&str>,
+    memory_names: &HashSet<&str>,
+    fabrics: &HashMap<&str, &FabricSection>,
+    source: &str,
+) -> SimResult {
+    match endpoint {
+        PortEndpoint::Pe { name } => {
+            if !pe_names.contains(name) {
+                return sim_error!("No PE '{name}'");
+            }
+            Ok(())
+        }
+        PortEndpoint::Cache { name, .. } => {
+            if !cache_names.contains(name) {
+                return sim_error!("No Cache '{name}'");
+            }
+            Ok(())
+        }
+        PortEndpoint::Mem { name } => {
+            if !memory_names.contains(name) {
+                return sim_error!("No Memory '{name}'");
+            }
+            Ok(())
+        }
+        PortEndpoint::FabricTile {
+            name,
+            col,
+            row,
+            port,
+        } => {
+            let Some(fabric) = fabrics.get(name).copied() else {
+                return sim_error!("No Fabric '{name}'");
+            };
+            validate_fabric_port(source, fabric, *col, *row, *port)
+        }
+    }
+}
+
+fn validate_fabric_port(
+    source: &str,
+    fabric: &FabricSection,
+    col: usize,
+    row: usize,
+    port: usize,
+) -> SimResult {
+    let ports_per_node = fabric
+        .fabric_ports_per_node
+        .unwrap_or(DEFAULT_FABRIC_PORTS_PER_NODE);
+    if col >= fabric.columns || row >= fabric.rows || port >= ports_per_node {
+        return sim_error!(
+            "Fabric port '{source}' is out of range for fabric '{}' with {} columns, {} rows and {} ports per node",
+            fabric.name,
+            fabric.columns,
+            fabric.rows,
+            ports_per_node,
+        );
+    }
+    Ok(())
+}
+
+fn validate_memory_ranges(memories: &[MemorySection]) -> SimResult {
+    let mut ranges = memories
+        .iter()
+        .filter(|memory| memory.capacity_bytes != 0)
+        .map(|memory| {
+            memory
+                .base_address
+                .checked_add(memory.capacity_bytes)
+                .map(|end| (memory, end))
+                .ok_or_else(|| {
+                    gwr_engine::types::SimError(format!(
+                        "Memory '{}' range overflows the physical address space",
+                        memory.name
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    ranges.sort_by_key(|(memory, _)| memory.base_address);
+
+    for pair in ranges.windows(2) {
+        let [(left, left_end), (right, right_end)] = pair else {
+            unreachable!();
+        };
+        if right.base_address < *left_end {
+            return sim_error!(
+                "Physical memory ranges overlap: '{}' ({:#x}..{:#x}) and '{}' ({:#x}..{:#x})",
+                left.name,
+                left.base_address,
+                left_end,
+                right.name,
+                right.base_address,
+                right_end,
+            );
+        }
+    }
+    Ok(())
+}

--- a/gwr-platform/tests/errors.rs
+++ b/gwr-platform/tests/errors.rs
@@ -2,6 +2,7 @@
 
 use gwr_engine::test_helpers::start_test;
 use gwr_platform::Platform;
+use gwr_platform::types::PlatformConfig;
 
 #[test]
 fn unknown_top_level_field_is_rejected() {
@@ -169,6 +170,158 @@ memories:
 }
 
 #[test]
+fn platform_config_validate_rejects_duplicate_device_names() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps:
+  - name: mm0
+    devices: []
+
+processing_elements:
+  - name: dev0
+    memory_map: mm0
+    config:
+
+memories:
+  - name: dev0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 0
+",
+    )
+    .unwrap();
+
+    let err = platform.validate().unwrap_err();
+    assert!(format!("{err}").contains("Duplicate device name dev0"));
+}
+
+#[test]
+fn memory_ending_at_top_of_physical_address_space_is_valid() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps: []
+memories:
+  - name: top
+    kind: hbm
+    base_address: 18446744073709551614
+    capacity_bytes: 1
+",
+    )
+    .unwrap();
+
+    platform.validate().unwrap();
+}
+
+#[test]
+fn memory_range_rejects_exclusive_end_overflow() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps: []
+memories:
+  - name: overflowing
+    kind: hbm
+    base_address: 18446744073709551615
+    capacity_bytes: 1
+",
+    )
+    .unwrap();
+
+    let err = platform.validate().unwrap_err();
+    assert!(format!("{err}").contains("Memory 'overflowing' range overflows"));
+}
+
+#[test]
+fn memory_map_rejects_zero_capacity_memory() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps:
+  - name: mm0
+    devices:
+      - name: hbm0
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 0
+",
+    )
+    .unwrap();
+
+    let err = platform.validate().unwrap_err();
+    assert!(format!("{err}").contains("Memory 'hbm0' in memory map 'mm0' has zero capacity"));
+}
+
+#[test]
+fn memory_map_rejects_duplicate_memory() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps:
+  - name: mm0
+    devices:
+      - name: hbm0
+      - name: hbm0
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 1024
+",
+    )
+    .unwrap();
+
+    let err = platform.validate().unwrap_err();
+    assert!(format!("{err}").contains("Duplicate memory 'hbm0' in memory map 'mm0'"));
+}
+
+#[test]
+fn overlapping_physical_memories_are_rejected() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let err = Platform::from_string(
+        &engine,
+        &clock,
+        "
+memory_maps: []
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 1024
+  - name: hbm1
+    kind: hbm
+    base_address: 512
+    capacity_bytes: 1024
+",
+    )
+    .unwrap_err();
+
+    let message = format!("{err}");
+    assert!(message.contains("Physical memory ranges overlap"));
+    assert!(message.contains("'hbm0' (0x0..0x400)"));
+    assert!(message.contains("'hbm1' (0x200..0x600)"));
+}
+
+#[test]
+fn unknown_pe_memory_map_is_rejected() {
+    let mut engine = start_test(file!());
+    let clock = engine.default_clock();
+    let err = Platform::from_string(
+        &engine,
+        &clock,
+        "
+memory_maps: []
+processing_elements:
+  - name: pe0
+    memory_map: missing
+    config: {}
+",
+    )
+    .unwrap_err();
+
+    assert!(format!("{err}").contains("Unknown memory map 'missing' for processing element 'pe0'"));
+}
+
+#[test]
 #[should_panic(expected = "Started without dispatcher")]
 fn no_dispatcher() {
     let mut engine = start_test(file!());
@@ -296,4 +449,97 @@ connections:
 ",
     )
     .unwrap();
+}
+
+#[test]
+fn platform_config_validate_rejects_invalid_connection_endpoint() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps:
+  - name: mm0
+    devices: []
+
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config:
+
+connections:
+  - connect:
+    - pe.pe0
+    - mem.missing
+",
+    )
+    .unwrap();
+
+    let err = platform.validate().unwrap_err();
+    assert!(format!("{err}").contains("No Memory 'missing'"));
+}
+
+#[test]
+fn platform_config_validate_rejects_direct_pe_connections() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps:
+  - name: mm0
+    devices: []
+
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config:
+  - name: pe1
+    memory_map: mm0
+    config:
+
+connections:
+  - connect:
+    - pe.pe0
+    - pe.pe1
+",
+    )
+    .unwrap();
+
+    let err = platform.validate().unwrap_err();
+    assert!(format!("{err}").contains("Cannot connect a PE directly to a PE"));
+}
+
+#[test]
+fn platform_config_validate_rejects_duplicate_connection_port() {
+    let platform: PlatformConfig = serde_yaml::from_str(
+        "
+memory_maps:
+  - name: mm0
+    devices:
+      - name: hbm0
+      - name: hbm1
+
+processing_elements:
+  - name: pe0
+    memory_map: mm0
+    config:
+
+memories:
+  - name: hbm0
+    kind: hbm
+    base_address: 0
+    capacity_bytes: 1024
+  - name: hbm1
+    kind: hbm
+    base_address: 1024
+    capacity_bytes: 1024
+
+connections:
+  - connect:
+    - pe.pe0
+    - mem.hbm0
+  - connect:
+    - pe.pe0
+    - mem.hbm1
+",
+    )
+    .unwrap();
+
+    let err = platform.validate().unwrap_err();
+    assert!(format!("{err}").contains("Port 'pe.pe0' is connected more than once"));
 }


### PR DESCRIPTION
Related to #334.

## Intent

Allow static tools to validate platform files without constructing simulator
entities.

Reject duplicate or unknown resources, overlapping or overflowing physical
memory ranges, invalid connection endpoints and fabric coordinates,
incompatible connections, and reused ports before platform wiring.

## Stack

This is part 5 of 7 in the decomposition of #334.

1. [#337](https://github.com/graphcore-research/gwr/pull/337) — `refactor(gwr-models,sim-restaurant): standardise simulation errors`
2. [#338](https://github.com/graphcore-research/gwr/pull/338) — `fix(gwr-models): preserve packed tensor byte ranges`
3. [#339](https://github.com/graphcore-research/gwr/pull/339) — `fix(gwr-timetable): preserve packed tensor byte ranges`
4. [#340](https://github.com/graphcore-research/gwr/pull/340) — `fix(gwr-timetable): derive scheduling dependencies from data edges`
5. [#341](https://github.com/graphcore-research/gwr/pull/341) — `feat(gwr-platform): support standalone platform validation` **← current**
6. [#342](https://github.com/graphcore-research/gwr/pull/342) — `feat(gwr-timetable)!: support standalone timetable validation`
7. [#343](https://github.com/graphcore-research/gwr/pull/343) — `feat(gwr-visualisation): add static timetable visualisation tool`

- Base branch: `pr-visualisation-decomposed-04-data-edge-scheduling`
- Head branch: `pr-visualisation-decomposed-05-platform-validation`
- Predecessor: [#340](https://github.com/graphcore-research/gwr/pull/340)
- Successor: [#342](https://github.com/graphcore-research/gwr/pull/342)

## Verification

- Patch SHA-256: `d96c285274d6363202fa9d63742487f4ec321349258f8d2a56edf8752a30fedb` (unchanged from the decomposition report)
- Rebased commit: `82b0548c46932d1d64aa2abab3b86ed1f744f5d5`
- Cumulative Git tree: `ff687253296ce118ffd056c52c38ee0a76639826`
- This rebased cumulative snapshot passes the build, test, benchmark, `prek`,
  and `cog` verification matrix.
- The decomposition reports remain unchanged historical artifacts and do not
  include the post-review amendments to #338 and #339.
