### PR TITLE
feat(gwr-timetable)!: support standalone timetable validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "gwr-timetable"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "byte-unit",

--- a/gwr-timetable/Cargo.toml
+++ b/gwr-timetable/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gwr-timetable"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/gwr-timetable/examples/tiny.yaml
+++ b/gwr-timetable/examples/tiny.yaml
@@ -52,7 +52,7 @@ nodes:
   - id: tensor_E
     kind: tensor
     config:
-      addr: 0x1_3000_0000
+      addr: 0x1_4000_0000
       dtype: fp32
       shape: [3, 224, 224]
 

--- a/gwr-timetable/src/lib.rs
+++ b/gwr-timetable/src/lib.rs
@@ -32,71 +32,15 @@ use gwr_track::{debug, info, trace};
 pub mod mermaid;
 pub mod timetable_file;
 pub mod types;
+mod validation;
 use timetable_file::{NodeSection, TimetableFile};
 use types::Node;
 
 use crate::mermaid::{MermaidNodeStatus, render_mermaid_from_parts};
 use crate::timetable_file::{
-    EdgeKind, EdgeSection, MemoryConfigSection, TensorConfigSection, TensorViewSection,
+    EdgeSection, MemoryConfigSection, TensorConfigSection, TensorViewSection,
     checked_dtype_byte_range,
 };
-
-fn validate_access_in_range(
-    node_id: &str,
-    direction: &str,
-    mem_config: &MemoryConfigSection,
-    tensor_config: &TensorConfigSection,
-) -> SimResult {
-    validate_view_in_range(node_id, direction, mem_config.view.as_ref(), tensor_config)
-}
-
-fn validate_view_in_range(
-    node_id: &str,
-    direction: &str,
-    view: Option<&TensorViewSection>,
-    tensor_config: &TensorConfigSection,
-) -> SimResult {
-    let Some(view) = view else {
-        // When the view is not provided it means we are simply using the entire Tensor
-        // so it is ok
-        return Ok(());
-    };
-
-    if view.offsets.len() != tensor_config.shape.len() {
-        return sim_error!(
-            "{direction} view on node '{}' has offsets rank {} but tensor rank {}",
-            node_id,
-            view.offsets.len(),
-            tensor_config.shape.len()
-        );
-    }
-
-    if view.shape.len() != tensor_config.shape.len() {
-        return sim_error!(
-            "{direction} view on node '{}' has shape rank {} but tensor rank {}",
-            node_id,
-            view.shape.len(),
-            tensor_config.shape.len()
-        );
-    }
-
-    for (i, ((offset, size), tensor_dim)) in view
-        .offsets
-        .iter()
-        .zip(view.shape.iter())
-        .zip(tensor_config.shape.iter())
-        .enumerate()
-    {
-        if (offset + size) > *tensor_dim {
-            return sim_error!(
-                "{direction} view on node '{}' is out of range in dim {i}: offset {offset} + size {size} > {tensor_dim}",
-                node_id,
-            );
-        }
-    }
-
-    Ok(())
-}
 
 fn tensor_view_offset(
     tensor_config: &TensorConfigSection,
@@ -132,8 +76,6 @@ pub struct Timetable {
     platform: Rc<Platform>,
     nodes: Vec<Node>,
     edges: Vec<EdgeSection>,
-    predecessors: Vec<Vec<usize>>,
-    successors: Vec<Vec<usize>>,
     node_pe_indices: Vec<Option<usize>>,
     completed_node_indices: RefCell<HashSet<usize>>,
     active_node_indices: RefCell<HashSet<usize>>,
@@ -154,40 +96,6 @@ impl fmt::Debug for Timetable {
     }
 }
 
-/// Make an edge connection by updating the edge indices of a given node.
-///
-/// If the edge_idx is given then ensure the vector of edges is large enough
-/// and assign. Otherwise, simply find an unassigned index or extend the vector
-/// in order to record the edge.
-fn update_edge_indices(
-    node_idx: usize,
-    edge_idx: Option<usize>,
-    edge_indices: &mut Vec<Option<usize>>,
-) -> SimResult {
-    if let Some(idx) = edge_idx {
-        if (idx + 1) > edge_indices.len() {
-            edge_indices.resize_with(idx + 1, || None);
-        }
-        if edge_indices[idx].is_some() {
-            return sim_error!("edge index {idx} already connected");
-        }
-        edge_indices[idx] = Some(node_idx);
-    } else {
-        let mut inserted = false;
-        for edge_idx in edge_indices.iter_mut() {
-            if edge_idx.is_none() {
-                *edge_idx = Some(node_idx);
-                inserted = true;
-                break;
-            }
-        }
-        if !inserted {
-            edge_indices.push(Some(node_idx));
-        }
-    }
-    Ok(())
-}
-
 type InOutTensorViews = (Vec<Option<TensorView>>, Vec<Option<TensorView>>);
 
 impl Timetable {
@@ -202,7 +110,8 @@ impl Timetable {
         mut timetable_file: TimetableFile,
         platform: &Rc<Platform>,
     ) -> Result<Self, SimError> {
-        timetable_file.validate(platform)?;
+        timetable_file.validate_structure()?;
+        timetable_file.validate_platform_references(platform)?;
 
         let entity = Rc::new(Entity::new(parent, "timetable"));
         let mut node_idx_by_id = HashMap::new();
@@ -225,51 +134,11 @@ impl Timetable {
                 None
             };
 
-            nodes.push(Node {
-                node_section,
-                inputs: Vec::new(),
-                outputs: Vec::new(),
-            });
+            nodes.push(Node::new(node_section));
             node_pe_indices.push(pe_idx);
         }
 
-        let mut predecessors = vec![Vec::new(); nodes.len()];
-        let mut successors = vec![Vec::new(); nodes.len()];
-
-        // Wire up the new node inputs/outputs to build the graph connectivity
-        for edge_section in &timetable_file.edges {
-            // Note: we have validated the edges so we can just unwrap()
-            let (from_node_id, from_edge_idx) = edge_section.from_node_and_edge()?;
-            let from_node_idx = node_idx_by_id.get(from_node_id).unwrap();
-            let (to_node_id, to_edge_idx) = edge_section.to_node_and_edge()?;
-            let to_node_idx = node_idx_by_id.get(to_node_id).unwrap();
-
-            if !matches!(&edge_section.kind, EdgeKind::Data) {
-                continue;
-            }
-
-            predecessors[*to_node_idx].push(*from_node_idx);
-            successors[*from_node_idx].push(*to_node_idx);
-
-            update_edge_indices(*from_node_idx, to_edge_idx, &mut nodes[*to_node_idx].inputs)
-                .map_err(|err| {
-                    SimError(format!(
-                        "Node {from_node_idx} '{}': {err}",
-                        nodes[*from_node_idx].node_section.id()
-                    ))
-                })?;
-            update_edge_indices(
-                *to_node_idx,
-                from_edge_idx,
-                &mut nodes[*from_node_idx].outputs,
-            )
-            .map_err(|err| {
-                SimError(format!(
-                    "Node {to_node_idx} '{}': {err}",
-                    nodes[*to_node_idx].node_section.id()
-                ))
-            })?;
-        }
+        validation::wire_nodes(&mut nodes, &node_idx_by_id, &timetable_file.edges)?;
 
         let timetable = Self {
             entity,
@@ -279,8 +148,6 @@ impl Timetable {
             platform: platform.clone(),
             completed_node_indices: RefCell::new(HashSet::new()),
             active_node_indices: RefCell::new(HashSet::new()),
-            predecessors,
-            successors,
             nodes_per_pe,
             ready_nodes_per_pe: RefCell::new(HashMap::new()),
             remaining_nodes_per_pe: RefCell::new(HashMap::new()),
@@ -312,148 +179,14 @@ impl Timetable {
     }
 
     fn validate(&self) -> SimResult {
-        for node in &self.nodes {
-            match &node.node_section {
-                NodeSection::Memory { id, op, config, .. } => match op {
-                    MemoryOp::Load => {
-                        self.validate_load_node(id, node, config)?;
-                    }
-                    MemoryOp::Store => {
-                        self.validate_store_node(id, node, config)?;
-                    }
-                },
-                NodeSection::Compute {
-                    id,
-                    input_views,
-                    output_views,
-                    ..
-                } => {
-                    self.validate_compute_node(node, id, input_views, output_views)?;
-                }
-                NodeSection::Tensor { .. } => {
-                    // Nothing for now
-                }
-            }
-        }
-
-        Ok(())
+        validation::validate_nodes(&self.nodes)
     }
 
     /// Given a Node, return the input Tensor config for a Memory Load and the
     /// output Tensor config for a Memory Store. In all other cases returns
     /// None.
     fn get_tensor_node_config(&self, node: &Node) -> Option<&TensorConfigSection> {
-        node.get_memory_tensor_node_idx().map(|node_idx| {
-            let node = &self.nodes[node_idx];
-            if let NodeSection::Tensor { config, .. } = &node.node_section {
-                Some(config)
-            } else {
-                None
-            }
-        })?
-    }
-
-    fn validate_compute_node(
-        &self,
-        node: &Node,
-        id: &str,
-        input_views: &[Option<TensorViewSection>],
-        output_views: &[Option<TensorViewSection>],
-    ) -> SimResult {
-        if node.inputs.len() != input_views.len() {
-            return sim_error!(
-                "Compute node '{}' has {} input edges but {} input views",
-                id,
-                node.inputs.len(),
-                input_views.len()
-            );
-        }
-
-        if node.outputs.len() != output_views.len() {
-            return sim_error!(
-                "Compute node '{}' has {} output edges but {} output views",
-                id,
-                node.outputs.len(),
-                output_views.len()
-            );
-        }
-
-        for (input_idx, tensor_idx) in node.inputs.iter().enumerate() {
-            let Some(tensor_idx) = tensor_idx else {
-                continue;
-            };
-            let tensor_node = &self.nodes[*tensor_idx];
-            let NodeSection::Tensor { config, .. } = &tensor_node.node_section else {
-                return sim_error!(
-                    "Compute node '{}' input {} is not connected from a Tensor node",
-                    id,
-                    input_idx
-                );
-            };
-            validate_view_in_range(id, "input", input_views[input_idx].as_ref(), config)?;
-        }
-
-        for (output_idx, tensor_idx) in node.outputs.iter().enumerate() {
-            let Some(tensor_idx) = tensor_idx else {
-                continue;
-            };
-            let tensor_node = &self.nodes[*tensor_idx];
-            let NodeSection::Tensor { config, .. } = &tensor_node.node_section else {
-                return sim_error!(
-                    "Compute node '{}' output {} is not connected to a Tensor node",
-                    id,
-                    output_idx
-                );
-            };
-            validate_view_in_range(id, "output", output_views[output_idx].as_ref(), config)?;
-        }
-
-        Ok(())
-    }
-
-    fn validate_load_node(
-        &self,
-        id: &str,
-        load_node: &Node,
-        load_config: &MemoryConfigSection,
-    ) -> SimResult {
-        if load_node.inputs.len() != 1 {
-            return sim_error!(
-                "{} edges connect into Load node '{id}'",
-                load_node.inputs.len(),
-            );
-        }
-
-        if !load_node.outputs.is_empty() {
-            return sim_error!(
-                "{} data edges connect from Load node '{id}'",
-                load_node.outputs.len()
-            );
-        }
-
-        let Some(config) = self.get_tensor_node_config(load_node) else {
-            return sim_error!("Load node '{id}' not connected from Tensor node",);
-        };
-        validate_access_in_range(id, "Load", load_config, config)
-    }
-
-    fn validate_store_node(
-        &self,
-        id: &str,
-        store_node: &Node,
-        store_config: &MemoryConfigSection,
-    ) -> SimResult {
-        if store_node.outputs.len() != 1 {
-            return sim_error!(
-                "{} edges connect from Store node '{id}'",
-                store_node.outputs.len(),
-            );
-        }
-
-        let Some(config) = self.get_tensor_node_config(store_node) else {
-            return sim_error!("Store node '{id}' not connected to Tensor node");
-        };
-        validate_access_in_range(id, "Store", store_config, config)
+        validation::tensor_config_for_memory_node(&self.nodes, node)
     }
 
     /// Check a given tensor index and move it if it is now complete.
@@ -463,8 +196,10 @@ impl Timetable {
             return false;
         }
 
+        let tensor_node = &self.nodes[tensor_idx];
+
         // Look for an input node that is not complete
-        for idx in &self.predecessors[tensor_idx] {
+        for idx in &tensor_node.predecessors {
             if !completed_node_indices.contains(idx) {
                 return false;
             }
@@ -499,7 +234,8 @@ impl Timetable {
                 }
 
                 remaining_nodes += 1;
-                let unresolved_inputs = self.predecessors[*node_idx]
+                let unresolved_inputs = self.nodes[*node_idx]
+                    .predecessors
                     .iter()
                     .filter(|input_idx| !completed_node_indices.contains(input_idx))
                     .count();
@@ -546,7 +282,7 @@ impl Timetable {
     }
 
     fn mark_successors_updated(&self, node_idx: usize) {
-        for output_node_idx in &self.successors[node_idx] {
+        for output_node_idx in &self.nodes[node_idx].successors {
             self.mark_dependency_completed(*output_node_idx);
         }
     }
@@ -815,6 +551,7 @@ impl Dispatch for Timetable {
             return Ok(());
         }
 
+        let node = &self.nodes[node_idx];
         if let Some(pe_idx) = self.node_pe_indices[node_idx] {
             self.ready_nodes_per_pe
                 .borrow_mut()
@@ -835,7 +572,7 @@ impl Dispatch for Timetable {
         self.completed_node_indices.borrow_mut().insert(node_idx);
         self.mark_successors_updated(node_idx);
 
-        for tensor_node_idx in &self.successors[node_idx] {
+        for tensor_node_idx in &node.successors {
             if matches!(
                 self.nodes[*tensor_node_idx].node_section,
                 NodeSection::Tensor { .. }

--- a/gwr-timetable/src/timetable_file.rs
+++ b/gwr-timetable/src/timetable_file.rs
@@ -2,7 +2,7 @@
 
 //! Types that map directly to the YAML file contents
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
@@ -32,41 +32,41 @@ impl TimetableFile {
             .map_err(|e| SimError(format!("serde_yaml::from_str failed: {e}")))
     }
 
-    pub fn validate(&self, platform: &Rc<Platform>) -> SimResult {
+    pub(crate) fn validate_structure(&self) -> SimResult {
         let mut errors = Vec::new();
-
-        // Iterate over nodes and build up set of all Node IDs whilst
-        // also checking that any defined PE IDs are valid
-        let mut node_ids = HashSet::new();
+        let mut nodes_by_id = HashMap::new();
         for node in &self.nodes {
-            let (id, pe) = node.id_pe();
-
-            if !node_ids.insert(id.to_string()) {
+            let id = node.id();
+            if nodes_by_id.insert(id.to_string(), node).is_some() {
                 errors.push(format!("Duplicate Node ID '{id}'"));
-            }
-
-            if let Some(node_pe_id) = &pe
-                && platform.pe_idx_from_name(node_pe_id).is_err()
-            {
-                errors.push(format!("Node '{id}' contains invalid PE ID '{node_pe_id}'"));
             }
         }
 
-        // Ensure that all node IDs on edges are valid
+        let mut connected_inputs = HashMap::new();
+        let mut connected_outputs = HashMap::new();
+        let endpoint_counts = data_endpoint_counts(&self.edges);
         for edge in &self.edges {
-            let from_id = edge.from_node_id();
-            let to_id = edge.to_node_id();
-
-            if !node_ids.contains(from_id) {
-                errors.push(format!(
-                    "Edge contains invalid from Node ID '{}'",
-                    edge.from
-                ));
-            }
-
-            if !node_ids.contains(to_id) {
-                errors.push(format!("Edge contains invalid to Node ID '{}'", edge.to));
-            }
+            let track_port = matches!(&edge.kind, EdgeKind::Data);
+            validate_edge_end(
+                &edge.from,
+                "from",
+                "output",
+                track_port,
+                &nodes_by_id,
+                &endpoint_counts,
+                &mut connected_outputs,
+                &mut errors,
+            );
+            validate_edge_end(
+                &edge.to,
+                "to",
+                "input",
+                track_port,
+                &nodes_by_id,
+                &endpoint_counts,
+                &mut connected_inputs,
+                &mut errors,
+            );
         }
 
         // TODO:
@@ -76,6 +76,122 @@ impl TimetableFile {
             return sim_error!("Failed to validate graph:\n{}", errors.join("\n"));
         }
         Ok(())
+    }
+
+    /// Validate graph structure, node connections, and tensor views.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when node IDs, edge endpoints, connections, or tensor
+    /// views are invalid.
+    pub fn validate(&self) -> SimResult {
+        crate::validation::validate_file(self)
+    }
+
+    pub(crate) fn validate_platform_references(&self, platform: &Rc<Platform>) -> SimResult {
+        let errors = self
+            .nodes
+            .iter()
+            .filter_map(|node| {
+                let (id, pe) = node.id_pe();
+                let pe = pe.as_ref()?;
+                platform
+                    .pe_idx_from_name(pe)
+                    .is_err()
+                    .then(|| format!("Node '{id}' contains invalid PE ID '{pe}'"))
+            })
+            .collect::<Vec<_>>();
+        if !errors.is_empty() {
+            return sim_error!("Failed to validate graph:\n{}", errors.join("\n"));
+        }
+        Ok(())
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn validate_edge_end(
+    endpoint: &str,
+    direction: &str,
+    port_kind: &str,
+    track_port: bool,
+    nodes_by_id: &HashMap<String, &NodeSection>,
+    endpoint_counts: &HashMap<(String, &'static str), usize>,
+    connected_ports: &mut HashMap<String, HashSet<usize>>,
+    errors: &mut Vec<String>,
+) {
+    let Ok((node_id, port)) = parse_edge_end(endpoint).inspect_err(|error| {
+        errors.push(error.to_string());
+    }) else {
+        return;
+    };
+    let Some(node) = nodes_by_id.get(node_id) else {
+        errors.push(format!(
+            "Edge contains invalid {direction} Node ID '{endpoint}'"
+        ));
+        return;
+    };
+    if !track_port {
+        return;
+    }
+    let port_count = node_port_count(node, node_id, port_kind, endpoint_counts);
+    let ports = connected_ports.entry(node_id.to_string()).or_default();
+    let port = match port {
+        Some(port) => port,
+        None => next_implicit_port(ports, port_count),
+    };
+    if let Some(limit) = port_count
+        && port >= limit
+    {
+        errors.push(format!(
+            "Node '{node_id}' {port_kind} edge index {port} is out of range for {limit} declared {port_kind} ports"
+        ));
+        return;
+    }
+    if ports.contains(&port) {
+        errors.push(format!(
+            "Node '{node_id}' {port_kind} edge index {port} is connected more than once"
+        ));
+    } else {
+        ports.insert(port);
+    }
+}
+
+fn next_implicit_port(ports: &HashSet<usize>, port_count: Option<usize>) -> usize {
+    let limit = port_count.unwrap_or_else(|| ports.len().saturating_add(1));
+    (0..limit)
+        .find(|candidate| !ports.contains(candidate))
+        .unwrap_or(limit)
+}
+
+fn data_endpoint_counts(edges: &[EdgeSection]) -> HashMap<(String, &'static str), usize> {
+    let mut counts = HashMap::new();
+    for edge in edges {
+        if !matches!(&edge.kind, EdgeKind::Data) {
+            continue;
+        }
+        if let Ok((node_id, _)) = edge.from_node_and_edge() {
+            *counts.entry((node_id.to_string(), "output")).or_default() += 1;
+        }
+        if let Ok((node_id, _)) = edge.to_node_and_edge() {
+            *counts.entry((node_id.to_string(), "input")).or_default() += 1;
+        }
+    }
+    counts
+}
+
+fn node_port_count(
+    node: &NodeSection,
+    node_id: &str,
+    port_kind: &str,
+    endpoint_counts: &HashMap<(String, &'static str), usize>,
+) -> Option<usize> {
+    match (node, port_kind) {
+        (NodeSection::Compute { input_views, .. }, "input") => Some(input_views.len()),
+        (NodeSection::Compute { output_views, .. }, "output") => Some(output_views.len()),
+        (NodeSection::Tensor { .. }, _) => None,
+        _ => endpoint_counts
+            .get(&(node_id.to_string(), port_kind))
+            .copied(),
     }
 }
 
@@ -273,15 +389,14 @@ impl EdgeSection {
 /// Some(1) as the edge index into that node.
 fn parse_edge_end(id: &str) -> Result<(&str, Option<usize>), SimError> {
     let parts: Vec<&str> = id.split('.').collect();
-    if parts.len() == 2 {
-        let index = match parts[1].parse::<usize>() {
-            Ok(index) => Some(index),
-            Err(e) => {
-                return sim_error!("Unable to parse edge id '{id}'\n{e}");
-            }
-        };
-        Ok((parts[0], index))
-    } else {
-        Ok((parts[0], None))
+    match parts.as_slice() {
+        [node_id] => Ok((node_id, None)),
+        [node_id, edge_id] => {
+            let index = edge_id
+                .parse::<usize>()
+                .map_err(|error| SimError(format!("Unable to parse edge id '{id}'\n{error}")))?;
+            Ok((node_id, Some(index)))
+        }
+        _ => sim_error!("Unable to parse edge id '{id}'"),
     }
 }

--- a/gwr-timetable/src/types.rs
+++ b/gwr-timetable/src/types.rs
@@ -11,11 +11,27 @@ use crate::timetable_file::NodeSection;
 /// other metadata like the structure of the TimeTable.
 pub struct Node {
     pub node_section: NodeSection,
+    /// Port-indexed tensor inputs connected by data edges.
     pub inputs: Vec<Option<usize>>,
+    /// Port-indexed tensor outputs connected by data edges.
     pub outputs: Vec<Option<usize>>,
+    /// Nodes that must complete before this node through data edges.
+    pub predecessors: Vec<usize>,
+    /// Nodes that depend on this node through data edges.
+    pub successors: Vec<usize>,
 }
 
 impl Node {
+    pub(crate) fn new(node_section: NodeSection) -> Self {
+        Self {
+            node_section,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            predecessors: Vec::new(),
+            successors: Vec::new(),
+        }
+    }
+
     #[must_use]
     pub fn is_store_node(&self) -> bool {
         match self.node_section {

--- a/gwr-timetable/src/validation.rs
+++ b/gwr-timetable/src/validation.rs
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+use std::collections::HashMap;
+use std::ops::Range;
+
+use gwr_engine::sim_error;
+use gwr_engine::types::{SimError, SimResult};
+use gwr_models::processing_element::task::MemoryOp;
+
+use crate::timetable_file::{
+    EdgeKind, EdgeSection, MemoryConfigSection, NodeSection, TensorConfigSection,
+    TensorViewSection, TimetableFile, checked_dtype_byte_range,
+};
+use crate::types::Node;
+
+pub(crate) fn validate_file(timetable_file: &TimetableFile) -> SimResult {
+    timetable_file.validate_structure()?;
+    let node_idx_by_id = timetable_file
+        .nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| (node.id().clone(), index))
+        .collect::<HashMap<_, _>>();
+    let mut nodes = timetable_file
+        .nodes
+        .iter()
+        .cloned()
+        .map(Node::new)
+        .collect::<Vec<_>>();
+    wire_nodes(&mut nodes, &node_idx_by_id, &timetable_file.edges)?;
+    validate_nodes(&nodes)
+}
+
+pub(crate) fn wire_nodes(
+    nodes: &mut [Node],
+    node_idx_by_id: &HashMap<String, usize>,
+    edges: &[EdgeSection],
+) -> SimResult {
+    for edge in edges {
+        let (from_node_id, from_edge_idx) = edge.from_node_and_edge()?;
+        let from_node_idx = node_idx_by_id
+            .get(from_node_id)
+            .copied()
+            .ok_or_else(|| SimError(format!("Unknown node '{from_node_id}'")))?;
+        let (to_node_id, to_edge_idx) = edge.to_node_and_edge()?;
+        let to_node_idx = node_idx_by_id
+            .get(to_node_id)
+            .copied()
+            .ok_or_else(|| SimError(format!("Unknown node '{to_node_id}'")))?;
+        if !matches!(&edge.kind, EdgeKind::Data) {
+            continue;
+        }
+
+        validate_edge_node_kinds(&nodes[from_node_idx], &nodes[to_node_idx])?;
+
+        let from_is_tensor = matches!(
+            nodes[from_node_idx].node_section,
+            NodeSection::Tensor { .. }
+        );
+        let to_is_tensor = matches!(nodes[to_node_idx].node_section, NodeSection::Tensor { .. });
+
+        nodes[to_node_idx].predecessors.push(from_node_idx);
+        nodes[from_node_idx].successors.push(to_node_idx);
+
+        if !to_is_tensor {
+            update_edge_indices(from_node_idx, to_edge_idx, &mut nodes[to_node_idx].inputs)
+                .map_err(|error| {
+                    SimError(format!(
+                        "Node {from_node_idx} '{}': {error}",
+                        nodes[from_node_idx].node_section.id()
+                    ))
+                })?;
+        }
+        if !from_is_tensor {
+            update_edge_indices(
+                to_node_idx,
+                from_edge_idx,
+                &mut nodes[from_node_idx].outputs,
+            )
+            .map_err(|error| {
+                SimError(format!(
+                    "Node {to_node_idx} '{}': {error}",
+                    nodes[to_node_idx].node_section.id()
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_edge_node_kinds(from_node: &Node, to_node: &Node) -> SimResult {
+    if matches!(from_node.node_section, NodeSection::Tensor { .. })
+        && matches!(to_node.node_section, NodeSection::Tensor { .. })
+    {
+        return sim_error!(
+            "Invalid edge from Tensor node '{}' to Tensor node '{}': tensors must be connected through compute or memory nodes",
+            from_node.node_section.id(),
+            to_node.node_section.id()
+        );
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_nodes(nodes: &[Node]) -> SimResult {
+    for node in nodes {
+        match &node.node_section {
+            NodeSection::Memory { id, op, config, .. } => match op {
+                MemoryOp::Load => validate_load_node(nodes, id, node, config)?,
+                MemoryOp::Store => validate_store_node(nodes, id, node, config)?,
+            },
+            NodeSection::Compute {
+                id,
+                input_views,
+                output_views,
+                ..
+            } => validate_compute_node(nodes, node, id, input_views, output_views)?,
+            NodeSection::Tensor { id, config } => validate_tensor_range(id, config)?,
+        }
+        validate_no_read_write_overlap(nodes, node)?;
+    }
+    Ok(())
+}
+
+fn validate_no_read_write_overlap(nodes: &[Node], node: &Node) -> SimResult {
+    let (input_views, output_views): (Vec<_>, Vec<_>) = match &node.node_section {
+        NodeSection::Compute {
+            input_views,
+            output_views,
+            ..
+        } => (
+            input_views.iter().map(Option::as_ref).collect(),
+            output_views.iter().map(Option::as_ref).collect(),
+        ),
+        NodeSection::Memory { config, .. } => (
+            vec![config.view.as_ref(); node.inputs.len()],
+            vec![config.view.as_ref(); node.outputs.len()],
+        ),
+        NodeSection::Tensor { .. } => return Ok(()),
+    };
+
+    let reads = tensor_accesses(nodes, &node.inputs, &input_views)?;
+    let writes = tensor_accesses(nodes, &node.outputs, &output_views)?;
+    for read in &reads {
+        for write in &writes {
+            if ranges_overlap(&read.range, &write.range) {
+                return sim_error!(
+                    "Node '{}' reads tensor '{}' from memory range {:#x}..{:#x} and writes tensor '{}' to overlapping range {:#x}..{:#x}",
+                    node.node_section.id(),
+                    read.tensor_id,
+                    read.range.start,
+                    read.range.end,
+                    write.tensor_id,
+                    write.range.start,
+                    write.range.end,
+                );
+            }
+        }
+    }
+    for (write_idx, first) in writes.iter().enumerate() {
+        for second in &writes[(write_idx + 1)..] {
+            if ranges_overlap(&first.range, &second.range) {
+                return sim_error!(
+                    "Node '{}' writes tensor '{}' to memory range {:#x}..{:#x} and tensor '{}' to overlapping range {:#x}..{:#x}",
+                    node.node_section.id(),
+                    first.tensor_id,
+                    first.range.start,
+                    first.range.end,
+                    second.tensor_id,
+                    second.range.start,
+                    second.range.end,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ranges_overlap(first: &Range<u128>, second: &Range<u128>) -> bool {
+    first.start < second.end && second.start < first.end
+}
+
+struct TensorAccess<'a> {
+    tensor_id: &'a str,
+    range: Range<u128>,
+}
+
+fn tensor_accesses<'a>(
+    nodes: &'a [Node],
+    tensor_indices: &[Option<usize>],
+    views: &[Option<&TensorViewSection>],
+) -> Result<Vec<TensorAccess<'a>>, SimError> {
+    let mut accesses = Vec::new();
+    for (tensor_idx, view) in tensor_indices.iter().zip(views) {
+        let Some(tensor_idx) = tensor_idx else {
+            continue;
+        };
+        let NodeSection::Tensor { id, config } = &nodes[*tensor_idx].node_section else {
+            continue;
+        };
+        accesses.push(TensorAccess {
+            tensor_id: id,
+            range: tensor_access_range(id, config, *view)?,
+        });
+    }
+    Ok(accesses)
+}
+
+fn validate_tensor_range(id: &str, config: &TensorConfigSection) -> SimResult {
+    if let Some(dim) = config.shape.iter().position(|size| *size == 0) {
+        return sim_error!("Tensor '{id}' has zero size in dim {dim}");
+    }
+    tensor_access_range(id, config, None).map(|_| ())
+}
+
+fn tensor_access_range(
+    id: &str,
+    config: &TensorConfigSection,
+    view: Option<&TensorViewSection>,
+) -> Result<Range<u128>, SimError> {
+    let offset_elements = match view {
+        Some(view) => checked_element_offset(&config.shape, &view.offsets),
+        None => Some(0),
+    }
+    .ok_or_else(|| SimError(format!("Tensor '{id}' view offset is too large")))?;
+    let shape = view.map_or(config.shape.as_slice(), |view| view.shape.as_slice());
+    let num_elements = checked_num_elements(shape)
+        .ok_or_else(|| SimError(format!("Tensor '{id}' shape is too large")))?;
+    let byte_range = checked_dtype_byte_range(&config.dtype, offset_elements, num_elements)
+        .ok_or_else(|| SimError(format!("Tensor '{id}' size is too large")))?;
+    let start = u128::from(config.addr) + u128::from(byte_range.start);
+    let end = u128::from(config.addr) + u128::from(byte_range.end);
+    if end > u128::from(u64::MAX) {
+        return sim_error!("Tensor '{id}' range overflows the physical address space");
+    }
+    Ok(start..end)
+}
+
+fn checked_element_offset(shape: &[usize], offsets: &[usize]) -> Option<u64> {
+    if offsets.len() != shape.len() {
+        return None;
+    }
+    offsets
+        .iter()
+        .enumerate()
+        .try_fold(0_u64, |total, (dim, offset)| {
+            let stride = checked_num_elements(&shape[(dim + 1)..])?;
+            let offset = u64::try_from(*offset).ok()?;
+            total.checked_add(offset.checked_mul(stride)?)
+        })
+}
+
+fn checked_num_elements(shape: &[usize]) -> Option<u64> {
+    shape.iter().try_fold(1_u64, |elements, dimension| {
+        elements.checked_mul(u64::try_from(*dimension).ok()?)
+    })
+}
+
+pub(crate) fn tensor_config_for_memory_node<'a>(
+    nodes: &'a [Node],
+    node: &Node,
+) -> Option<&'a TensorConfigSection> {
+    let node_idx = node.get_memory_tensor_node_idx()?;
+    let NodeSection::Tensor { config, .. } = &nodes[node_idx].node_section else {
+        return None;
+    };
+    Some(config)
+}
+
+fn update_edge_indices(
+    node_idx: usize,
+    edge_idx: Option<usize>,
+    edge_indices: &mut Vec<Option<usize>>,
+) -> SimResult {
+    if let Some(idx) = edge_idx {
+        if (idx + 1) > edge_indices.len() {
+            edge_indices.resize_with(idx + 1, || None);
+        }
+        if edge_indices[idx].is_some() {
+            return sim_error!("edge index {idx} already connected");
+        }
+        edge_indices[idx] = Some(node_idx);
+    } else if let Some(edge_idx) = edge_indices.iter_mut().find(|edge_idx| edge_idx.is_none()) {
+        *edge_idx = Some(node_idx);
+    } else {
+        edge_indices.push(Some(node_idx));
+    }
+    Ok(())
+}
+
+fn validate_compute_node(
+    nodes: &[Node],
+    node: &Node,
+    id: &str,
+    input_views: &[Option<TensorViewSection>],
+    output_views: &[Option<TensorViewSection>],
+) -> SimResult {
+    if node.inputs.len() != input_views.len() {
+        return sim_error!(
+            "Compute node '{}' has {} input edges but {} input views",
+            id,
+            node.inputs.len(),
+            input_views.len()
+        );
+    }
+    if node.outputs.len() != output_views.len() {
+        return sim_error!(
+            "Compute node '{}' has {} output edges but {} output views",
+            id,
+            node.outputs.len(),
+            output_views.len()
+        );
+    }
+
+    for (input_idx, tensor_idx) in node.inputs.iter().enumerate() {
+        let Some(tensor_idx) = tensor_idx else {
+            continue;
+        };
+        let NodeSection::Tensor { config, .. } = &nodes[*tensor_idx].node_section else {
+            return sim_error!(
+                "Compute node '{}' input {} is not connected from a Tensor node",
+                id,
+                input_idx
+            );
+        };
+        validate_view_in_range(id, "input", input_views[input_idx].as_ref(), config)?;
+    }
+    for (output_idx, tensor_idx) in node.outputs.iter().enumerate() {
+        let Some(tensor_idx) = tensor_idx else {
+            continue;
+        };
+        let NodeSection::Tensor { config, .. } = &nodes[*tensor_idx].node_section else {
+            return sim_error!(
+                "Compute node '{}' output {} is not connected to a Tensor node",
+                id,
+                output_idx
+            );
+        };
+        validate_view_in_range(id, "output", output_views[output_idx].as_ref(), config)?;
+    }
+    Ok(())
+}
+
+fn validate_load_node(
+    nodes: &[Node],
+    id: &str,
+    node: &Node,
+    config: &MemoryConfigSection,
+) -> SimResult {
+    if node.inputs.len() != 1 {
+        return sim_error!("{} edges connect into Load node '{id}'", node.inputs.len());
+    }
+    if !node.outputs.is_empty() {
+        return sim_error!(
+            "{} data edges connect from Load node '{id}'",
+            node.outputs.len()
+        );
+    }
+    let Some(tensor_config) = tensor_config_for_memory_node(nodes, node) else {
+        return sim_error!("Load node '{id}' not connected from Tensor node");
+    };
+    validate_access_in_range(id, "Load", config, tensor_config)
+}
+
+fn validate_store_node(
+    nodes: &[Node],
+    id: &str,
+    node: &Node,
+    config: &MemoryConfigSection,
+) -> SimResult {
+    if node.outputs.len() != 1 {
+        return sim_error!(
+            "{} edges connect from Store node '{id}'",
+            node.outputs.len()
+        );
+    }
+    let Some(tensor_config) = tensor_config_for_memory_node(nodes, node) else {
+        return sim_error!("Store node '{id}' not connected to Tensor node");
+    };
+    validate_access_in_range(id, "Store", config, tensor_config)
+}
+
+fn validate_access_in_range(
+    node_id: &str,
+    direction: &str,
+    mem_config: &MemoryConfigSection,
+    tensor_config: &TensorConfigSection,
+) -> SimResult {
+    validate_view_in_range(node_id, direction, mem_config.view.as_ref(), tensor_config)
+}
+
+fn validate_view_in_range(
+    node_id: &str,
+    direction: &str,
+    view: Option<&TensorViewSection>,
+    tensor_config: &TensorConfigSection,
+) -> SimResult {
+    let Some(view) = view else {
+        return Ok(());
+    };
+    if view.offsets.len() != tensor_config.shape.len() {
+        return sim_error!(
+            "{direction} view on node '{}' has offsets rank {} but tensor rank {}",
+            node_id,
+            view.offsets.len(),
+            tensor_config.shape.len()
+        );
+    }
+    if view.shape.len() != tensor_config.shape.len() {
+        return sim_error!(
+            "{direction} view on node '{}' has shape rank {} but tensor rank {}",
+            node_id,
+            view.shape.len(),
+            tensor_config.shape.len()
+        );
+    }
+    if let Some(dim) = view.shape.iter().position(|size| *size == 0) {
+        return sim_error!(
+            "{direction} view on node '{}' has zero size in dim {dim}",
+            node_id,
+        );
+    }
+    for (i, ((offset, size), tensor_dim)) in view
+        .offsets
+        .iter()
+        .zip(view.shape.iter())
+        .zip(tensor_config.shape.iter())
+        .enumerate()
+    {
+        if offset
+            .checked_add(*size)
+            .is_none_or(|end| end > *tensor_dim)
+        {
+            return sim_error!(
+                "{direction} view on node '{}' is out of range in dim {i}: offset {offset} + size {size} > {tensor_dim}",
+                node_id,
+            );
+        }
+    }
+    Ok(())
+}

--- a/gwr-timetable/tests/errors.rs
+++ b/gwr-timetable/tests/errors.rs
@@ -93,6 +93,12 @@ fn timetable_file() {
 }
 
 #[test]
+fn timetable_file_validation_without_platform() {
+    let (_, _, timetable_file) = create_default_timetable_file();
+    timetable_file.validate().unwrap();
+}
+
+#[test]
 fn control_edges_are_ignored_by_scheduler() {
     let (top, platform, mut timetable_file) = create_default_timetable_file();
     timetable_file.edges.push(EdgeSection {
@@ -101,6 +107,7 @@ fn control_edges_are_ignored_by_scheduler() {
         kind: EdgeKind::Control,
     });
 
+    timetable_file.validate().unwrap();
     let timetable = Timetable::new(&top, timetable_file, &platform).unwrap();
     assert_eq!(timetable.ready_task_indices("pe0").unwrap().1, vec![1, 2]);
 
@@ -110,14 +117,14 @@ fn control_edges_are_ignored_by_scheduler() {
 
 #[test]
 fn control_edges_ignore_data_port_suffixes() {
-    let (top, platform, mut timetable_file) = create_default_timetable_file();
+    let (_, _, mut timetable_file) = create_default_timetable_file();
     timetable_file.edges.push(EdgeSection {
         from: "load0.99".to_string(),
         to: "load1.99".to_string(),
         kind: EdgeKind::Control,
     });
 
-    Timetable::new(&top, timetable_file, &platform).unwrap();
+    timetable_file.validate().unwrap();
 }
 
 #[test]
@@ -149,6 +156,357 @@ fn control_edges_through_tensors_are_ignored_by_scheduler() {
 
     timetable.set_task_completed(1).unwrap();
     assert_eq!(timetable.ready_task_indices("pe0").unwrap().1, vec![2]);
+}
+
+#[test]
+fn semantic_validation_rejects_tensor_to_tensor_edges() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: tensor0
+    kind: tensor
+    config: { addr: 0, dtype: fp32, shape: [1] }
+  - id: tensor1
+    kind: tensor
+    config: { addr: 4, dtype: fp32, shape: [1] }
+edges:
+  - { from: tensor0, to: tensor1, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(
+        format!("{err}")
+            .contains("Invalid edge from Tensor node 'tensor0' to Tensor node 'tensor1'")
+    );
+}
+
+#[test]
+fn semantic_validation_rejects_compute_to_compute_data_edges() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: producer
+    kind: compute
+    op: add
+    input_views: []
+    output_views: [null]
+  - id: consumer
+    kind: compute
+    op: add
+    input_views: [null]
+    output_views: []
+edges:
+  - from: producer
+    to: consumer
+    kind: data
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("output 0 is not connected to a Tensor node"));
+}
+
+#[test]
+fn semantic_validation_rejects_overlapping_compute_reads_and_writes() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0x1000, dtype: fp32, shape: [4] }
+  - id: compute
+    kind: compute
+    op: add
+    input_views: [null]
+    output_views: [null]
+  - id: output
+    kind: tensor
+    config: { addr: 0x1008, dtype: fp32, shape: [4] }
+edges:
+  - { from: input, to: compute, kind: data }
+  - { from: compute, to: output, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    let message = format!("{err}");
+    assert!(message.contains("Node 'compute' reads tensor 'input'"));
+    assert!(message.contains("writes tensor 'output' to overlapping range"));
+}
+
+#[test]
+fn semantic_validation_accepts_compute_views_in_adjacent_bytes() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0x1000, dtype: int4, shape: [4] }
+  - id: compute
+    kind: compute
+    op: add
+    input_views:
+      - { offsets: [0], shape: [1] }
+    output_views:
+      - { offsets: [2], shape: [1] }
+  - id: output
+    kind: tensor
+    config: { addr: 0x1000, dtype: int4, shape: [4] }
+edges:
+  - { from: input, to: compute, kind: data }
+  - { from: compute, to: output, kind: data }
+",
+    )
+    .unwrap();
+
+    timetable_file.validate().unwrap();
+}
+
+#[test]
+fn semantic_validation_rejects_overlapping_sub_byte_compute_views() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0x1000, dtype: int4, shape: [2] }
+  - id: compute
+    kind: compute
+    op: add
+    input_views:
+      - { offsets: [1], shape: [1] }
+    output_views:
+      - { offsets: [0], shape: [1] }
+  - id: output
+    kind: tensor
+    config: { addr: 0x1000, dtype: int4, shape: [2] }
+edges:
+  - { from: input, to: compute, kind: data }
+  - { from: compute, to: output, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("writes tensor 'output' to overlapping range"));
+}
+
+#[test]
+fn semantic_validation_rejects_overlapping_memory_reads_and_writes() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0x1000, dtype: fp32, shape: [4] }
+  - id: store
+    kind: memory
+    op: store
+    config: { view: null }
+  - id: output
+    kind: tensor
+    config: { addr: 0x1008, dtype: fp32, shape: [4] }
+edges:
+  - { from: input, to: store, kind: data }
+  - { from: store, to: output, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    let message = format!("{err}");
+    assert!(message.contains("Node 'store' reads tensor 'input'"));
+    assert!(message.contains("writes tensor 'output' to overlapping range"));
+}
+
+#[test]
+fn semantic_validation_rejects_overlapping_compute_writes() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: compute
+    kind: compute
+    op: { custom: { machine_ops: {} } }
+    input_views: []
+    output_views: [null, null]
+  - id: output0
+    kind: tensor
+    config: { addr: 0x1000, dtype: fp32, shape: [2] }
+  - id: output1
+    kind: tensor
+    config: { addr: 0x1004, dtype: fp32, shape: [2] }
+edges:
+  - { from: compute.0, to: output0, kind: data }
+  - { from: compute.1, to: output1, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    let message = format!("{err}");
+    assert!(message.contains("Node 'compute' writes tensor 'output0'"));
+    assert!(message.contains("tensor 'output1' to overlapping range"));
+}
+
+#[test]
+fn semantic_validation_accepts_adjacent_compute_writes() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: compute
+    kind: compute
+    op: { custom: { machine_ops: {} } }
+    input_views: []
+    output_views: [null, null]
+  - id: output0
+    kind: tensor
+    config: { addr: 0x1000, dtype: fp32, shape: [1] }
+  - id: output1
+    kind: tensor
+    config: { addr: 0x1004, dtype: fp32, shape: [1] }
+edges:
+  - { from: compute.0, to: output0, kind: data }
+  - { from: compute.1, to: output1, kind: data }
+",
+    )
+    .unwrap();
+
+    timetable_file.validate().unwrap();
+}
+
+#[test]
+fn semantic_validation_rejects_zero_sized_compute_views() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0, dtype: fp32, shape: [4] }
+  - id: compute
+    kind: compute
+    op: add
+    input_views:
+      - { offsets: [0], shape: [0] }
+    output_views: []
+edges:
+  - { from: input, to: compute, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("input view on node 'compute' has zero size in dim 0"));
+}
+
+#[test]
+fn semantic_validation_rejects_zero_sized_memory_views() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0, dtype: fp32, shape: [4] }
+  - id: load
+    kind: memory
+    op: load
+    config:
+      view:
+        offsets: [0]
+        shape: [0]
+edges:
+  - { from: input, to: load, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("Load view on node 'load' has zero size in dim 0"));
+}
+
+#[test]
+fn semantic_validation_rejects_zero_sized_tensors() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: empty
+    kind: tensor
+    config: { addr: 0, dtype: fp32, shape: [2, 0] }
+edges: []
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("Tensor 'empty' has zero size in dim 1"));
+}
+
+#[test]
+fn semantic_validation_rejects_tensor_address_overflow() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: overflowing
+    kind: tensor
+    config: { addr: 18446744073709551615, dtype: fp32, shape: [1] }
+edges: []
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(
+        format!("{err}")
+            .contains("Tensor 'overflowing' range overflows the physical address space")
+    );
+}
+
+#[test]
+fn semantic_validation_accepts_tensor_ending_at_final_physical_byte() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: top_exclusive
+    kind: tensor
+    config: { addr: 18446744073709551614, dtype: int8, shape: [1] }
+edges: []
+",
+    )
+    .unwrap();
+
+    timetable_file.validate().unwrap();
+}
+
+#[test]
+fn semantic_validation_rejects_tensor_at_final_physical_byte() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: final_byte
+    kind: tensor
+    config: { addr: 18446744073709551615, dtype: int8, shape: [1] }
+edges: []
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(
+        format!("{err}").contains("Tensor 'final_byte' range overflows the physical address space")
+    );
+}
+
+#[test]
+fn tiny_example_is_valid() {
+    let timetable_file = TimetableFile::from_file(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/tiny.yaml"),
+    )
+    .unwrap();
+
+    timetable_file.validate().unwrap();
 }
 
 #[test]
@@ -248,7 +606,6 @@ fn load_not_connected_to_tensor() {
 
 #[test]
 fn load_with_data_output_is_rejected() {
-    let (top, platform, _) = create_default_timetable_file();
     let timetable_file = TimetableFile::from_string(
         r"
 nodes:
@@ -269,7 +626,7 @@ edges:
     )
     .unwrap();
 
-    let err = Timetable::new(&top, timetable_file, &platform).unwrap_err();
+    let err = timetable_file.validate().unwrap_err();
     assert!(format!("{err}").contains("1 data edges connect from Load node 'load'"));
 }
 
@@ -334,9 +691,9 @@ fn store_outside_tensor() {
         },
     });
     timetable_file.edges.push(EdgeSection {
-        from: "load0".to_string(),
+        from: "tensor0".to_string(),
         to: "store0".to_string(),
-        kind: EdgeKind::Control,
+        kind: EdgeKind::Data,
     });
     timetable_file.edges.push(EdgeSection {
         from: "store0".to_string(),
@@ -374,6 +731,87 @@ fn invalid_to_edge_pe() {
 
     let err = Timetable::new(&top, timetable_file, &platform).unwrap_err();
     assert!(format!("{err}").contains("Edge contains invalid to Node ID 'node2'"));
+}
+
+#[test]
+fn invalid_edge_endpoint_syntax() {
+    let (_, _, mut timetable_file) = create_default_timetable_file();
+    timetable_file.edges.push(EdgeSection {
+        from: "tensor0.invalid".to_string(),
+        to: "load0".to_string(),
+        kind: EdgeKind::Data,
+    });
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("Unable to parse edge id 'tensor0.invalid'"));
+}
+
+#[test]
+fn duplicate_explicit_edge_port_after_implicit_port() {
+    let (_, _, mut timetable_file) = create_default_timetable_file();
+    timetable_file.edges.push(EdgeSection {
+        from: "tensor0".to_string(),
+        to: "load0.0".to_string(),
+        kind: EdgeKind::Data,
+    });
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("input edge index 0 is connected more than once"));
+}
+
+#[test]
+fn sparse_explicit_tensor_port_and_implicit_port_are_allowed() {
+    let (top, platform, mut timetable_file) = create_default_timetable_file();
+    timetable_file.edges[0].from = "tensor0.5".to_string();
+
+    timetable_file.validate().unwrap();
+    let timetable = Timetable::new(&top, timetable_file, &platform).unwrap();
+    assert_eq!(timetable.ready_task_indices("pe0").unwrap().1, vec![1, 2]);
+}
+
+#[test]
+fn maximum_tensor_port_does_not_materialize_intervening_ports() {
+    let (top, platform, mut timetable_file) = create_default_timetable_file();
+    timetable_file.edges[0].from = format!("tensor0.{}", usize::MAX);
+
+    timetable_file.validate().unwrap();
+    Timetable::new(&top, timetable_file, &platform).unwrap();
+}
+
+#[test]
+fn duplicate_sparse_tensor_ports_are_rejected() {
+    let (_, _, mut timetable_file) = create_default_timetable_file();
+    timetable_file.edges[0].from = "tensor0.5".to_string();
+    timetable_file.edges[1].from = "tensor0.5".to_string();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(format!("{err}").contains("output edge index 5 is connected more than once"));
+}
+
+#[test]
+fn explicit_edge_port_index_is_checked_before_tracking_occupancy() {
+    let timetable_file = TimetableFile::from_string(
+        r"
+nodes:
+  - id: input
+    kind: tensor
+    config: { addr: 0, dtype: fp32, shape: [1] }
+  - id: compute
+    kind: compute
+    op: add
+    input_views:
+      -
+    output_views: []
+edges:
+  - { from: input, to: compute.1000000000, kind: data }
+",
+    )
+    .unwrap();
+
+    let err = timetable_file.validate().unwrap_err();
+    assert!(
+        format!("{err}").contains("Node 'compute' input edge index 1000000000 is out of range")
+    );
 }
 
 #[test]

--- a/licenses.html
+++ b/licenses.html
@@ -8420,7 +8420,7 @@ SOFTWARE.
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-resources 0.1.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-spotter 0.9.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-terminus 0.4.0</a></li>
-                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-timetable 0.3.0</a></li>
+                    <li><a href=" https://github.com/graphcore-research/gwr ">gwr-timetable 0.4.0</a></li>
                     <li><a href=" https://github.com/graphcore-research/gwr ">gwr-track 0.13.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License


### PR DESCRIPTION
Related to #334.

## Intent

Allow static tools to validate timetable files without constructing simulator
entities.

Reject invalid graph structure, data-edge connections, tensor ranges, views,
and overlapping node accesses before timetable construction. Keep
PE-reference checks in construction, where a built Platform is available.

BREAKING CHANGE: TimetableFile::validate no longer accepts a Platform.
Platform references are validated when constructing a Timetable.

## Stack

This is part 6 of 7 in the decomposition of #334.

1. [#337](https://github.com/graphcore-research/gwr/pull/337) — `refactor(gwr-models,sim-restaurant): standardise simulation errors`
2. [#338](https://github.com/graphcore-research/gwr/pull/338) — `fix(gwr-models): preserve packed tensor byte ranges`
3. [#339](https://github.com/graphcore-research/gwr/pull/339) — `fix(gwr-timetable): preserve packed tensor byte ranges`
4. [#340](https://github.com/graphcore-research/gwr/pull/340) — `fix(gwr-timetable): derive scheduling dependencies from data edges`
5. [#341](https://github.com/graphcore-research/gwr/pull/341) — `feat(gwr-platform): support standalone platform validation`
6. [#342](https://github.com/graphcore-research/gwr/pull/342) — `feat(gwr-timetable)!: support standalone timetable validation` **← current**
7. [#343](https://github.com/graphcore-research/gwr/pull/343) — `feat(gwr-visualisation): add static timetable visualisation tool`

- Base branch: `pr-visualisation-decomposed-05-platform-validation`
- Head branch: `pr-visualisation-decomposed-06-timetable-validation`
- Predecessor: [#341](https://github.com/graphcore-research/gwr/pull/341)
- Successor: [#343](https://github.com/graphcore-research/gwr/pull/343)

## Verification

- Post-review amended commit: `f0104a5dce9acbbd29799462c1fcc89f51d611fc`
- Current PR patch SHA-256: `816572f46e056509e8f4795fd6f0387b320190c3e5fbb4ff46306607d662f72a`
- Cumulative Git tree: `742ddb61002f5d56ee89a50495a085bda140b884`
- Post-review regressions cover sparse tensor ports, maximum tensor-side port
  indices, duplicate ports, and overlapping or adjacent compute writes.
- The amended snapshot passes the all-features build, test, and benchmark
  compilation, the all-files `prek` suite, and `cog verify`.
- The decomposition reports remain unchanged historical artifacts and do not
  include post-review amendments.
